### PR TITLE
List of registrants (respondents) in backoffice

### DIFF
--- a/backend/src/opendlp/adapters/sql_repository.py
+++ b/backend/src/opendlp/adapters/sql_repository.py
@@ -870,6 +870,25 @@ class SqlAlchemyRespondentRepository(SqlAlchemyRepository, RespondentRepository)
 
         return query.order_by(orm.respondents.c.created_at.desc()).all()
 
+    def get_by_assembly_id_paginated(
+        self,
+        assembly_id: uuid.UUID,
+        page: int = 1,
+        per_page: int = 50,
+        status: RespondentStatus | None = None,
+    ) -> tuple[list[Respondent], int]:
+        """Get paginated respondents for an assembly. Returns (respondents, total_count)."""
+        query = self.session.query(Respondent).filter(orm.respondents.c.assembly_id == assembly_id)
+
+        if status:
+            query = query.filter(orm.respondents.c.selection_status == status)
+
+        total_count = query.count()
+        offset = (page - 1) * per_page
+        respondents = query.order_by(orm.respondents.c.created_at.desc()).offset(offset).limit(per_page).all()
+
+        return respondents, total_count
+
     def count_by_assembly_id(self, assembly_id: uuid.UUID) -> int:
         return self.session.query(Respondent).filter(orm.respondents.c.assembly_id == assembly_id).count()
 

--- a/backend/src/opendlp/domain/respondents.py
+++ b/backend/src/opendlp/domain/respondents.py
@@ -169,7 +169,15 @@ class Respondent:
         return hash(self.id)
 
     def create_detached_copy(self) -> "Respondent":
-        """Create a detached copy for use outside SQLAlchemy sessions"""
+        """Create a detached copy for use outside SQLAlchemy sessions.
+
+        Note: Filters out any attributes that collide with reserved field names
+        (case-insensitive) for backward compatibility with legacy data.
+        """
+        # Filter out attributes that collide with reserved fields (case-insensitive)
+        sanitized_attributes = {
+            k: v for k, v in self.attributes.items() if normalise_field_name(k) not in _RESERVED_FIELD_NAMES
+        }
         return Respondent(
             assembly_id=self.assembly_id,
             external_id=self.external_id,
@@ -182,7 +190,7 @@ class Respondent:
             email=self.email,
             source_type=self.source_type,
             source_reference=self.source_reference,
-            attributes=self.attributes.copy(),
+            attributes=sanitized_attributes,
             respondent_id=self.id,
             created_at=self.created_at,
             updated_at=self.updated_at,

--- a/backend/src/opendlp/domain/respondents.py
+++ b/backend/src/opendlp/domain/respondents.py
@@ -19,6 +19,18 @@ def normalise_field_name(key: str) -> str:
     return re.sub(r"[^a-z0-9]", "", key.lower())
 
 
+def pop_normalised(attrs: dict[str, Any], key: str, default: Any = None) -> Any:
+    """Pop a key from dict using normalised matching.
+
+    Matches keys like "canAttend", "can_attend", "CAN_ATTEND" to "can_attend".
+    """
+    key_normal = normalise_field_name(key)
+    for k in list(attrs.keys()):
+        if normalise_field_name(k) == key_normal:
+            return attrs.pop(k)
+    return default
+
+
 # Top-level Respondent fields that must not be shadowed by an attribute key.
 # Kept in sync with the Respondent constructor signature.
 _RESERVED_FIELD_NAMES: frozenset[str] = frozenset(

--- a/backend/src/opendlp/domain/respondents.py
+++ b/backend/src/opendlp/domain/respondents.py
@@ -169,15 +169,7 @@ class Respondent:
         return hash(self.id)
 
     def create_detached_copy(self) -> "Respondent":
-        """Create a detached copy for use outside SQLAlchemy sessions.
-
-        Note: Filters out any attributes that collide with reserved field names
-        (case-insensitive) for backward compatibility with legacy data.
-        """
-        # Filter out attributes that collide with reserved fields (case-insensitive)
-        sanitized_attributes = {
-            k: v for k, v in self.attributes.items() if normalise_field_name(k) not in _RESERVED_FIELD_NAMES
-        }
+        """Create a detached copy for use outside SQLAlchemy sessions."""
         return Respondent(
             assembly_id=self.assembly_id,
             external_id=self.external_id,
@@ -190,7 +182,7 @@ class Respondent:
             email=self.email,
             source_type=self.source_type,
             source_reference=self.source_reference,
-            attributes=sanitized_attributes,
+            attributes=self.attributes,
             respondent_id=self.id,
             created_at=self.created_at,
             updated_at=self.updated_at,

--- a/backend/src/opendlp/domain/value_objects.py
+++ b/backend/src/opendlp/domain/value_objects.py
@@ -115,6 +115,16 @@ class RespondentStatus(Enum):
     PARTICIPATED = "PARTICIPATED"
     EXCLUDED = "EXCLUDED"
 
+    @classmethod
+    def from_str(cls, value: str) -> "RespondentStatus | None":
+        """Parse a string to RespondentStatus, returning None for invalid values."""
+        if not value:
+            return None
+        try:
+            return cls(value)
+        except ValueError:
+            return None
+
 
 class RespondentSourceType(Enum):
     """Source of respondent data"""

--- a/backend/src/opendlp/entrypoints/blueprints/dev.py
+++ b/backend/src/opendlp/entrypoints/blueprints/dev.py
@@ -399,7 +399,7 @@ def patterns() -> ResponseReturnValue:
 
     # Get active tab from query parameter, default to 'dropdown'
     active_tab = request.args.get("tab", "dropdown")
-    valid_tabs = ["dropdown", "form", "ajax", "file-upload", "progress"]
+    valid_tabs = ["dropdown", "form", "ajax", "file-upload", "progress", "pagination", "scroll"]
     if active_tab not in valid_tabs:
         active_tab = "dropdown"
 

--- a/backend/src/opendlp/entrypoints/blueprints/dev.py
+++ b/backend/src/opendlp/entrypoints/blueprints/dev.py
@@ -10,6 +10,7 @@ from flask.typing import ResponseReturnValue
 from flask_login import current_user, login_required
 
 from opendlp import bootstrap
+from opendlp.domain.value_objects import RespondentStatus
 from opendlp.service_layer.assembly_service import (
     get_or_create_csv_config,
     get_or_create_selection_settings,
@@ -19,7 +20,11 @@ from opendlp.service_layer.assembly_service import (
 )
 from opendlp.service_layer.exceptions import InsufficientPermissions, InvalidSelection, NotFoundError
 from opendlp.service_layer.permissions import has_global_admin
-from opendlp.service_layer.respondent_service import import_respondents_from_csv
+from opendlp.service_layer.respondent_service import (
+    get_respondents_for_assembly,
+    import_respondents_from_csv,
+    reset_selection_status,
+)
 from opendlp.service_layer.user_service import get_user_assemblies
 from opendlp.translations import gettext as _
 
@@ -144,6 +149,64 @@ def _handle_import_respondents(uow: Any, params: dict[str, Any]) -> dict[str, An
             }
         except InvalidSelection as e:
             return {"status": "error", "error": str(e), "error_type": "InvalidSelection"}
+        except InsufficientPermissions as e:
+            return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+        except NotFoundError as e:
+            return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_reset_selection_status(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle reset_selection_status service call."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+
+    with uow:
+        try:
+            count = reset_selection_status(
+                uow=uow,
+                user_id=current_user.id,
+                assembly_id=assembly_id,
+            )
+            return {
+                "status": "success",
+                "respondents_reset": count,
+            }
+        except InsufficientPermissions as e:
+            return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+        except NotFoundError as e:
+            return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_get_respondents(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle get_respondents_for_assembly service call."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+    status_str = params.get("status")
+    status = RespondentStatus(status_str) if status_str else None
+
+    with uow:
+        try:
+            respondents = get_respondents_for_assembly(
+                uow=uow,
+                user_id=current_user.id,
+                assembly_id=assembly_id,
+                status=status,
+            )
+            return {
+                "status": "success",
+                "total_count": len(respondents),
+                "respondents": [
+                    {
+                        "external_id": r.external_id,
+                        "attributes": r.attributes,
+                        "selection_status": r.selection_status.value if r.selection_status else None,
+                        "email": r.email,
+                        "consent": r.consent,
+                        "eligible": r.eligible,
+                        "can_attend": r.can_attend,
+                    }
+                    for r in respondents[:20]  # Show first 20 as sample
+                ],
+                "showing": min(20, len(respondents)),
+            }
         except InsufficientPermissions as e:
             return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
         except NotFoundError as e:
@@ -298,6 +361,8 @@ def _handle_update_csv_config(uow: Any, params: dict[str, Any]) -> dict[str, Any
 # Mapping of service names to their handler functions
 _SERVICE_HANDLERS: dict[str, Callable[[Any, dict[str, Any]], dict[str, Any]]] = {
     "import_respondents_from_csv": _handle_import_respondents,
+    "reset_selection_status": _handle_reset_selection_status,
+    "get_respondents_for_assembly": _handle_get_respondents,
     "import_targets_from_csv": _handle_import_targets,
     "get_or_create_csv_config": _handle_get_csv_config,
     "update_csv_config": _handle_update_csv_config,

--- a/backend/src/opendlp/entrypoints/blueprints/respondents.py
+++ b/backend/src/opendlp/entrypoints/blueprints/respondents.py
@@ -9,6 +9,7 @@ from flask.typing import ResponseReturnValue
 from flask_login import current_user, login_required
 
 from opendlp import bootstrap
+from opendlp.domain.value_objects import RespondentStatus
 from opendlp.service_layer.assembly_service import (
     CSVUploadStatus,
     delete_respondents_for_assembly,
@@ -160,12 +161,26 @@ def view_assembly_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
         page = request.args.get("page", 1, type=int)
         per_page = 25
 
+        # Get status filter
+        status_filter_str = request.args.get("status", "")
+        status_filter: RespondentStatus | None = None
+        if status_filter_str:
+            try:
+                status_filter = RespondentStatus(status_filter_str)
+            except ValueError:
+                status_filter = None
+
         # Get assembly with permissions
         uow = bootstrap.bootstrap()
         with uow:
             assembly = get_assembly_with_permissions(uow, assembly_id, current_user.id)
             respondents, total_count = get_respondents_for_assembly_paginated(
-                uow, user_id=current_user.id, assembly_id=assembly_id, page=page, per_page=per_page
+                uow,
+                user_id=current_user.id,
+                assembly_id=assembly_id,
+                page=page,
+                per_page=per_page,
+                status=status_filter,
             )
 
         # Calculate pagination info
@@ -208,6 +223,7 @@ def view_assembly_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
             per_page=per_page,
             total_pages=total_pages,
             total_count=total_count,
+            status_filter=status_filter_str,
         ), 200
     except NotFoundError as e:
         current_app.logger.warning(f"Assembly {assembly_id} not found for user {current_user.id}: {e}")

--- a/backend/src/opendlp/entrypoints/blueprints/respondents.py
+++ b/backend/src/opendlp/entrypoints/blueprints/respondents.py
@@ -9,6 +9,7 @@ from flask.typing import ResponseReturnValue
 from flask_login import current_user, login_required
 
 from opendlp import bootstrap
+from opendlp.domain.respondents import Respondent
 from opendlp.domain.value_objects import RespondentStatus
 from opendlp.service_layer.assembly_service import (
     CSVUploadStatus,
@@ -161,21 +162,28 @@ def view_assembly_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
         page = request.args.get("page", 1, type=int)
         per_page = 25
 
-        # Get status filter
-        status_filter = RespondentStatus.from_str(request.args.get("status", ""))
+        # Get status filter - keep raw value for template, parse for service
+        status_filter_str = request.args.get("status", "")
+        status_filter = RespondentStatus.from_str(status_filter_str)
 
         # Get assembly with permissions
         uow = bootstrap.bootstrap()
         with uow:
             assembly = get_assembly_with_permissions(uow, assembly_id, current_user.id)
-            respondents, total_count = get_respondents_for_assembly_paginated(
-                uow,
-                user_id=current_user.id,
-                assembly_id=assembly_id,
-                page=page,
-                per_page=per_page,
-                status=status_filter,
-            )
+
+            # If filter string provided but not a valid enum, return empty results
+            if status_filter_str and status_filter is None:
+                respondents: list[Respondent] = []
+                total_count = 0
+            else:
+                respondents, total_count = get_respondents_for_assembly_paginated(
+                    uow,
+                    user_id=current_user.id,
+                    assembly_id=assembly_id,
+                    page=page,
+                    per_page=per_page,
+                    status=status_filter,
+                )
 
         # Calculate pagination info
         total_pages = (total_count + per_page - 1) // per_page if total_count > 0 else 1
@@ -217,7 +225,7 @@ def view_assembly_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
             per_page=per_page,
             total_pages=total_pages,
             total_count=total_count,
-            status_filter=status_filter.value if status_filter else "",
+            status_filter=status_filter_str,
         ), 200
     except NotFoundError as e:
         current_app.logger.warning(f"Assembly {assembly_id} not found for user {current_user.id}: {e}")

--- a/backend/src/opendlp/entrypoints/blueprints/respondents.py
+++ b/backend/src/opendlp/entrypoints/blueprints/respondents.py
@@ -25,7 +25,7 @@ from opendlp.service_layer.exceptions import (
 )
 from opendlp.service_layer.respondent_service import (
     get_respondent,
-    get_respondents_for_assembly,
+    get_respondents_for_assembly_paginated,
     import_respondents_from_csv,
 )
 from opendlp.translations import gettext as _
@@ -156,11 +156,20 @@ def delete_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
 def view_assembly_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
     """Backoffice assembly respondents page."""
     try:
+        # Get pagination parameters
+        page = request.args.get("page", 1, type=int)
+        per_page = 25
+
         # Get assembly with permissions
         uow = bootstrap.bootstrap()
         with uow:
             assembly = get_assembly_with_permissions(uow, assembly_id, current_user.id)
-            respondents = get_respondents_for_assembly(uow, user_id=current_user.id, assembly_id=assembly_id)
+            respondents, total_count = get_respondents_for_assembly_paginated(
+                uow, user_id=current_user.id, assembly_id=assembly_id, page=page, per_page=per_page
+            )
+
+        # Calculate pagination info
+        total_pages = (total_count + per_page - 1) // per_page if total_count > 0 else 1
 
         # Determine data source and whether tabs should be enabled
         gsheet = None
@@ -195,6 +204,10 @@ def view_assembly_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
             targets_enabled=targets_enabled,
             respondents_enabled=respondents_enabled,
             selection_enabled=selection_enabled,
+            page=page,
+            per_page=per_page,
+            total_pages=total_pages,
+            total_count=total_count,
         ), 200
     except NotFoundError as e:
         current_app.logger.warning(f"Assembly {assembly_id} not found for user {current_user.id}: {e}")

--- a/backend/src/opendlp/entrypoints/blueprints/respondents.py
+++ b/backend/src/opendlp/entrypoints/blueprints/respondents.py
@@ -162,13 +162,7 @@ def view_assembly_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
         per_page = 25
 
         # Get status filter
-        status_filter_str = request.args.get("status", "")
-        status_filter: RespondentStatus | None = None
-        if status_filter_str:
-            try:
-                status_filter = RespondentStatus(status_filter_str)
-            except ValueError:
-                status_filter = None
+        status_filter = RespondentStatus.from_str(request.args.get("status", ""))
 
         # Get assembly with permissions
         uow = bootstrap.bootstrap()
@@ -223,7 +217,7 @@ def view_assembly_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
             per_page=per_page,
             total_pages=total_pages,
             total_count=total_count,
-            status_filter=status_filter_str,
+            status_filter=status_filter.value if status_filter else "",
         ), 200
     except NotFoundError as e:
         current_app.logger.warning(f"Assembly {assembly_id} not found for user {current_user.id}: {e}")

--- a/backend/src/opendlp/service_layer/repositories.py
+++ b/backend/src/opendlp/service_layer/repositories.py
@@ -383,6 +383,17 @@ class RespondentRepository(AbstractRepository):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def get_by_assembly_id_paginated(
+        self,
+        assembly_id: uuid.UUID,
+        page: int = 1,
+        per_page: int = 50,
+        status: RespondentStatus | None = None,
+    ) -> tuple[list[Respondent], int]:
+        """Get paginated respondents for an assembly. Returns (respondents, total_count)."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def get_by_external_id(self, assembly_id: uuid.UUID, external_id: str) -> Respondent | None:
         """Get a respondent by assembly and external ID."""
         raise NotImplementedError

--- a/backend/src/opendlp/service_layer/respondent_service.py
+++ b/backend/src/opendlp/service_layer/respondent_service.py
@@ -137,17 +137,26 @@ def import_respondents_from_csv(  # noqa: C901
             # All columns except id_column become attributes
             attributes = {k: v for k, v in row.items() if k != id_column}
 
+            # Helper to pop a key case-insensitively from attributes
+            def pop_case_insensitive(attrs: dict[str, Any], key: str, default: Any = None) -> Any:
+                """Pop a key from dict using case-insensitive matching."""
+                key_lower = key.lower()
+                for k in list(attrs.keys()):
+                    if k.lower() == key_lower:
+                        return attrs.pop(k)
+                return default
+
             # Extract boolean flags if present (leave as None if not in CSV)
-            consent_str = attributes.pop("consent", None)
+            consent_str = pop_case_insensitive(attributes, "consent")
             consent = consent_str.lower() == "true" if consent_str else None
 
-            eligible_str = attributes.pop("eligible", None)
+            eligible_str = pop_case_insensitive(attributes, "eligible")
             eligible = eligible_str.lower() == "true" if eligible_str else None
 
-            can_attend_str = attributes.pop("can_attend", None)
+            can_attend_str = pop_case_insensitive(attributes, "can_attend")
             can_attend = can_attend_str.lower() == "true" if can_attend_str else None
 
-            email = attributes.pop("email", "")
+            email = pop_case_insensitive(attributes, "email", "")
 
             respondent = Respondent(
                 assembly_id=assembly_id,

--- a/backend/src/opendlp/service_layer/respondent_service.py
+++ b/backend/src/opendlp/service_layer/respondent_service.py
@@ -6,7 +6,7 @@ import uuid
 from io import StringIO
 from typing import Any
 
-from opendlp.domain.respondents import Respondent
+from opendlp.domain.respondents import Respondent, pop_normalised
 from opendlp.domain.value_objects import RespondentSourceType, RespondentStatus
 from opendlp.service_layer.exceptions import (
     AssemblyNotFoundError,
@@ -137,26 +137,17 @@ def import_respondents_from_csv(  # noqa: C901
             # All columns except id_column become attributes
             attributes = {k: v for k, v in row.items() if k != id_column}
 
-            # Helper to pop a key case-insensitively from attributes
-            def pop_case_insensitive(attrs: dict[str, Any], key: str, default: Any = None) -> Any:
-                """Pop a key from dict using case-insensitive matching."""
-                key_lower = key.lower()
-                for k in list(attrs.keys()):
-                    if k.lower() == key_lower:
-                        return attrs.pop(k)
-                return default
-
             # Extract boolean flags if present (leave as None if not in CSV)
-            consent_str = pop_case_insensitive(attributes, "consent")
+            consent_str = pop_normalised(attributes, "consent")
             consent = consent_str.lower() == "true" if consent_str else None
 
-            eligible_str = pop_case_insensitive(attributes, "eligible")
+            eligible_str = pop_normalised(attributes, "eligible")
             eligible = eligible_str.lower() == "true" if eligible_str else None
 
-            can_attend_str = pop_case_insensitive(attributes, "can_attend")
+            can_attend_str = pop_normalised(attributes, "can_attend")
             can_attend = can_attend_str.lower() == "true" if can_attend_str else None
 
-            email = pop_case_insensitive(attributes, "email", "")
+            email = pop_normalised(attributes, "email", "")
 
             respondent = Respondent(
                 assembly_id=assembly_id,

--- a/backend/src/opendlp/service_layer/respondent_service.py
+++ b/backend/src/opendlp/service_layer/respondent_service.py
@@ -230,6 +230,36 @@ def get_respondents_for_assembly(
         return [r.create_detached_copy() for r in respondents]
 
 
+def get_respondents_for_assembly_paginated(
+    uow: AbstractUnitOfWork,
+    user_id: uuid.UUID,
+    assembly_id: uuid.UUID,
+    page: int = 1,
+    per_page: int = 50,
+    status: RespondentStatus | None = None,
+) -> tuple[list[Respondent], int]:
+    """Get paginated respondents for an assembly. Returns (respondents, total_count)."""
+    with uow:
+        user = uow.users.get(user_id)
+        if not user:
+            raise UserNotFoundError(f"User {user_id} not found")
+
+        assembly = uow.assemblies.get(assembly_id)
+        if not assembly:
+            raise AssemblyNotFoundError(f"Assembly {assembly_id} not found")
+
+        if not can_view_assembly(user, assembly):
+            raise InsufficientPermissions(
+                action="view respondents",
+                required_role="assembly role or global privileges",
+            )
+
+        respondents, total_count = uow.respondents.get_by_assembly_id_paginated(
+            assembly_id, page=page, per_page=per_page, status=status
+        )
+        return [r.create_detached_copy() for r in respondents], total_count
+
+
 def count_non_pool_respondents(uow: AbstractUnitOfWork, assembly_id: uuid.UUID) -> int:
     """Count respondents for an assembly that are not in POOL status."""
     return uow.respondents.count_non_pool(assembly_id)

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -444,6 +444,16 @@
         background-color: var(--color-button-secondary-bg-hover);
     }
 
+    /* ========================================
+       TABLE COMPONENT STYLES
+       Hover states for table rows
+       ======================================== */
+
+    /* Table row hover */
+    .table-row-hover:hover {
+        background-color: var(--color-neutral-100);
+    }
+
     /* Tab bar container */
     .tab-bar {
         display: flex;

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -434,6 +434,16 @@
        Horizontal tab navigation based on Figma spec
        ======================================== */
 
+    /* ========================================
+       PAGINATION COMPONENT STYLES
+       Hover states for pagination buttons
+       ======================================== */
+
+    /* Pagination button hover - uses same color as secondary/tertiary buttons */
+    .pagination-btn:hover {
+        background-color: var(--color-button-secondary-bg-hover);
+    }
+
     /* Tab bar container */
     .tab-bar {
         display: flex;

--- a/backend/static/js/utilities.js
+++ b/backend/static/js/utilities.js
@@ -2,13 +2,21 @@
 // ABOUTME: Provides event-driven handlers for common UI interactions without inline handlers
 
 // Handle select elements that navigate on change via data-navigate-base-url
+// Optionally preserves scroll position with data-navigate-preserve-scroll attribute
 document.addEventListener("change", function (e) {
   var baseUrl = e.target.dataset.navigateBaseUrl;
   if (baseUrl) {
     var paramName = e.target.dataset.navigateParam || "value";
+    var preserveScroll = e.target.hasAttribute("data-navigate-preserve-scroll");
     var url = baseUrl;
     if (e.target.value) {
       url += "?" + paramName + "=" + encodeURIComponent(e.target.value);
+    }
+    // Add scroll parameter if preservation is enabled
+    if (preserveScroll) {
+      var currentScroll = Math.round(window.scrollY);
+      var separator = url.includes("?") ? "&" : "?";
+      url += separator + "scroll=" + currentScroll;
     }
     window.location.href = url;
   }

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -79,6 +79,25 @@ ABOUTME: Displays respondent data configuration for assemblies
         </section>
     {% elif data_source == "csv" %}
         <section class="mb-8">
+            {# Filter controls - show when there are respondents or when filter is active #}
+            {% if total_count > 0 or status_filter %}
+                <div class="flex justify-end mb-4">
+                    <div class="flex items-center gap-2">
+                        <label for="status-filter" class="text-body-md" style="color: var(--color-secondary-text);">{{ _("Filter by status:") }}</label>
+                        <select id="status-filter"
+                                class="px-3 py-2 rounded-lg text-body-md"
+                                style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                                data-navigate-base-url="{{ url_for('respondents.view_assembly_respondents', assembly_id=assembly.id) }}"
+                                data-navigate-param="status">
+                            <option value="" {% if not status_filter %}selected{% endif %}>{{ _("All statuses") }}</option>
+                            <option value="POOL" {% if status_filter == "POOL" %}selected{% endif %}>{{ _("Pool") }}</option>
+                            <option value="SELECTED" {% if status_filter == "SELECTED" %}selected{% endif %}>{{ _("Selected") }}</option>
+                            <option value="CONFIRMED" {% if status_filter == "CONFIRMED" %}selected{% endif %}>{{ _("Confirmed") }}</option>
+                            <option value="WITHDRAWN" {% if status_filter == "WITHDRAWN" %}selected{% endif %}>{{ _("Withdrawn") }}</option>
+                        </select>
+                    </div>
+                </div>
+            {% endif %}
             {% if respondents %}
                 {% call table(striped=true) %}
                     {{ table_head([
@@ -107,16 +126,24 @@ ABOUTME: Displays respondent data configuration for assemblies
                     {% endcall %}
                 {% endcall %}
                 {# Pagination Controls #}
+                {% set pagination_base_url = url_for('respondents.view_assembly_respondents', assembly_id=assembly.id) %}
+                {% if status_filter %}
+                    {% set pagination_base_url = pagination_base_url ~ '?status=' ~ status_filter %}
+                {% endif %}
                 {{ pagination(
                 page=page,
                 total_pages=total_pages,
                 per_page=per_page,
                 total_count=total_count,
-                base_url=url_for('respondents.view_assembly_respondents', assembly_id=assembly.id),
+                base_url=pagination_base_url,
                 item_name=_("respondents")
                 ) }}
             {% else %}
-                {{ alert(_("No respondents uploaded yet."), variant="info") }}
+                {% if status_filter %}
+                    {{ alert(_("No respondents match the selected status filter."), variant="info") }}
+                {% else %}
+                    {{ alert(_("No respondents uploaded yet."), variant="info") }}
+                {% endif %}
             {% endif %}
         </section>
     {% else %}

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -101,7 +101,7 @@ ABOUTME: Displays respondent data configuration for assemblies
                 </div>
             {% endif %}
             {% if respondents %}
-                {% call table(striped=true) %}
+                {% call table() %}
                     {{ table_head([
                     {"label": _("Status")},
                     {"label": _("External ID")},
@@ -111,7 +111,7 @@ ABOUTME: Displays respondent data configuration for assemblies
                     ]) }}
                     {% call table_body() %}
                         {% for respondent in respondents %}
-                            {% call table_row(is_odd=loop.index is odd) %}
+                            {% call table_row() %}
                                 {{ table_cell_status(respondent.selection_status) }}
                                 {{ table_cell(respondent.external_id, bold=true) }}
                                 {{ table_cell(respondent.email or "—") }}

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -9,6 +9,7 @@ ABOUTME: Displays respondent data configuration for assemblies
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_link, table_cell_status %}
 {% from "backoffice/components/pagination.html" import pagination %}
+{% from "backoffice/components/section.html" import section %}
 
 {% block title %}{{ _("Respondents") }} - {{ assembly.title }}{% endblock %}
 
@@ -78,76 +79,79 @@ ABOUTME: Displays respondent data configuration for assemblies
             </div>
         </section>
     {% elif data_source == "csv" %}
-        <section class="mb-8">
-            {# Filter controls - show when there are respondents or when filter is active #}
-            {% if total_count > 0 or status_filter %}
-                <div class="flex justify-end mb-4">
-                    <div class="flex items-center gap-2">
-                        <label for="status-filter" class="text-body-md" style="color: var(--color-secondary-text);">{{ _("Filter by status:") }}</label>
-                        <select id="status-filter"
-                                class="px-3 py-2 rounded-lg text-body-md"
-                                style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
-                                data-navigate-base-url="{{ url_for('respondents.view_assembly_respondents', assembly_id=assembly.id) }}"
-                                data-navigate-param="status"
-                                data-navigate-preserve-scroll>
-                            <option value="" {% if not status_filter %}selected{% endif %}>{{ _("All statuses") }}</option>
-                            <option value="POOL" {% if status_filter == "POOL" %}selected{% endif %}>{{ _("Pool") }}</option>
-                            <option value="SELECTED" {% if status_filter == "SELECTED" %}selected{% endif %}>{{ _("Selected") }}</option>
-                            <option value="CONFIRMED" {% if status_filter == "CONFIRMED" %}selected{% endif %}>{{ _("Confirmed") }}</option>
-                            <option value="WITHDRAWN" {% if status_filter == "WITHDRAWN" %}selected{% endif %}>{{ _("Withdrawn") }}</option>
-                            <option value="DELETED" {% if status_filter == "DELETED" %}selected{% endif %}>{{ _("Deleted") }}</option>
-                        </select>
+        <div class="mb-8">
+            {% call section() %}
+                <h2 class="text-heading-md mb-4" style="color: var(--color-headings);">{{ _("Respondents") }}</h2>
+                {# Filter controls - show when there are respondents or when filter is active #}
+                {% if total_count > 0 or status_filter %}
+                    <div class="flex justify-end mb-4">
+                        <div class="flex items-center gap-2">
+                            <label for="status-filter" class="text-body-md" style="color: var(--color-secondary-text);">{{ _("Filter by status:") }}</label>
+                            <select id="status-filter"
+                                    class="px-3 py-2 rounded-lg text-body-md"
+                                    style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                                    data-navigate-base-url="{{ url_for('respondents.view_assembly_respondents', assembly_id=assembly.id) }}"
+                                    data-navigate-param="status"
+                                    data-navigate-preserve-scroll>
+                                <option value="" {% if not status_filter %}selected{% endif %}>{{ _("All statuses") }}</option>
+                                <option value="POOL" {% if status_filter == "POOL" %}selected{% endif %}>{{ _("Pool") }}</option>
+                                <option value="SELECTED" {% if status_filter == "SELECTED" %}selected{% endif %}>{{ _("Selected") }}</option>
+                                <option value="CONFIRMED" {% if status_filter == "CONFIRMED" %}selected{% endif %}>{{ _("Confirmed") }}</option>
+                                <option value="WITHDRAWN" {% if status_filter == "WITHDRAWN" %}selected{% endif %}>{{ _("Withdrawn") }}</option>
+                                <option value="DELETED" {% if status_filter == "DELETED" %}selected{% endif %}>{{ _("Deleted") }}</option>
+                            </select>
+                        </div>
                     </div>
-                </div>
-            {% endif %}
-            {% if respondents %}
-                {% call table() %}
-                    {{ table_head([
-                    {"label": _("Status")},
-                    {"label": _("External ID")},
-                    {"label": _("Email")},
-                    {"label": _("Name")},
-                    {"label": _("Actions"), "align": "right"}
-                    ]) }}
-                    {% call table_body() %}
-                        {% for respondent in respondents %}
-                            {% call table_row() %}
-                                {{ table_cell_status(respondent.selection_status) }}
-                                {{ table_cell(respondent.external_id, bold=true) }}
-                                {{ table_cell(respondent.email or "—") }}
-                                {{ table_cell(respondent.display_name(assembly.name_fields)) }}
-                                {{ table_cell_link(
-                                _("View"),
-                                href=url_for('respondents.view_respondent',
-                                assembly_id=assembly.id,
-                                respondent_id=respondent.id),
-                                align="right"
-                                ) }}
-                            {% endcall %}
-                        {% endfor %}
+                {% endif %}
+                {% if respondents %}
+                    {% call table() %}
+                        {{ table_head([
+                        {"label": _("Status")},
+                        {"label": _("External ID")},
+                        {"label": _("Email")},
+                        {"label": _("Name")},
+                        {"label": _("Actions"), "align": "right"}
+                        ]) }}
+                        {% call table_body() %}
+                            {% for respondent in respondents %}
+                                {% call table_row() %}
+                                    {{ table_cell_status(respondent.selection_status) }}
+                                    {{ table_cell(respondent.external_id, bold=true) }}
+                                    {{ table_cell(respondent.email or "—") }}
+                                    {{ table_cell(respondent.display_name(assembly.name_fields)) }}
+                                    {{ table_cell_link(
+                                    _("View"),
+                                    href=url_for('respondents.view_respondent',
+                                    assembly_id=assembly.id,
+                                    respondent_id=respondent.id),
+                                    align="right"
+                                    ) }}
+                                {% endcall %}
+                            {% endfor %}
+                        {% endcall %}
                     {% endcall %}
-                {% endcall %}
-                {# Pagination Controls #}
-                {% set pagination_base_url = url_for('respondents.view_assembly_respondents', assembly_id=assembly.id) %}
-                {% if status_filter %}
-                    {% set pagination_base_url = pagination_base_url ~ '?status=' ~ status_filter %}
-                {% endif %}
-                {{ pagination(
-                page=page,
-                total_pages=total_pages,
-                per_page=per_page,
-                total_count=total_count,
-                base_url=pagination_base_url,
-                item_name=_("respondents")
-                ) }}
-            {% else %}
-                {% if status_filter %}
-                    {{ alert(_("No respondents match the selected status filter."), variant="info") }}
+                    {# Pagination Controls #}
+                    {% set pagination_base_url = url_for('respondents.view_assembly_respondents', assembly_id=assembly.id) %}
+                    {% if status_filter %}
+                        {% set pagination_base_url = pagination_base_url ~ '?status=' ~ status_filter %}
+                    {% endif %}
+                    {{ pagination(
+                    page=page,
+                    total_pages=total_pages,
+                    per_page=per_page,
+                    total_count=total_count,
+                    base_url=pagination_base_url,
+                    item_name=_("respondents")
+                    ) }}
                 {% else %}
-                    {{ alert(_("No respondents uploaded yet."), variant="info") }}
+                    {% if status_filter %}
+                        {{ alert(_("No respondents match the selected status filter."), variant="info") }}
+                    {% else %}
+                        {{ alert(_("No respondents uploaded yet."), variant="info") }}
+                    {% endif %}
                 {% endif %}
-            {% endif %}
-        </section>
+            {% endcall %}
+        </div>
     {% else %}
         {# No data source selected #}
         <section class="mb-8">

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -88,7 +88,8 @@ ABOUTME: Displays respondent data configuration for assemblies
                                 class="px-3 py-2 rounded-lg text-body-md"
                                 style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
                                 data-navigate-base-url="{{ url_for('respondents.view_assembly_respondents', assembly_id=assembly.id) }}"
-                                data-navigate-param="status">
+                                data-navigate-param="status"
+                                data-navigate-preserve-scroll>
                             <option value="" {% if not status_filter %}selected{% endif %}>{{ _("All statuses") }}</option>
                             <option value="POOL" {% if status_filter == "POOL" %}selected{% endif %}>{{ _("Pool") }}</option>
                             <option value="SELECTED" {% if status_filter == "SELECTED" %}selected{% endif %}>{{ _("Selected") }}</option>

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -95,6 +95,7 @@ ABOUTME: Displays respondent data configuration for assemblies
                             <option value="SELECTED" {% if status_filter == "SELECTED" %}selected{% endif %}>{{ _("Selected") }}</option>
                             <option value="CONFIRMED" {% if status_filter == "CONFIRMED" %}selected{% endif %}>{{ _("Confirmed") }}</option>
                             <option value="WITHDRAWN" {% if status_filter == "WITHDRAWN" %}selected{% endif %}>{{ _("Withdrawn") }}</option>
+                            <option value="DELETED" {% if status_filter == "DELETED" %}selected{% endif %}>{{ _("Deleted") }}</option>
                         </select>
                     </div>
                 </div>

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -8,6 +8,7 @@ ABOUTME: Displays respondent data configuration for assemblies
 {% from "backoffice/components/alert.html" import alert %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_link, table_cell_status %}
+{% from "backoffice/components/pagination.html" import pagination %}
 
 {% block title %}{{ _("Respondents") }} - {{ assembly.title }}{% endblock %}
 
@@ -105,6 +106,15 @@ ABOUTME: Displays respondent data configuration for assemblies
                         {% endfor %}
                     {% endcall %}
                 {% endcall %}
+                {# Pagination Controls #}
+                {{ pagination(
+                page=page,
+                total_pages=total_pages,
+                per_page=per_page,
+                total_count=total_count,
+                base_url=url_for('respondents.view_assembly_respondents', assembly_id=assembly.id),
+                item_name=_("respondents")
+                ) }}
             {% else %}
                 {{ alert(_("No respondents uploaded yet."), variant="info") }}
             {% endif %}

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -7,7 +7,7 @@ ABOUTME: Displays respondent data configuration for assemblies
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/alert.html" import alert %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
-{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_link %}
+{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_link, table_cell_status %}
 
 {% block title %}{{ _("Respondents") }} - {{ assembly.title }}{% endblock %}
 
@@ -81,6 +81,7 @@ ABOUTME: Displays respondent data configuration for assemblies
             {% if respondents %}
                 {% call table(striped=true) %}
                     {{ table_head([
+                    {"label": _("Status")},
                     {"label": _("External ID")},
                     {"label": _("Email")},
                     {"label": _("Name")},
@@ -89,6 +90,7 @@ ABOUTME: Displays respondent data configuration for assemblies
                     {% call table_body() %}
                         {% for respondent in respondents %}
                             {% call table_row(is_odd=loop.index is odd) %}
+                                {{ table_cell_status(respondent.selection_status) }}
                                 {{ table_cell(respondent.external_id, bold=true) }}
                                 {{ table_cell(respondent.email or "—") }}
                                 {{ table_cell(respondent.display_name(assembly.name_fields)) }}

--- a/backend/templates/backoffice/assembly_selection.html
+++ b/backend/templates/backoffice/assembly_selection.html
@@ -8,6 +8,7 @@ ABOUTME: Displays selection operations: initial selection, replacement, and tab 
 {% from "backoffice/components/card.html" import card, card_body, card_footer %}
 {% from "backoffice/components/alert.html" import alert %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
+{% from "backoffice/components/pagination.html" import pagination %}
 {% block title %}{{ _("Selection") }} - {{ assembly.title }}{% endblock %}
 {% block breadcrumb_section %}
     <div class="mb-6">
@@ -238,69 +239,14 @@ ABOUTME: Displays selection operations: initial selection, replacement, and tab 
                             </table>
                         </div>
                         {# Pagination Controls #}
-                        {% if total_pages > 1 %}
-                            <div class="mt-6 flex items-center justify-between">
-                                {# Results count #}
-                                <p class="text-body-sm" style="color: var(--color-secondary-text);">
-                                    {% set end_record = page * per_page if page * per_page < total_count else total_count %}
-                                    {{ _("Showing %(start)s-%(end)s of %(total)s runs",
-                                    start=((page - 1) * per_page + 1),
-                                    end=end_record,
-                                    total=total_count) }}
-                                </p>
-                                {# Pagination buttons #}
-                                <nav class="flex items-center gap-2" x-data="{}" x-scroll-preserve-links>
-                                    {# Previous button #}
-                                    {% if page > 1 %}
-                                        <a href="{{ url_for('gsheets.view_assembly_selection', assembly_id=assembly.id, page=page - 1) }}"
-                                           class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
-                                           style="border: 1px solid var(--color-borders-dividers);
-                                                  color: var(--color-body-text)"
-                                           onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                                           onmouseout="this.style.backgroundColor='transparent'">
-                                            {{ _("Previous") }}
-                                        </a>
-                                    {% else %}
-                                        <span class="px-3 py-2 rounded text-body-sm font-medium"
-                                              style="border: 1px solid var(--color-borders-dividers);
-                                                     color: var(--color-secondary-text);
-                                                     opacity: 0.5">{{ _("Previous") }}</span>
-                                    {% endif %}
-                                    {# Page numbers #}
-                                    {% for page_num in range(1, total_pages + 1) %}
-                                        {% if page_num == page %}
-                                            <span class="px-3 py-2 rounded text-body-sm font-medium"
-                                                  style="background-color: var(--color-primary-action);
-                                                         color: white">{{ page_num }}</span>
-                                        {% elif page_num == 1 or page_num == total_pages or (page_num >= page - 2 and page_num <= page + 2) %}
-                                            <a href="{{ url_for('gsheets.view_assembly_selection', assembly_id=assembly.id, page=page_num) }}"
-                                               class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      color: var(--color-body-text)"
-                                               onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                                               onmouseout="this.style.backgroundColor='transparent'">{{ page_num }}</a>
-                                        {% elif page_num == page - 3 or page_num == page + 3 %}
-                                            <span class="px-3 py-2 text-body-sm"
-                                                  style="color: var(--color-secondary-text)">...</span>
-                                        {% endif %}
-                                    {% endfor %}
-                                    {# Next button #}
-                                    {% if page < total_pages %}
-                                        <a href="{{ url_for('gsheets.view_assembly_selection', assembly_id=assembly.id, page=page + 1) }}"
-                                           class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
-                                           style="border: 1px solid var(--color-borders-dividers);
-                                                  color: var(--color-body-text)"
-                                           onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                                           onmouseout="this.style.backgroundColor='transparent'">{{ _("Next") }}</a>
-                                    {% else %}
-                                        <span class="px-3 py-2 rounded text-body-sm font-medium"
-                                              style="border: 1px solid var(--color-borders-dividers);
-                                                     color: var(--color-secondary-text);
-                                                     opacity: 0.5">{{ _("Next") }}</span>
-                                    {% endif %}
-                                </nav>
-                            </div>
-                        {% endif %}
+                        {{ pagination(
+                        page=page,
+                        total_pages=total_pages,
+                        per_page=per_page,
+                        total_count=total_count,
+                        base_url=url_for('gsheets.view_assembly_selection', assembly_id=assembly.id),
+                        item_name=_("runs")
+                        ) }}
                     {% else %}
                         {# Empty state #}
                         <div class="text-center py-8">
@@ -460,69 +406,14 @@ ABOUTME: Displays selection operations: initial selection, replacement, and tab 
                             </table>
                         </div>
                         {# Pagination Controls #}
-                        {% if total_pages > 1 %}
-                            <div class="mt-6 flex items-center justify-between">
-                                {# Results count #}
-                                <p class="text-body-sm" style="color: var(--color-secondary-text);">
-                                    {% set end_record = page * per_page if page * per_page < total_count else total_count %}
-                                    {{ _("Showing %(start)s-%(end)s of %(total)s runs",
-                                    start=((page - 1) * per_page + 1),
-                                    end=end_record,
-                                    total=total_count) }}
-                                </p>
-                                {# Pagination buttons #}
-                                <nav class="flex items-center gap-2" x-data="{}" x-scroll-preserve-links>
-                                    {# Previous button #}
-                                    {% if page > 1 %}
-                                        <a href="{{ url_for('gsheets.view_assembly_selection', assembly_id=assembly.id, page=page - 1) }}"
-                                           class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
-                                           style="border: 1px solid var(--color-borders-dividers);
-                                                  color: var(--color-body-text)"
-                                           onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                                           onmouseout="this.style.backgroundColor='transparent'">
-                                            {{ _("Previous") }}
-                                        </a>
-                                    {% else %}
-                                        <span class="px-3 py-2 rounded text-body-sm font-medium"
-                                              style="border: 1px solid var(--color-borders-dividers);
-                                                     color: var(--color-secondary-text);
-                                                     opacity: 0.5">{{ _("Previous") }}</span>
-                                    {% endif %}
-                                    {# Page numbers #}
-                                    {% for page_num in range(1, total_pages + 1) %}
-                                        {% if page_num == page %}
-                                            <span class="px-3 py-2 rounded text-body-sm font-medium"
-                                                  style="background-color: var(--color-primary-action);
-                                                         color: white">{{ page_num }}</span>
-                                        {% elif page_num == 1 or page_num == total_pages or (page_num >= page - 2 and page_num <= page + 2) %}
-                                            <a href="{{ url_for('gsheets.view_assembly_selection', assembly_id=assembly.id, page=page_num) }}"
-                                               class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      color: var(--color-body-text)"
-                                               onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                                               onmouseout="this.style.backgroundColor='transparent'">{{ page_num }}</a>
-                                        {% elif page_num == page - 3 or page_num == page + 3 %}
-                                            <span class="px-3 py-2 text-body-sm"
-                                                  style="color: var(--color-secondary-text)">...</span>
-                                        {% endif %}
-                                    {% endfor %}
-                                    {# Next button #}
-                                    {% if page < total_pages %}
-                                        <a href="{{ url_for('gsheets.view_assembly_selection', assembly_id=assembly.id, page=page + 1) }}"
-                                           class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
-                                           style="border: 1px solid var(--color-borders-dividers);
-                                                  color: var(--color-body-text)"
-                                           onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                                           onmouseout="this.style.backgroundColor='transparent'">{{ _("Next") }}</a>
-                                    {% else %}
-                                        <span class="px-3 py-2 rounded text-body-sm font-medium"
-                                              style="border: 1px solid var(--color-borders-dividers);
-                                                     color: var(--color-secondary-text);
-                                                     opacity: 0.5">{{ _("Next") }}</span>
-                                    {% endif %}
-                                </nav>
-                            </div>
-                        {% endif %}
+                        {{ pagination(
+                        page=page,
+                        total_pages=total_pages,
+                        per_page=per_page,
+                        total_count=total_count,
+                        base_url=url_for('gsheets.view_assembly_selection', assembly_id=assembly.id),
+                        item_name=_("runs")
+                        ) }}
                     {% else %}
                         {# Empty state #}
                         <div class="text-center py-8">

--- a/backend/templates/backoffice/assembly_view_respondent.html
+++ b/backend/templates/backoffice/assembly_view_respondent.html
@@ -41,13 +41,13 @@ ABOUTME: Displays a single respondent's full details including attributes
 
     <section class="mb-8">
         <h2 class="text-display-sm mb-4" style="color: var(--color-headings);">{{ _("Details") }}</h2>
-        {% call table(striped=true) %}
+        {% call table() %}
             {{ table_head([
             {"label": _("Field")},
             {"label": _("Value")}
             ]) }}
             {% call table_body() %}
-                {% call table_row(is_odd=true) %}
+                {% call table_row() %}
                     {{ table_cell(_("External ID"), bold=true) }}
                     {{ table_cell(respondent.external_id) }}
                 {% endcall %}
@@ -55,7 +55,7 @@ ABOUTME: Displays a single respondent's full details including attributes
                     {{ table_cell(_("Email"), bold=true) }}
                     {{ table_cell(respondent.email or "—") }}
                 {% endcall %}
-                {% call table_row(is_odd=true) %}
+                {% call table_row() %}
                     {{ table_cell(_("Selection status"), bold=true) }}
                     {{ table_cell(respondent.selection_status.value|title) }}
                 {% endcall %}
@@ -63,7 +63,7 @@ ABOUTME: Displays a single respondent's full details including attributes
                     {{ table_cell(_("Selection run ID"), bold=true) }}
                     {{ table_cell(respondent.selection_run_id or "—") }}
                 {% endcall %}
-                {% call table_row(is_odd=true) %}
+                {% call table_row() %}
                     {{ table_cell(_("Consent"), bold=true) }}
                     {{ table_cell_yes_no(respondent.consent) }}
                 {% endcall %}
@@ -71,7 +71,7 @@ ABOUTME: Displays a single respondent's full details including attributes
                     {{ table_cell(_("Stay on database"), bold=true) }}
                     {{ table_cell_yes_no(respondent.stay_on_db) }}
                 {% endcall %}
-                {% call table_row(is_odd=true) %}
+                {% call table_row() %}
                     {{ table_cell(_("Eligible"), bold=true) }}
                     {{ table_cell_yes_no(respondent.eligible) }}
                 {% endcall %}
@@ -79,7 +79,7 @@ ABOUTME: Displays a single respondent's full details including attributes
                     {{ table_cell(_("Can attend"), bold=true) }}
                     {{ table_cell_yes_no(respondent.can_attend) }}
                 {% endcall %}
-                {% call table_row(is_odd=true) %}
+                {% call table_row() %}
                     {{ table_cell(_("Source type"), bold=true) }}
                     {{ table_cell(respondent.source_type.value|replace("_", " ")|title) }}
                 {% endcall %}
@@ -87,7 +87,7 @@ ABOUTME: Displays a single respondent's full details including attributes
                     {{ table_cell(_("Source reference"), bold=true) }}
                     {{ table_cell(respondent.source_reference or "—") }}
                 {% endcall %}
-                {% call table_row(is_odd=true) %}
+                {% call table_row() %}
                     {{ table_cell(_("Created"), bold=true) }}
                     {{ table_cell(respondent.created_at.strftime("%d %B %Y at %H:%M") if respondent.created_at else "—") }}
                 {% endcall %}
@@ -102,14 +102,14 @@ ABOUTME: Displays a single respondent's full details including attributes
     <section class="mb-8">
         <h2 class="text-display-sm mb-4" style="color: var(--color-headings);">{{ _("Attributes") }}</h2>
         {% if respondent.attributes %}
-            {% call table(striped=true) %}
+            {% call table() %}
                 {{ table_head([
                 {"label": _("Attribute")},
                 {"label": _("Value")}
                 ]) }}
                 {% call table_body() %}
                     {% for key, value in respondent.attributes.items() %}
-                        {% call table_row(is_odd=loop.index is odd) %}
+                        {% call table_row() %}
                             {{ table_cell(key, bold=true) }}
                             {{ table_cell(value if value not in (none, "") else "—") }}
                         {% endcall %}

--- a/backend/templates/backoffice/components/pagination.html
+++ b/backend/templates/backoffice/components/pagination.html
@@ -1,0 +1,115 @@
+{#
+ABOUTME: Stateless pagination component macro for backoffice design system
+ABOUTME: Provides page navigation with ellipsis, result counts, and scroll preservation
+#}
+
+{# Helper macro to build page URL #}
+{% macro _page_url(base_url, page_num, page_param="page") %}
+    {#- Check if base_url already has query params -#}
+    {%- if '?' in base_url -%}
+        {{ base_url }}&{{ page_param }}={{ page_num }}
+    {%- else -%}
+        {{ base_url }}?{{ page_param }}={{ page_num }}
+    {%- endif -%}
+{% endmacro %}
+
+{# Pagination component with result count and page navigation #}
+{% macro pagination(page, total_pages, per_page, total_count, base_url, item_name="items", preserve_scroll=true, page_param="page") %}
+    {#
+Stateless pagination component with result count and page navigation.
+
+Args:
+  page: Current page number (1-indexed)
+  total_pages: Total number of pages
+  per_page: Number of items per page
+  total_count: Total number of items
+  base_url: Base URL for pagination links. The page query parameter will be appended.
+            Example: url_for('my.route', assembly_id=assembly.id)
+  item_name: Label for items being paginated (default: "items")
+  preserve_scroll: If true, adds x-scroll-preserve-links directive for scroll restoration (default: true)
+  page_param: Name of the query parameter for page number (default: "page")
+
+Usage:
+  {{ pagination(
+      page=page,
+      total_pages=total_pages,
+      per_page=per_page,
+      total_count=total_count,
+      base_url=url_for('backoffice.view_respondents', assembly_id=assembly.id),
+      item_name=_("respondents")
+  ) }}
+
+Design tokens used:
+  --color-secondary-text (results count)
+  --color-borders-dividers (button borders)
+  --color-body-text (button text)
+  --color-subtle-background-panels (hover state)
+  --color-primary-action (active page background)
+    #}
+    {% if total_pages > 1 %}
+        <div class="mt-6 flex items-center justify-between">
+            {# Results count #}
+            <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                {% set start_record = (page - 1) * per_page + 1 %}
+                {% set end_record = page * per_page if page * per_page < total_count else total_count %}
+                {{ _("Showing %(start)s-%(end)s of %(total)s %(items)s",
+                start=start_record,
+                end=end_record,
+                total=total_count,
+                items=item_name) }}
+            </p>
+            {# Pagination buttons #}
+            <nav class="flex items-center gap-2"
+                 {% if preserve_scroll %}x-data="{}" x-scroll-preserve-links{% endif %}>
+                {# Previous button #}
+                {% if page > 1 %}
+                    <a href="{{ _page_url(base_url, page - 1, page_param) }}"
+                       class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
+                       style="border: 1px solid var(--color-borders-dividers);
+                              color: var(--color-body-text)"
+                       onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
+                       onmouseout="this.style.backgroundColor='transparent'">
+                        {{ _("Previous") }}
+                    </a>
+                {% else %}
+                    <span class="px-3 py-2 rounded text-body-sm font-medium"
+                          style="border: 1px solid var(--color-borders-dividers);
+                                 color: var(--color-secondary-text);
+                                 opacity: 0.5">{{ _("Previous") }}</span>
+                {% endif %}
+                {# Page numbers #}
+                {% for page_num in range(1, total_pages + 1) %}
+                    {% if page_num == page %}
+                        <span class="px-3 py-2 rounded text-body-sm font-medium"
+                              style="background-color: var(--color-primary-action);
+                                     color: white">{{ page_num }}</span>
+                    {% elif page_num == 1 or page_num == total_pages or (page_num >= page - 2 and page_num <= page + 2) %}
+                        <a href="{{ _page_url(base_url, page_num, page_param) }}"
+                           class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
+                           style="border: 1px solid var(--color-borders-dividers);
+                                  color: var(--color-body-text)"
+                           onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
+                           onmouseout="this.style.backgroundColor='transparent'">{{ page_num }}</a>
+                    {% elif page_num == page - 3 or page_num == page + 3 %}
+                        <span class="px-3 py-2 text-body-sm"
+                              style="color: var(--color-secondary-text)">...</span>
+                    {% endif %}
+                {% endfor %}
+                {# Next button #}
+                {% if page < total_pages %}
+                    <a href="{{ _page_url(base_url, page + 1, page_param) }}"
+                       class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
+                       style="border: 1px solid var(--color-borders-dividers);
+                              color: var(--color-body-text)"
+                       onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
+                       onmouseout="this.style.backgroundColor='transparent'">{{ _("Next") }}</a>
+                {% else %}
+                    <span class="px-3 py-2 rounded text-body-sm font-medium"
+                          style="border: 1px solid var(--color-borders-dividers);
+                                 color: var(--color-secondary-text);
+                                 opacity: 0.5">{{ _("Next") }}</span>
+                {% endif %}
+            </nav>
+        </div>
+    {% endif %}
+{% endmacro %}

--- a/backend/templates/backoffice/components/pagination.html
+++ b/backend/templates/backoffice/components/pagination.html
@@ -64,11 +64,9 @@ Design tokens used:
                 {# Previous button #}
                 {% if page > 1 %}
                     <a href="{{ _page_url(base_url, page - 1, page_param) }}"
-                       class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
+                       class="pagination-btn px-3 py-2 rounded text-body-sm font-medium transition-colors"
                        style="border: 1px solid var(--color-borders-dividers);
-                              color: var(--color-body-text)"
-                       onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                       onmouseout="this.style.backgroundColor='transparent'">
+                              color: var(--color-body-text)">
                         {{ _("Previous") }}
                     </a>
                 {% else %}
@@ -85,11 +83,9 @@ Design tokens used:
                                      color: white">{{ page_num }}</span>
                     {% elif page_num == 1 or page_num == total_pages or (page_num >= page - 2 and page_num <= page + 2) %}
                         <a href="{{ _page_url(base_url, page_num, page_param) }}"
-                           class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
+                           class="pagination-btn px-3 py-2 rounded text-body-sm font-medium transition-colors"
                            style="border: 1px solid var(--color-borders-dividers);
-                                  color: var(--color-body-text)"
-                           onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                           onmouseout="this.style.backgroundColor='transparent'">{{ page_num }}</a>
+                                  color: var(--color-body-text)">{{ page_num }}</a>
                     {% elif page_num == page - 3 or page_num == page + 3 %}
                         <span class="px-3 py-2 text-body-sm"
                               style="color: var(--color-secondary-text)">...</span>
@@ -98,11 +94,9 @@ Design tokens used:
                 {# Next button #}
                 {% if page < total_pages %}
                     <a href="{{ _page_url(base_url, page + 1, page_param) }}"
-                       class="px-3 py-2 rounded text-body-sm font-medium transition-colors"
+                       class="pagination-btn px-3 py-2 rounded text-body-sm font-medium transition-colors"
                        style="border: 1px solid var(--color-borders-dividers);
-                              color: var(--color-body-text)"
-                       onmouseover="this.style.backgroundColor='var(--color-subtle-background-panels)'"
-                       onmouseout="this.style.backgroundColor='transparent'">{{ _("Next") }}</a>
+                              color: var(--color-body-text)">{{ _("Next") }}</a>
                 {% else %}
                     <span class="px-3 py-2 rounded text-body-sm font-medium"
                           style="border: 1px solid var(--color-borders-dividers);

--- a/backend/templates/backoffice/components/section.html
+++ b/backend/templates/backoffice/components/section.html
@@ -1,0 +1,36 @@
+{#
+ABOUTME: Section component macro for backoffice design system
+ABOUTME: Provides a simple white box container with rounded corners and padding
+#}
+
+{# Section container with white background, rounded corners, and padding #}
+{% macro section(classes="") %}
+    {#
+Section container component using semantic design tokens.
+
+A simple white box for grouping related content on layouts.
+Uses 8px border radius and 24px padding by default.
+
+Args:
+  classes: Additional CSS classes for customization
+
+Usage:
+  {% call section() %}
+    <h2>Section Title</h2>
+    <p>Section content goes here...</p>
+  {% endcall %}
+
+  {% call section(classes="mb-6") %}
+    <p>Section with extra margin bottom</p>
+  {% endcall %}
+
+Design tokens used:
+  --color-tables-cards (background)
+  --radius-lg (border radius - 8px)
+  --spacing-6 (padding - 24px)
+    #}
+  <div class="rounded-lg p-6 {{ classes }}"
+       style="background-color: var(--color-tables-cards);">
+    {{ caller() }}
+  </div>
+{% endmacro %}

--- a/backend/templates/backoffice/components/showcase_section.html
+++ b/backend/templates/backoffice/components/showcase_section.html
@@ -42,8 +42,9 @@
 {#
   Showcase example with tab toggle between Preview and Code
   Use with {% call %} - the caller content is the preview, code param is the code example
+  Set transparent=true to remove the gray background panel (useful for tables that have their own background)
 #}
-{% macro showcase_example(code) %}
+{% macro showcase_example(code, transparent=false) %}
     <div class="mt-6" x-data="{ tab: 'preview' }">
         {# Tab buttons #}
         <div class="flex gap-1 mb-3">
@@ -76,17 +77,31 @@
         </div>
 
         {# Tab content #}
-        <div class="p-4 rounded-lg rounded-tl-none" style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
-            {# Preview panel #}
-            <div x-show="tab === 'preview'" x-cloak>
-                {{ caller() }}
+        {% if transparent %}
+            <div>
+            {# Preview panel - no background #}
+                <div x-show="tab === 'preview'" x-cloak>
+                    {{ caller() }}
+                </div>
+
+            {# Code panel - always has background #}
+                <div x-show="tab === 'code'" x-cloak class="p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
+                <pre class="text-body-sm overflow-x-auto" style="color: var(--color-body-text);"><code>{{ code | e }}</code></pre>
+                </div>
             </div>
+        {% else %}
+            <div class="p-4 rounded-lg rounded-tl-none" style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
+            {# Preview panel #}
+                <div x-show="tab === 'preview'" x-cloak>
+                    {{ caller() }}
+                </div>
 
             {# Code panel #}
-            <div x-show="tab === 'code'" x-cloak>
+                <div x-show="tab === 'code'" x-cloak>
                 <pre class="text-body-sm overflow-x-auto" style="color: var(--color-body-text);"><code>{{ code | e }}</code></pre>
+                </div>
             </div>
-        </div>
+        {% endif %}
     </div>
 {% endmacro %}
 

--- a/backend/templates/backoffice/components/showcase_section.html
+++ b/backend/templates/backoffice/components/showcase_section.html
@@ -3,11 +3,16 @@
   Internal macros for structuring the component showcase page.
   Not intended for use outside of showcase.html.
 #}
+{% from "backoffice/components/section.html" import section %}
 
 {# Section wrapper - use with {% call %} #}
 {% macro showcase_section(id="") %}
-    <section{% if id %} id="{{ id }}"{% endif %} class="mb-24">
-        {{ caller() }}
+    {# Capture caller content before nested call to avoid scoping issues #}
+    {% set content = caller() %}
+    <section{% if id %} id="{{ id }}"{% endif %} class="mb-12">
+        {% call section() %}
+            {{ content }}
+        {% endcall %}
     </section>
 {% endmacro %}
 

--- a/backend/templates/backoffice/components/table.html
+++ b/backend/templates/backoffice/components/table.html
@@ -181,6 +181,7 @@ Status colors:
   - confirmed: green (confirmed participant)
   - selected: gray (pending confirmation)
   - withdrawn: red (no longer participating)
+  - deleted: dark gray (GDPR deletion)
 
 Usage:
   {{ table_cell_status("pool") }}
@@ -199,6 +200,9 @@ Usage:
   {% elif status_lower == "withdrawn" %}
     {% set dot_color = "var(--color-error-400)" %}
     {% set label = _("Withdrawn") %}
+  {% elif status_lower == "deleted" %}
+    {% set dot_color = "var(--color-secondary-text)" %}
+    {% set label = _("Deleted") %}
   {% else %}
     {% set dot_color = "var(--color-borders-dividers)" %}
     {% set label = status_lower|capitalize %}

--- a/backend/templates/backoffice/components/table.html
+++ b/backend/templates/backoffice/components/table.html
@@ -1,21 +1,24 @@
 {#
 ABOUTME: Table component macros for backoffice design system
-ABOUTME: Supports simple tables, striped rows, and responsive horizontal scrolling
+ABOUTME: Supports tables with hover effect and responsive horizontal scrolling
 #}
 
 {# Table container with responsive horizontal scroll wrapper #}
-{% macro table(id="", classes="", striped=false, hoverable=false) %}
+{% macro table(id="", classes="") %}
     {#
 Table component using semantic design tokens.
 
 Args:
   id: Optional id attribute
   classes: Additional CSS classes for the table
-  striped: If true, alternates row background colors
-  hoverable: If true, adds hover effect to rows
+
+Features:
+  - Hover effect on rows (neutral-100 background)
+  - Header background in neutral-50
+  - Responsive with horizontal scrolling
 
 Usage:
-  {% call table(striped=true, hoverable=true) %}
+  {% call table() %}
     {{ table_head([
       {"label": "Name"},
       {"label": "Age", "align": "center"},
@@ -37,9 +40,7 @@ Usage:
              style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
           <table {% if id %}id="{{ id }}"{% endif %}
                  class="min-w-full divide-y {{ classes }}"
-                 style="--table-divide-color: var(--color-borders-dividers);"
-                 data-striped="{{ 'true' if striped else 'false' }}"
-                 data-hoverable="{{ 'true' if hoverable else 'false' }}">
+                 style="--table-divide-color: var(--color-borders-dividers);">
             {{ caller() }}
           </table>
         </div>
@@ -66,7 +67,7 @@ Usage:
     {"label": "Actions", "align": "right"}
   ]) }}
     #}
-  <thead style="background-color: var(--color-subtle-background-panels);">
+  <thead style="background-color: var(--color-neutral-50);">
     <tr>
       {% for col in columns %}
         {% set align = col.align | default("left") %}
@@ -97,21 +98,20 @@ Usage:
 {% endmacro %}
 
 {# Table row #}
-{% macro table_row(is_odd=false, classes="") %}
+{% macro table_row(classes="") %}
     {#
 Table row. Use within table_body().
 
 Args:
-  is_odd: If true and table is striped, applies alternate background
   classes: Additional CSS classes
 
 Usage:
-  {% call table_row(is_odd=loop.index is odd) %}
+  {% call table_row() %}
     {{ table_cell("Content") }}
   {% endcall %}
     #}
-  <tr class="{{ classes }}"
-      style="color: var(--color-body-text);{% if is_odd %} background-color: var(--color-subtle-background-panels);{% endif %}">
+  <tr class="table-row-hover {{ classes }}"
+      style="color: var(--color-body-text);">
     {{ caller() }}
   </tr>
 {% endmacro %}

--- a/backend/templates/backoffice/components/table.html
+++ b/backend/templates/backoffice/components/table.html
@@ -66,12 +66,12 @@ Usage:
     {"label": "Actions", "align": "right"}
   ]) }}
     #}
-  <thead>
-    <tr style="color: var(--color-headings);">
+  <thead style="background-color: var(--color-subtle-background-panels);">
+    <tr>
       {% for col in columns %}
         {% set align = col.align | default("left") %}
-        <th class="px-5 py-3 text-body-sm font-medium uppercase text-{{ align }} {{ col.classes | default('') }}"
-            style="color: var(--color-headings);">
+        <th class="px-5 py-3 text-body-sm font-semibold text-{{ align }} {{ col.classes | default('') }}"
+            style="color: var(--color-headings); border-bottom: 1px solid var(--color-borders-dividers);">
           {{ col.label }}
         </th>
       {% endfor %}
@@ -160,6 +160,57 @@ Usage:
        onmouseout="this.style.color='var(--color-primary-action)'">
       {{ text }}
     </a>
+  </td>
+{% endmacro %}
+
+{# Table cell with status indicator #}
+{% macro table_cell_status(status, align="left", show_dot=true, nowrap=true, classes="") %}
+    {#
+Table cell with colored status text and optional indicator dot.
+
+Args:
+  status: Status value - one of "pool", "selected", "confirmed", "withdrawn"
+          (case-insensitive, also accepts RespondentStatus enum values)
+  align: Text alignment ("left", "center", "right")
+  show_dot: If true, shows colored dot before the text
+  nowrap: If true, prevents text wrapping
+  classes: Additional CSS classes
+
+Status colors:
+  - pool: green (available for selection)
+  - confirmed: green (confirmed participant)
+  - selected: gray (pending confirmation)
+  - withdrawn: red (no longer participating)
+
+Usage:
+  {{ table_cell_status("pool") }}
+  {{ table_cell_status(respondent.selection_status, show_dot=false) }}
+    #}
+  {% set status_lower = (status.value if status.value is defined else status)|lower %}
+  {% if status_lower == "pool" %}
+    {% set dot_color = "var(--color-success-400)" %}
+    {% set label = _("Pool") %}
+  {% elif status_lower == "confirmed" %}
+    {% set dot_color = "var(--color-success-400)" %}
+    {% set label = _("Confirmed") %}
+  {% elif status_lower == "selected" %}
+    {% set dot_color = "var(--color-borders-dividers)" %}
+    {% set label = _("Selected") %}
+  {% elif status_lower == "withdrawn" %}
+    {% set dot_color = "var(--color-error-400)" %}
+    {% set label = _("Withdrawn") %}
+  {% else %}
+    {% set dot_color = "var(--color-borders-dividers)" %}
+    {% set label = status_lower|capitalize %}
+  {% endif %}
+  <td class="px-5 py-4 text-body-sm text-{{ align }} {{ 'whitespace-nowrap' if nowrap else '' }} {{ classes }}">
+    <span class="inline-flex items-center gap-2">
+      {% if show_dot %}
+        <span class="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+              style="background-color: {{ dot_color }};"></span>
+      {% endif %}
+      <span style="color: var(--color-body-text);">{{ label }}</span>
+    </span>
   </td>
 {% endmacro %}
 

--- a/backend/templates/backoffice/components/table.html
+++ b/backend/templates/backoffice/components/table.html
@@ -176,12 +176,12 @@ Args:
   nowrap: If true, prevents text wrapping
   classes: Additional CSS classes
 
-Status colors:
-  - pool: green (available for selection)
+Status colors (traffic light pattern):
+  - pool: gray (waiting in pool)
+  - selected: amber (pending confirmation - needs attention)
   - confirmed: green (confirmed participant)
-  - selected: gray (pending confirmation)
   - withdrawn: red (no longer participating)
-  - deleted: dark gray (GDPR deletion)
+  - deleted: light gray (GDPR deletion)
 
 Usage:
   {{ table_cell_status("pool") }}
@@ -189,19 +189,19 @@ Usage:
     #}
   {% set status_lower = (status.value if status.value is defined else status)|lower %}
   {% if status_lower == "pool" %}
-    {% set dot_color = "var(--color-success-400)" %}
+    {% set dot_color = "var(--color-secondary-text)" %}
     {% set label = _("Pool") %}
   {% elif status_lower == "confirmed" %}
     {% set dot_color = "var(--color-success-400)" %}
     {% set label = _("Confirmed") %}
   {% elif status_lower == "selected" %}
-    {% set dot_color = "var(--color-borders-dividers)" %}
+    {% set dot_color = "var(--color-warning-400)" %}
     {% set label = _("Selected") %}
   {% elif status_lower == "withdrawn" %}
     {% set dot_color = "var(--color-error-400)" %}
     {% set label = _("Withdrawn") %}
   {% elif status_lower == "deleted" %}
-    {% set dot_color = "var(--color-secondary-text)" %}
+    {% set dot_color = "var(--color-borders-dividers)" %}
     {% set label = _("Deleted") %}
   {% else %}
     {% set dot_color = "var(--color-borders-dividers)" %}

--- a/backend/templates/backoffice/patterns.html
+++ b/backend/templates/backoffice/patterns.html
@@ -43,7 +43,8 @@ ABOUTME: Documents Alpine.js patterns, form handling, and AJAX with live example
         {"label": _("Form State"), "href": url_for('dev.patterns', tab='form'), "active": active_tab == 'form'},
         {"label": _("AJAX"), "href": url_for('dev.patterns', tab='ajax'), "active": active_tab == 'ajax'},
         {"label": _("File Upload"), "href": url_for('dev.patterns', tab='file-upload'), "active": active_tab == 'file-upload'},
-        {"label": _("Progress"), "href": url_for('dev.patterns', tab='progress'), "active": active_tab == 'progress'}
+        {"label": _("Progress"), "href": url_for('dev.patterns', tab='progress'), "active": active_tab == 'progress'},
+        {"label": _("Pagination"), "href": url_for('dev.patterns', tab='pagination'), "active": active_tab == 'pagination'}
         ],
         aria_label=_("Pattern categories")
         ) }}
@@ -540,6 +541,212 @@ def upload_csv():
             </div>
         {% endif %}
 
+        {# ===== PAGINATION PATTERN ===== #}
+        {% if active_tab == 'pagination' %}
+            {% from "backoffice/components/pagination.html" import pagination %}
+            <div class="space-y-6">
+                {# Pagination Pattern #}
+                {% call card(title="Pagination Pattern", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Server-side pagination using URL query parameters. Page state is managed via the <code>page</code> query parameter, enabling bookmarkable URLs and browser history support.") | safe }}
+                        </p>
+
+                        {# When to Use #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("When to Use") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li>{{ _("Listing data that exceeds comfortable single-page viewing") }}</li>
+                                <li>{{ _("Tables with more than ~20-50 rows") }}</li>
+                                <li>{{ _("When users need to share or bookmark specific page positions") }}</li>
+                            </ul>
+                        </div>
+
+                        {# Live Example #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">
+                                <span class="mr-2">🧪</span>{{ _("Live Example") }}
+                            </h4>
+                            <div class="p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
+                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                    {{ _("Try clicking the pagination buttons below. Notice how the URL changes with the page parameter.") }}
+                                </p>
+                                {% set demo_page = request.args.get('demo_page', 1)|int %}
+                                {{ pagination(
+                                page=demo_page,
+                                total_pages=15,
+                                per_page=10,
+                                total_count=142,
+                                base_url=url_for('dev.patterns', tab='pagination'),
+                                item_name=_("items"),
+                                preserve_scroll=true,
+                                page_param="demo_page"
+                                ) }}
+                                {% if demo_page != 1 %}
+                                    <p class="text-body-sm mt-4" style="color: var(--color-success-600);">
+                                        ✅ {{ _("Current page: %(page)s (see URL: demo_page=%(page)s)", page=demo_page) }}
+                                    </p>
+                                {% endif %}
+                            </div>
+                        </div>
+
+                        {# Code Example #}
+                        <div class="mb-6">
+                            <div class="flex items-center justify-between mb-2">
+                                <h4 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Template Code") }}</h4>
+                                <button @click="copyPaginationTemplateCode()"
+                                        class="text-body-sm px-2 py-1 rounded transition-colors"
+                                        style="background-color: var(--color-subtle-background-panels);">
+                                    📋 {{ _("Copy") }}
+                                </button>
+                            </div>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{% raw %}{# Import the component #}
+{% from "backoffice/components/pagination.html" import pagination %}
+
+{# Use with base_url - page param will be appended automatically #}
+{{ pagination(
+    page=page,
+    total_pages=total_pages,
+    per_page=per_page,
+    total_count=total_count,
+    base_url=url_for('my.route', assembly_id=assembly.id),
+    item_name=_("respondents")
+) }}{% endraw %}</pre>
+                        </div>
+
+                        {# Flask Route Code #}
+                        <div class="mb-6">
+                            <div class="flex items-center justify-between mb-2">
+                                <h4 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Flask Route Code") }}</h4>
+                                <button @click="copyPaginationRouteCode()"
+                                        class="text-body-sm px-2 py-1 rounded transition-colors"
+                                        style="background-color: var(--color-subtle-background-panels);">
+                                    📋 {{ _("Copy") }}
+                                </button>
+                            </div>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">@bp.route("/items")
+def list_items():
+    # Get page from query param, default to 1
+    page = request.args.get("page", 1, type=int)
+    per_page = 20  # Items per page
+
+    # Paginate query
+    items = Item.query.paginate(page=page, per_page=per_page)
+
+    return render_template(
+        "items/list.html",
+        items=items.items,
+        page=page,
+        total_pages=items.pages,
+        per_page=per_page,
+        total_count=items.total,
+    )</pre>
+                        </div>
+
+                        {# Architecture Notes #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-warning-600);">⚠️ {{ _("Key Points") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><strong>base_url</strong> — {{ _("Pass a URL without the page param; it will be appended automatically") }}</li>
+                                <li><strong>{{ _("1-indexed pages") }}</strong> — {{ _("Page numbers start at 1, not 0") }}</li>
+                                <li><strong>{{ _("Stateless") }}</strong> — {{ _("Component has no internal state; all values come from server") }}</li>
+                                <li><strong>{{ _("Hidden when single page") }}</strong> — {{ _("Renders nothing when total_pages ≤ 1") }}</li>
+                            </ul>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+
+                {# Scroll Preservation Pattern #}
+                {% call card(title="Scroll Preservation (x-scroll-preserve-links)", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("The <code>x-scroll-preserve-links</code> Alpine.js directive preserves and restores scroll position when navigating between pages. This prevents the jarring experience of scrolling back to find your place after clicking a pagination link.") | safe }}
+                        </p>
+
+                        {# How it works #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("How It Works") }}</h4>
+                            <ol class="list-decimal list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li>{{ _("When a link inside the element is clicked, the current scroll position is saved to sessionStorage") }}</li>
+                                <li>{{ _("On page load, if a saved position exists for this URL, the page scrolls to that position") }}</li>
+                                <li>{{ _("Position is keyed by full URL including query parameters") }}</li>
+                            </ol>
+                        </div>
+
+                        {# Code Example #}
+                        <div class="mb-6">
+                            <div class="flex items-center justify-between mb-2">
+                                <h4 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Usage") }}</h4>
+                                <button @click="copyScrollPreserveCode()"
+                                        class="text-body-sm px-2 py-1 rounded transition-colors"
+                                        style="background-color: var(--color-subtle-background-panels);">
+                                    📋 {{ _("Copy") }}
+                                </button>
+                            </div>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{# Add the directive to any container with navigation links #}
+&lt;nav class="pagination" x-data="{}" x-scroll-preserve-links&gt;
+    &lt;a href="?page=1"&gt;1&lt;/a&gt;
+    &lt;a href="?page=2"&gt;2&lt;/a&gt;
+    &lt;a href="?page=3"&gt;3&lt;/a&gt;
+&lt;/nav&gt;
+
+{# The pagination component includes this by default #}
+{{ "{{" }} pagination(..., preserve_scroll=true) {{ "}}" }}
+
+{# Disable scroll preservation if needed #}
+{{ "{{" }} pagination(..., preserve_scroll=false) {{ "}}" }}</pre>
+                        </div>
+
+                        {# Where it's defined #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">📍 {{ _("Definition") }}</h4>
+                            <p class="text-body-sm" style="color: var(--color-body-text);">
+                                {{ _("The directive is defined in:") }}
+                                <code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">static/backoffice/js/alpine-components.js</code>
+                            </p>
+                        </div>
+
+                        {# Implementation Index #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">
+                                <span class="mr-2">📍</span>{{ _("Implementations") }}
+                            </h4>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-body-sm" style="border: 1px solid var(--color-borders-dividers);">
+                                    <thead style="background-color: var(--color-subtle-background-panels);">
+                                        <tr>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("File") }}</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Line") }}</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Usage") }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);">static/backoffice/js/alpine-components.js</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">—</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">Directive definition</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);">templates/backoffice/components/pagination.html</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">47</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">Pagination component</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);">templates/backoffice/assembly_selection.html</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">252, 474</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">Selection run history pagination</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+            </div>
+        {% endif %}
+
         {# ===== PROGRESS PATTERN ===== #}
         {% if active_tab == 'progress' %}
             {% from "backoffice/components/modal.html" import progress_bar, spinner %}
@@ -908,6 +1115,56 @@ def upload_csv():
 
                 copyProgressBarCode() {
                     this.copyToClipboard(this.progressBarCode);
+                },
+
+                // Pagination pattern code snippets
+                paginationTemplateCode: '{{ "{%" }} from "backoffice/components/pagination.html" import pagination {{ "%}" }}\n\n' +
+                '{{ "{{" }} pagination(\n' +
+                '    page=page,\n' +
+                '    total_pages=total_pages,\n' +
+                '    per_page=per_page,\n' +
+                '    total_count=total_count,\n' +
+                '    base_url=url_for(\'my.route\', assembly_id=assembly.id),\n' +
+                '    item_name=_("respondents")\n' +
+                ') {{ "}}" }}',
+
+                paginationRouteCode: '@bp.route("/items")\n' +
+                'def list_items():\n' +
+                '    # Get page from query param, default to 1\n' +
+                '    page = request.args.get("page", 1, type=int)\n' +
+                '    per_page = 20  # Items per page\n\n' +
+                '    # Paginate query\n' +
+                '    items = Item.query.paginate(page=page, per_page=per_page)\n\n' +
+                '    return render_template(\n' +
+                '        "items/list.html",\n' +
+                '        items=items.items,\n' +
+                '        page=page,\n' +
+                '        total_pages=items.pages,\n' +
+                '        per_page=per_page,\n' +
+                '        total_count=items.total,\n' +
+                '    )',
+
+                scrollPreserveCode: '{# Add the directive to any container with navigation links #}\n' +
+                '<nav class="pagination" x-data="{}" x-scroll-preserve-links>\n' +
+                '    <a href="?page=1">1</a>\n' +
+                '    <a href="?page=2">2</a>\n' +
+                '    <a href="?page=3">3</a>\n' +
+                '</nav>\n\n' +
+                '{# The pagination component includes this by default #}\n' +
+                '{{ "{{" }} pagination(..., preserve_scroll=true) {{ "}}" }}\n\n' +
+                '{# Disable scroll preservation if needed #}\n' +
+                '{{ "{{" }} pagination(..., preserve_scroll=false) {{ "}}" }}',
+
+                copyPaginationTemplateCode() {
+                    this.copyToClipboard(this.paginationTemplateCode);
+                },
+
+                copyPaginationRouteCode() {
+                    this.copyToClipboard(this.paginationRouteCode);
+                },
+
+                copyScrollPreserveCode() {
+                    this.copyToClipboard(this.scrollPreserveCode);
                 }
             }));
 

--- a/backend/templates/backoffice/patterns.html
+++ b/backend/templates/backoffice/patterns.html
@@ -44,7 +44,8 @@ ABOUTME: Documents Alpine.js patterns, form handling, and AJAX with live example
         {"label": _("AJAX"), "href": url_for('dev.patterns', tab='ajax'), "active": active_tab == 'ajax'},
         {"label": _("File Upload"), "href": url_for('dev.patterns', tab='file-upload'), "active": active_tab == 'file-upload'},
         {"label": _("Progress"), "href": url_for('dev.patterns', tab='progress'), "active": active_tab == 'progress'},
-        {"label": _("Pagination"), "href": url_for('dev.patterns', tab='pagination'), "active": active_tab == 'pagination'}
+        {"label": _("Pagination"), "href": url_for('dev.patterns', tab='pagination'), "active": active_tab == 'pagination'},
+        {"label": _("Scroll"), "href": url_for('dev.patterns', tab='scroll'), "active": active_tab == 'scroll'}
         ],
         aria_label=_("Pattern categories")
         ) }}
@@ -973,6 +974,283 @@ def list_items():
             </div>
         {% endif %}
 
+        {# ===== SCROLL PRESERVATION PATTERN ===== #}
+        {% if active_tab == 'scroll' %}
+            <div class="space-y-6">
+                {# Overview Card #}
+                {% call card(title="Scroll Preservation Overview", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Scroll preservation prevents the jarring experience of losing your scroll position when navigating or filtering. The system saves the current scroll position in the URL as an ephemeral <code>scroll</code> parameter, restores it on page load, then immediately cleans the URL.") | safe }}
+                        </p>
+
+                        {# Philosophy #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("Design Philosophy") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><strong>{{ _("Ephemeral") }}:</strong> {{ _("Scroll parameter exists only during page transition — removed immediately after restoration") }}</li>
+                                <li><strong>{{ _("URL-based state") }}:</strong> {{ _("Testable, shareable, bookmarkable (without scroll param in final URL)") }}</li>
+                                <li><strong>{{ _("Zero configuration") }}:</strong> {{ _("Global restoration runs automatically on any page with scroll param") }}</li>
+                                <li><strong>{{ _("CSP-safe") }}:</strong> {{ _("No inline scripts required") }}</li>
+                            </ul>
+                        </div>
+
+                        {# Available Tools #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">
+                                <span class="mr-2">🧰</span>{{ _("Available Tools") }}
+                            </h4>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-body-sm" style="border: 1px solid var(--color-borders-dividers);">
+                                    <thead style="background-color: var(--color-subtle-background-panels);">
+                                        <tr>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Tool") }}</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Use Case") }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);"><code>$preserveScroll(url)</code></td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Alpine magic for single links/forms") }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);"><code>x-scroll-preserve-links</code></td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Alpine directive for auto-applying to all links in a container") }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono"><code>data-navigate-preserve-scroll</code></td>
+                                            <td class="px-3 py-2">{{ _("Add to select elements with data-navigate-base-url") }}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        {# Where it's defined #}
+                        <div class="p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">📍 {{ _("Source Files") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">static/js/alpine-scroll-manager.js</code> — {{ _("$preserveScroll magic and x-scroll-preserve-links directive") }}</li>
+                                <li><code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">static/js/utilities.js</code> — {{ _("data-navigate-* handlers for select elements") }}</li>
+                            </ul>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+
+                {# $preserveScroll Magic Pattern #}
+                {% call card(title="$preserveScroll Magic Helper", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Alpine.js magic helper that appends the current scroll position to a URL. Use for individual links or form actions.") }}
+                        </p>
+
+                        {# When to Use #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("When to Use") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li>{{ _("Single links where you need explicit control") }}</li>
+                                <li>{{ _("Form actions that redirect after submission") }}</li>
+                                <li>{{ _("Programmatic navigation in Alpine components") }}</li>
+                            </ul>
+                        </div>
+
+                        {# Code Example #}
+                        <div class="mb-6">
+                            <div class="flex items-center justify-between mb-2">
+                                <h4 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Code") }}</h4>
+                                <button @click="copyPreserveScrollCode()"
+                                        class="text-body-sm px-2 py-1 rounded transition-colors"
+                                        style="background-color: var(--color-subtle-background-panels);">
+                                    📋 {{ _("Copy") }}
+                                </button>
+                            </div>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{# Link with scroll preservation #}
+&lt;a :href="$preserveScroll('/some/url?page=2')"&gt;Page 2&lt;/a&gt;
+
+{# Form action with scroll preservation #}
+&lt;form :action="$preserveScroll('/submit')" method="post"&gt;
+    ...
+&lt;/form&gt;
+
+{# Result: URL gets &amp;scroll=1250 appended #}
+/some/url?page=2&amp;scroll=1250</pre>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+
+                {# x-scroll-preserve-links Directive #}
+                {% call card(title="x-scroll-preserve-links Directive", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Alpine.js directive that automatically applies scroll preservation to all links within an element. Links can opt-out with <code>data-no-scroll-preserve</code> attribute.") | safe }}
+                        </p>
+
+                        {# When to Use #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("When to Use") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li>{{ _("Pagination navigation (already included in pagination component)") }}</li>
+                                <li>{{ _("Any container with multiple navigation links") }}</li>
+                                <li>{{ _("Table rows with action links") }}</li>
+                            </ul>
+                        </div>
+
+                        {# Code Example #}
+                        <div class="mb-6">
+                            <div class="flex items-center justify-between mb-2">
+                                <h4 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Code") }}</h4>
+                                <button @click="copyScrollDirectiveCode()"
+                                        class="text-body-sm px-2 py-1 rounded transition-colors"
+                                        style="background-color: var(--color-subtle-background-panels);">
+                                    📋 {{ _("Copy") }}
+                                </button>
+                            </div>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{# Container with auto-scroll preservation #}
+&lt;nav x-data="{}" x-scroll-preserve-links&gt;
+    &lt;a href="?page=1"&gt;1&lt;/a&gt;  {# scroll preserved #}
+    &lt;a href="?page=2"&gt;2&lt;/a&gt;  {# scroll preserved #}
+    &lt;a href="/dashboard" data-no-scroll-preserve&gt;Home&lt;/a&gt;  {# opt-out #}
+&lt;/nav&gt;
+
+{# The pagination component includes this by default #}
+{% raw %}{{ pagination(..., preserve_scroll=true) }}{% endraw %}</pre>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+
+                {# Select Dropdown Pattern #}
+                {% call card(title="Select Dropdown with Scroll Preservation", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("For filter dropdowns using <code>data-navigate-base-url</code>, add <code>data-navigate-preserve-scroll</code> to preserve scroll position when the selection changes.") | safe }}
+                        </p>
+
+                        {# Live Example #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">
+                                <span class="mr-2">🧪</span>{{ _("Live Example") }}
+                            </h4>
+                            <div class="p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
+                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                    {{ _("Scroll down, then change this filter. Notice how scroll position is preserved (or not, depending on which dropdown you use).") }}
+                                </p>
+                                <div class="flex gap-4 flex-wrap">
+                                    <div>
+                                        <label class="text-label-md block mb-1" style="color: var(--color-headings);">{{ _("Without scroll preservation") }}</label>
+                                        <select class="px-3 py-2 rounded-lg text-body-md"
+                                                style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                                                data-navigate-base-url="{{ url_for('dev.patterns', tab='scroll') }}"
+                                                data-navigate-param="filter_no_scroll">
+                                            <option value="" {% if not request.args.get('filter_no_scroll') %}selected{% endif %}>{{ _("All") }}</option>
+                                            <option value="active" {% if request.args.get('filter_no_scroll') == 'active' %}selected{% endif %}>{{ _("Active") }}</option>
+                                            <option value="inactive" {% if request.args.get('filter_no_scroll') == 'inactive' %}selected{% endif %}>{{ _("Inactive") }}</option>
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label class="text-label-md block mb-1" style="color: var(--color-headings);">{{ _("With scroll preservation") }}</label>
+                                        <select class="px-3 py-2 rounded-lg text-body-md"
+                                                style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                                                data-navigate-base-url="{{ url_for('dev.patterns', tab='scroll') }}"
+                                                data-navigate-param="filter_with_scroll"
+                                                data-navigate-preserve-scroll>
+                                            <option value="" {% if not request.args.get('filter_with_scroll') %}selected{% endif %}>{{ _("All") }}</option>
+                                            <option value="active" {% if request.args.get('filter_with_scroll') == 'active' %}selected{% endif %}>{{ _("Active") }}</option>
+                                            <option value="inactive" {% if request.args.get('filter_with_scroll') == 'inactive' %}selected{% endif %}>{{ _("Inactive") }}</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                {% if request.args.get('filter_no_scroll') or request.args.get('filter_with_scroll') %}
+                                    <p class="text-body-sm mt-4" style="color: var(--color-success-600);">
+                                        ✅ {{ _("Filter applied: %(filter)s", filter=request.args.get('filter_no_scroll') or request.args.get('filter_with_scroll')) }}
+                                    </p>
+                                {% endif %}
+                            </div>
+                        </div>
+
+                        {# Code Example #}
+                        <div class="mb-6">
+                            <div class="flex items-center justify-between mb-2">
+                                <h4 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Code") }}</h4>
+                                <button @click="copyNavigateScrollCode()"
+                                        class="text-body-sm px-2 py-1 rounded transition-colors"
+                                        style="background-color: var(--color-subtle-background-panels);">
+                                    📋 {{ _("Copy") }}
+                                </button>
+                            </div>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{# Filter dropdown WITHOUT scroll preservation #}
+&lt;select data-navigate-base-url="{% raw %}{{ url_for('...') }}{% endraw %}"
+        data-navigate-param="status"&gt;
+    &lt;option value=""&gt;All&lt;/option&gt;
+    &lt;option value="active"&gt;Active&lt;/option&gt;
+&lt;/select&gt;
+
+{# Filter dropdown WITH scroll preservation #}
+&lt;select data-navigate-base-url="{% raw %}{{ url_for('...') }}{% endraw %}"
+        data-navigate-param="status"
+        data-navigate-preserve-scroll&gt;
+    &lt;option value=""&gt;All&lt;/option&gt;
+    &lt;option value="active"&gt;Active&lt;/option&gt;
+&lt;/select&gt;</pre>
+                        </div>
+
+                        {# Key Points #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-warning-600);">⚠️ {{ _("Key Points") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><strong>data-navigate-preserve-scroll</strong> — {{ _("Boolean attribute (no value needed)") }}</li>
+                                <li><strong>{{ _("Works with existing pattern") }}</strong> — {{ _("Just add the attribute to any data-navigate-base-url select") }}</li>
+                                <li><strong>{{ _("URL cleanup") }}</strong> — {{ _("Scroll param is removed automatically after restoration") }}</li>
+                            </ul>
+                        </div>
+
+                        {# Implementation Index #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">
+                                <span class="mr-2">📍</span>{{ _("Implementations") }}
+                            </h4>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-body-sm" style="border: 1px solid var(--color-borders-dividers);">
+                                    <thead style="background-color: var(--color-subtle-background-panels);">
+                                        <tr>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("File") }}</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Line") }}</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Usage") }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);">static/js/alpine-scroll-manager.js</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">—</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">$preserveScroll magic, x-scroll-preserve-links directive</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);">static/js/utilities.js</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">5</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">data-navigate-* handler</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);">templates/backoffice/components/pagination.html</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">47</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">Pagination uses x-scroll-preserve-links</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono">templates/backoffice/assembly_selection.html</td>
+                                            <td class="px-3 py-2">252, 474</td>
+                                            <td class="px-3 py-2">Selection history pagination</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+            </div>
+        {% endif %}
+
         {# Toast Notification #}
         <div x-cloak x-show="toast.show" x-transition
              class="fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg"
@@ -1155,6 +1433,39 @@ def list_items():
                 '{# Disable scroll preservation if needed #}\n' +
                 '{{ "{{" }} pagination(..., preserve_scroll=false) {{ "}}" }}',
 
+                // Scroll tab code snippets
+                preserveScrollCode: '{# Link with scroll preservation #}\n' +
+                '<a :href="$preserveScroll(\'/some/url?page=2\')">Page 2</a>\n\n' +
+                '{# Form action with scroll preservation #}\n' +
+                '<form :action="$preserveScroll(\'/submit\')" method="post">\n' +
+                '    ...\n' +
+                '</form>\n\n' +
+                '{# Result: URL gets &scroll=1250 appended #}\n' +
+                '/some/url?page=2&scroll=1250',
+
+                scrollDirectiveCode: '{# Container with auto-scroll preservation #}\n' +
+                '<nav x-data="{}" x-scroll-preserve-links>\n' +
+                '    <a href="?page=1">1</a>  {# scroll preserved #}\n' +
+                '    <a href="?page=2">2</a>  {# scroll preserved #}\n' +
+                '    <a href="/dashboard" data-no-scroll-preserve>Home</a>  {# opt-out #}\n' +
+                '</nav>\n\n' +
+                '{# The pagination component includes this by default #}\n' +
+                '{{ "{{" }} pagination(..., preserve_scroll=true) {{ "}}" }}',
+
+                navigateScrollCode: '{# Filter dropdown WITHOUT scroll preservation #}\n' +
+                '<select data-navigate-base-url="{{ "{{" }} url_for(\'...\') {{ "}}" }}"\n' +
+                '        data-navigate-param="status">\n' +
+                '    <option value="">All</option>\n' +
+                '    <option value="active">Active</option>\n' +
+                '</select>\n\n' +
+                '{# Filter dropdown WITH scroll preservation #}\n' +
+                '<select data-navigate-base-url="{{ "{{" }} url_for(\'...\') {{ "}}" }}"\n' +
+                '        data-navigate-param="status"\n' +
+                '        data-navigate-preserve-scroll>\n' +
+                '    <option value="">All</option>\n' +
+                '    <option value="active">Active</option>\n' +
+                '</select>',
+
                 copyPaginationTemplateCode() {
                     this.copyToClipboard(this.paginationTemplateCode);
                 },
@@ -1165,6 +1476,18 @@ def list_items():
 
                 copyScrollPreserveCode() {
                     this.copyToClipboard(this.scrollPreserveCode);
+                },
+
+                copyPreserveScrollCode() {
+                    this.copyToClipboard(this.preserveScrollCode);
+                },
+
+                copyScrollDirectiveCode() {
+                    this.copyToClipboard(this.scrollDirectiveCode);
+                },
+
+                copyNavigateScrollCode() {
+                    this.copyToClipboard(this.navigateScrollCode);
                 }
             }));
 

--- a/backend/templates/backoffice/service_docs.html
+++ b/backend/templates/backoffice/service_docs.html
@@ -52,7 +52,7 @@ ABOUTME: Provides testing console with code references, sample data, and executi
 
         {# ===== RESPONDENTS TAB ===== #}
         {% if active_tab == 'respondents' %}
-            <div>
+            <div class="space-y-6">
             {# import_respondents_from_csv #}
                 {% call card(title="import_respondents_from_csv()", composed=true) %}
                     {% call card_body() %}
@@ -223,6 +223,257 @@ ABOUTME: Provides testing console with code references, sample data, and executi
                                         </button>
                                     </div>
                                 <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap" style="color: var(--color-body-text);" x-text="JSON.stringify(responses.import_respondents, null, 2)"></pre>
+                                </div>
+                            </template>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+
+                {# reset_selection_status #}
+                {% call card(title="reset_selection_status()", composed=true) %}
+                    {% call card_body() %}
+                        {# Code Reference #}
+                        <div class="flex items-center justify-between mb-4">
+                            <code class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600);">
+                                respondent_service.py:171
+                            </code>
+                            <div class="flex gap-2">
+                                <span class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-warning-100); color: var(--color-warning-600);">
+                                    🔒 can_manage_assembly()
+                                </span>
+                            </div>
+                        </div>
+
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Resets all respondents for an assembly back to POOL status. Use this to clear selection results and start fresh. Returns the count of respondents updated.") }}
+                        </p>
+
+                        {# Parameters Table #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-body-sm" style="border: 1px solid var(--color-borders-dividers);">
+                                    <thead style="background-color: var(--color-subtle-background-panels);">
+                                        <tr>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">Name</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">Type</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">Required</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">Description</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono">assembly_id</td>
+                                            <td class="px-3 py-2">UUID</td>
+                                            <td class="px-3 py-2">✅</td>
+                                            <td class="px-3 py-2">Target assembly ID</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        {# Returns #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                            <code class="text-body-sm px-2 py-1 rounded block" style="background-color: var(--color-subtle-background-panels);">
+                                int  →  Count of respondents reset to POOL status
+                            </code>
+                        </div>
+
+                        {# Error Cases #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Error Cases") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><code class="px-1 rounded" style="background-color: var(--color-error-100);">InsufficientPermissions</code> — User lacks can_manage_assembly() permission</li>
+                                <li><code class="px-1 rounded" style="background-color: var(--color-error-100);">UserNotFoundError</code> — User not found</li>
+                                <li><code class="px-1 rounded" style="background-color: var(--color-error-100);">AssemblyNotFoundError</code> — Assembly not found</li>
+                            </ul>
+                        </div>
+
+                        {# Used By #}
+                        <div class="mb-6 p-3 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("Used By") }}</h4>
+                            <p class="text-body-sm" style="color: var(--color-body-text);">
+                                <code>respondents_legacy.reset_respondent_status</code> — POST /assemblies/&lt;id&gt;/respondents/reset-status
+                            </p>
+                        </div>
+
+                        {# Try It Section #}
+                        <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers);">
+                            <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                                <span class="mr-2">🧪</span>{{ _("Try It") }}
+                            </h4>
+
+                            {# Assembly Select #}
+                            <div class="mb-4">
+                                <label class="text-label-md block mb-1" style="color: var(--color-headings);">{{ _("Assembly") }}</label>
+                                <select x-model="resetStatusAssemblyId"
+                                        class="w-full px-3 py-2 rounded-lg text-body-md"
+                                        style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);">
+                                    <option value="">{{ _("Select an assembly...") }}</option>
+                                    {% for assembly in assemblies %}
+                                        <option value="{{ assembly.id }}">{{ assembly.title }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+
+                            {# Warning #}
+                            <div class="mb-4 p-3 rounded-lg" style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
+                                <p class="text-body-sm" style="color: var(--color-warning-600);">
+                                    ⚠️ {{ _("This operation resets ALL respondents to POOL status, clearing any selection results.") }}
+                                </p>
+                            </div>
+
+                            {# Action Buttons #}
+                            <div class="flex gap-2 mb-4">
+                                <button @click="executeResetStatus()"
+                                        :disabled="loading.reset_status"
+                                        class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                                        style="background-color: var(--color-warning-400); color: var(--color-page-background);">
+                                    <span x-show="!loading.reset_status">▶️ {{ _("Execute") }}</span>
+                                    <span x-cloak x-show="loading.reset_status">⏳ {{ _("Running...") }}</span>
+                                </button>
+                            </div>
+
+                            {# Response Display #}
+                            <template x-if="responses.reset_status">
+                                <div class="rounded-lg p-4" :style="responses.reset_status.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                                    <div class="flex items-center justify-between mb-2">
+                                        <span class="text-heading-sm" :style="responses.reset_status.status === 'success' ? 'color: var(--color-success-600);' : 'color: var(--color-error-600);'">
+                                            <span x-text="responses.reset_status.status === 'success' ? '✅ Success' : '❌ Error'"></span>
+                                        </span>
+                                        <button @click="copyResetStatusResponse()"
+                                                class="text-body-sm px-2 py-1 rounded"
+                                                style="background-color: var(--color-page-background);">
+                                            📋 {{ _("Copy JSON") }}
+                                        </button>
+                                    </div>
+                                    <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap" style="color: var(--color-body-text);" x-text="JSON.stringify(responses.reset_status, null, 2)"></pre>
+                                </div>
+                            </template>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+
+                {# get_respondents_for_assembly #}
+                {% call card(title="get_respondents_for_assembly()", composed=true) %}
+                    {% call card_body() %}
+                        {# Code Reference #}
+                        <div class="flex items-center justify-between mb-4">
+                            <code class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600);">
+                                respondent_service.py:197
+                            </code>
+                            <div class="flex gap-2">
+                                <span class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-success-100); color: var(--color-success-600);">
+                                    👁️ can_view_assembly()
+                                </span>
+                            </div>
+                        </div>
+
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Retrieves respondents for an assembly with optional status filtering. Returns detached copies safe for use outside the unit of work context.") }}
+                        </p>
+
+                        {# Parameters Table #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-body-sm" style="border: 1px solid var(--color-borders-dividers);">
+                                    <thead style="background-color: var(--color-subtle-background-panels);">
+                                        <tr>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">Name</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">Type</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">Required</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">Description</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);">assembly_id</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">UUID</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">✅</td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">Target assembly ID</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono">status</td>
+                                            <td class="px-3 py-2">RespondentStatus | None</td>
+                                            <td class="px-3 py-2">❌</td>
+                                            <td class="px-3 py-2">Filter by status: POOL, SELECTED, CONFIRMED, WITHDRAWN</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        {# Returns #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                            <code class="text-body-sm px-2 py-1 rounded block" style="background-color: var(--color-subtle-background-panels);">
+                                list[Respondent]  →  List of respondent objects with external_id, attributes, status, etc.
+                            </code>
+                        </div>
+
+                        {# Try It Section #}
+                        <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers);">
+                            <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                                <span class="mr-2">🧪</span>{{ _("Try It") }}
+                            </h4>
+
+                            {# Assembly and Status Select #}
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                <div>
+                                    <label class="text-label-md block mb-1" style="color: var(--color-headings);">{{ _("Assembly") }}</label>
+                                    <select x-model="getRespondentsAssemblyId"
+                                            class="w-full px-3 py-2 rounded-lg text-body-md"
+                                            style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);">
+                                        <option value="">{{ _("Select an assembly...") }}</option>
+                                        {% for assembly in assemblies %}
+                                            <option value="{{ assembly.id }}">{{ assembly.title }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                <div>
+                                    <label class="text-label-md block mb-1" style="color: var(--color-headings);">{{ _("Status Filter") }}</label>
+                                    <select x-model="getRespondentsStatus"
+                                            class="w-full px-3 py-2 rounded-lg text-body-md"
+                                            style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);">
+                                        <option value="">{{ _("All statuses") }}</option>
+                                        <option value="POOL">POOL</option>
+                                        <option value="SELECTED">SELECTED</option>
+                                        <option value="CONFIRMED">CONFIRMED</option>
+                                        <option value="WITHDRAWN">WITHDRAWN</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            {# Action Buttons #}
+                            <div class="flex gap-2 mb-4">
+                                <button @click="executeGetRespondents()"
+                                        :disabled="loading.get_respondents"
+                                        class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                                        style="background-color: var(--color-primary-action); color: var(--color-page-background);">
+                                    <span x-show="!loading.get_respondents">▶️ {{ _("Execute") }}</span>
+                                    <span x-cloak x-show="loading.get_respondents">⏳ {{ _("Running...") }}</span>
+                                </button>
+                            </div>
+
+                            {# Response Display #}
+                            <template x-if="responses.get_respondents">
+                                <div class="rounded-lg p-4" :style="responses.get_respondents.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                                    <div class="flex items-center justify-between mb-2">
+                                        <span class="text-heading-sm" :style="responses.get_respondents.status === 'success' ? 'color: var(--color-success-600);' : 'color: var(--color-error-600);'">
+                                            <span x-text="responses.get_respondents.status === 'success' ? '✅ Success' : '❌ Error'"></span>
+                                        </span>
+                                        <button @click="copyGetRespondentsResponse()"
+                                                class="text-body-sm px-2 py-1 rounded"
+                                                style="background-color: var(--color-page-background);">
+                                            📋 {{ _("Copy JSON") }}
+                                        </button>
+                                    </div>
+                                    <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap" style="color: var(--color-body-text);" x-text="JSON.stringify(responses.get_respondents, null, 2)"></pre>
                                 </div>
                             </template>
                         </div>
@@ -1090,6 +1341,11 @@ Age,51+,2,5,1,1</pre>
                 importRespondentsCsvContent: '',
                 importRespondentsReplaceExisting: false,
                 importRespondentsIdColumn: '',
+                // Reset Status form
+                resetStatusAssemblyId: '',
+                // Get Respondents form
+                getRespondentsAssemblyId: '',
+                getRespondentsStatus: '',
                 // Import Targets form
                 importTargetsAssemblyId: '',
                 importTargetsCsvContent: '',
@@ -1105,6 +1361,8 @@ Age,51+,2,5,1,1</pre>
             // Loading state for each service
                 loading: {
                     import_respondents: false,
+                    reset_status: false,
+                    get_respondents: false,
                     import_targets: false,
                     get_csv_config: false,
                     update_csv_config: false
@@ -1113,6 +1371,8 @@ Age,51+,2,5,1,1</pre>
             // Response data for each service
                 responses: {
                     import_respondents: null,
+                    reset_status: null,
+                    get_respondents: null,
                     import_targets: null,
                     get_csv_config: null,
                     update_csv_config: null
@@ -1138,6 +1398,8 @@ Age,51+,2,5,1,1`
                 // Map service name to loading/response key
                     const keyMap = {
                         'import_respondents_from_csv': 'import_respondents',
+                        'reset_selection_status': 'reset_status',
+                        'get_respondents_for_assembly': 'get_respondents',
                         'import_targets_from_csv': 'import_targets',
                         'get_or_create_csv_config': 'get_csv_config',
                         'update_csv_config': 'update_csv_config'
@@ -1209,6 +1471,17 @@ Age,51+,2,5,1,1`
                         id_column: this.importRespondentsIdColumn
                     });
                 },
+                executeResetStatus() {
+                    this.executeService('reset_selection_status', {
+                        assembly_id: this.resetStatusAssemblyId
+                    });
+                },
+                executeGetRespondents() {
+                    this.executeService('get_respondents_for_assembly', {
+                        assembly_id: this.getRespondentsAssemblyId,
+                        status: this.getRespondentsStatus || null
+                    });
+                },
                 executeImportTargets() {
                     this.executeService('import_targets_from_csv', {
                         assembly_id: this.importTargetsAssemblyId,
@@ -1266,6 +1539,12 @@ Age,51+,2,5,1,1`
                 // Copy response JSON
                 copyImportRespondentsResponse() {
                     this.copyToClipboard(JSON.stringify(this.responses.import_respondents, null, 2));
+                },
+                copyResetStatusResponse() {
+                    this.copyToClipboard(JSON.stringify(this.responses.reset_status, null, 2));
+                },
+                copyGetRespondentsResponse() {
+                    this.copyToClipboard(JSON.stringify(this.responses.get_respondents, null, 2));
                 },
                 copyImportTargetsResponse() {
                     this.copyToClipboard(JSON.stringify(this.responses.import_targets, null, 2));

--- a/backend/templates/backoffice/showcase.html
+++ b/backend/templates/backoffice/showcase.html
@@ -11,6 +11,7 @@
 {% from "backoffice/showcase/radio_component.html" import radio_section %}
 {% from "backoffice/showcase/switch_component.html" import switch_section %}
 {% from "backoffice/showcase/card_component.html" import card_section %}
+{% from "backoffice/showcase/section_component.html" import section_section %}
 {% from "backoffice/showcase/navigation_component.html" import navigation_section %}
 {% from "backoffice/showcase/breadcrumb_component.html" import breadcrumb_section %}
 {% from "backoffice/showcase/tabs_component.html" import tabs_section %}
@@ -73,6 +74,7 @@
             {{ switch_section() }}
             {{ search_dropdown_section() }}
             {{ card_section() }}
+            {{ section_section() }}
             {{ modal_section() }}
             {{ progress_section() }}
             {{ table_section() }}

--- a/backend/templates/backoffice/showcase.html
+++ b/backend/templates/backoffice/showcase.html
@@ -19,6 +19,7 @@
 {% from "backoffice/showcase/modal_component.html" import modal_section %}
 {% from "backoffice/showcase/progress_component.html" import progress_section %}
 {% from "backoffice/showcase/table_component.html" import table_section %}
+{% from "backoffice/showcase/pagination_component.html" import pagination_section %}
 {% from "backoffice/showcase/interactivity.html" import interactivity_section %}
 
 {% block title %}Design System{% endblock %}
@@ -75,6 +76,7 @@
             {{ modal_section() }}
             {{ progress_section() }}
             {{ table_section() }}
+            {{ pagination_section() }}
             {{ navigation_section() }}
             {{ breadcrumb_section() }}
             {{ tabs_section() }}

--- a/backend/templates/backoffice/showcase/pagination_component.html
+++ b/backend/templates/backoffice/showcase/pagination_component.html
@@ -1,0 +1,133 @@
+{#
+ABOUTME: Showcase section for pagination component
+ABOUTME: Displays pagination variants with different page counts and states
+#}
+{% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_subtitle, showcase_example, showcase_tokens %}
+{% from "backoffice/components/pagination.html" import pagination %}
+
+{% macro pagination_section() %}
+    {% call showcase_section() %}
+        {{ showcase_title("Pagination Component") }}
+        {{ showcase_description("Pagination controls for navigating through paginated data. Shows result counts, page numbers with ellipsis for large page counts, and Previous/Next buttons. Supports scroll preservation via Alpine.js directive.") }}
+
+        {% call showcase_example('{% from "backoffice/components/pagination.html" import pagination %}
+
+{# Basic usage with base_url #}
+            {{ pagination(
+            page=3,
+            total_pages=10,
+            per_page=20,
+            total_count=195,
+            base_url=url_for("my.route", assembly_id=assembly.id),
+            item_name=_("respondents")
+            ) }}') %}
+      {# Demo: Middle page #}
+            <div class="mb-4">
+                <p class="text-body-sm mb-2" style="color: var(--color-secondary-text);">Page 3 of 10 (middle page)</p>
+                {{ pagination(
+                page=3,
+                total_pages=10,
+                per_page=20,
+                total_count=195,
+                base_url=url_for('backoffice.showcase'),
+                item_name=_("respondents"),
+                preserve_scroll=false
+                ) }}
+            </div>
+        {% endcall %}
+
+        {{ showcase_subtitle("First page") }}
+        {{ showcase_description("When on the first page, the Previous button is disabled.") }}
+
+        {% call showcase_example('{# First page - Previous disabled #}
+        {{ pagination(page=1, total_pages=10, ...) }}') %}
+        {{ pagination(
+        page=1,
+        total_pages=10,
+        per_page=20,
+        total_count=195,
+        base_url=url_for('backoffice.showcase'),
+        item_name=_("items"),
+        preserve_scroll=false
+        ) }}
+    {% endcall %}
+
+    {{ showcase_subtitle("Last page") }}
+    {{ showcase_description("When on the last page, the Next button is disabled.") }}
+
+    {% call showcase_example('{# Last page - Next disabled #}
+    {{ pagination(page=10, total_pages=10, ...) }}') %}
+    {{ pagination(
+    page=10,
+    total_pages=10,
+    per_page=20,
+    total_count=195,
+    base_url=url_for('backoffice.showcase'),
+    item_name=_("runs"),
+    preserve_scroll=false
+    ) }}
+{% endcall %}
+
+{{ showcase_subtitle("Few pages") }}
+{{ showcase_description("When there are few pages, all page numbers are shown without ellipsis.") }}
+
+{% call showcase_example('{# Few pages - no ellipsis #}
+{{ pagination(page=2, total_pages=4, ...) }}') %}
+{{ pagination(
+page=2,
+total_pages=4,
+per_page=25,
+total_count=87,
+base_url=url_for('backoffice.showcase'),
+item_name=_("entries"),
+preserve_scroll=false
+) }}
+{% endcall %}
+
+{{ showcase_subtitle("Many pages with ellipsis") }}
+{{ showcase_description("For large page counts, ellipsis are shown to keep the pagination compact. Always shows first page, last page, and 2 pages around the current page.") }}
+
+{% call showcase_example('{# Many pages - ellipsis on both sides #}
+{{ pagination(page=25, total_pages=50, ...) }}') %}
+{{ pagination(
+page=25,
+total_pages=50,
+per_page=10,
+total_count=500,
+base_url=url_for('backoffice.showcase'),
+item_name=_("records"),
+preserve_scroll=false
+) }}
+{% endcall %}
+
+{{ showcase_subtitle("Single page (hidden)") }}
+{{ showcase_description("When there's only one page, the pagination component renders nothing.") }}
+
+{% call showcase_example('{# Single page - pagination is hidden #}
+{{ pagination(page=1, total_pages=1, ...) }}
+{# Renders nothing when total_pages <= 1 #}') %}
+<div class="p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+    <p class="text-body-sm" style="color: var(--color-info-600);">
+        ℹ️ {{ _("When total_pages is 1, no pagination is rendered.") }}
+    </p>
+</div>
+{{ pagination(
+page=1,
+total_pages=1,
+per_page=20,
+total_count=15,
+base_url=url_for('backoffice.showcase'),
+item_name=_("items"),
+preserve_scroll=false
+) }}
+{% endcall %}
+
+{{ showcase_tokens([
+"--color-secondary-text (results count, disabled button text)",
+"--color-borders-dividers (button borders)",
+"--color-body-text (button text)",
+"--color-subtle-background-panels (button hover state)",
+"--color-primary-action (active page background)"
+]) }}
+{% endcall %}
+{% endmacro %}

--- a/backend/templates/backoffice/showcase/section_component.html
+++ b/backend/templates/backoffice/showcase/section_component.html
@@ -1,0 +1,52 @@
+{#
+ABOUTME: Showcase section for section component
+ABOUTME: Displays section container examples with white background and padding
+#}
+{% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_subtitle, showcase_example, showcase_tokens %}
+{% from "backoffice/components/section.html" import section %}
+
+{% macro section_section() %}
+  {% call showcase_section() %}
+    {{ showcase_title("Section Component") }}
+    {{ showcase_description("A simple white box container for grouping related content on page layouts. Uses 8px border radius and 24px padding.") }}
+
+    {% call showcase_example('{% from "backoffice/components/section.html" import section %}
+
+{# Basic section #}
+      {% call section() %}
+        <h3 class="text-heading-md mb-2" style="color: var(--color-headings);">Section Title</h3>
+        <p class="text-body-md" style="color: var(--color-body-text);">
+          Section content goes here. Use sections to visually group related content.
+        </p>
+      {% endcall %}
+
+{# Section with additional classes #}
+      {% call section(classes="mb-6") %}
+        <p>Section with margin bottom</p>
+      {% endcall %}') %}
+      {# Basic section example #}
+      {% call section(classes="mb-4") %}
+        <h3 class="text-heading-md mb-2" style="color: var(--color-headings);">Section Title</h3>
+        <p class="text-body-md" style="color: var(--color-body-text);">
+          Section content goes here. Use sections to visually group related content on layouts.
+        </p>
+      {% endcall %}
+
+      {# Nested content example #}
+      {% call section() %}
+        <h3 class="text-heading-md mb-3" style="color: var(--color-headings);">With Rich Content</h3>
+        <ul class="list-disc list-inside text-body-md space-y-1" style="color: var(--color-body-text);">
+          <li>Sections work great for dashboard widgets</li>
+          <li>Form groups and fieldsets</li>
+          <li>Content panels and sidebars</li>
+        </ul>
+      {% endcall %}
+    {% endcall %}
+
+    {{ showcase_tokens([
+    "--color-tables-cards (background)",
+    "--radius-lg (border radius - 8px)",
+    "--spacing-6 (padding - 24px via p-6)"
+    ]) }}
+  {% endcall %}
+{% endmacro %}

--- a/backend/templates/backoffice/showcase/table_component.html
+++ b/backend/templates/backoffice/showcase/table_component.html
@@ -34,7 +34,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell_link("Edit", href="#", align="right") }}
           {% endcall %}
         {% endcall %}
-      {% endcall %}') %}
+      {% endcall %}', transparent=true) %}
             {# Striped table example #}
       {% call table(striped=true) %}
         {{ table_head([
@@ -105,7 +105,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell_yes_no(none) }}
           {% endcall %}
         {% endcall %}
-      {% endcall %}') %}
+      {% endcall %}', transparent=true) %}
       {% call table(striped=true) %}
         {{ table_head([
         {"label": "Respondent"},
@@ -169,7 +169,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell("deleted@example.com") }}
           {% endcall %}
         {% endcall %}
-      {% endcall %}') %}
+      {% endcall %}', transparent=true) %}
       {% call table(striped=true) %}
         {{ table_head([
         {"label": "Status"},

--- a/backend/templates/backoffice/showcase/table_component.html
+++ b/backend/templates/backoffice/showcase/table_component.html
@@ -131,7 +131,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
     {% endcall %}
 
     {{ showcase_subtitle("Status indicator cells") }}
-    {{ showcase_description("Use table_cell_status for colored status text with optional dot indicator. Pool and Confirmed show green, Selected shows gray, Withdrawn shows red.") }}
+    {{ showcase_description("Use table_cell_status for colored status text with optional dot indicator. Pool and Confirmed show green, Selected shows gray, Withdrawn shows red, Deleted shows dark gray.") }}
 
     {% call showcase_example('{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_status %}
 
@@ -163,6 +163,11 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell("R004", bold=true) }}
             {{ table_cell("alice@example.com") }}
           {% endcall %}
+          {% call table_row(is_odd=true) %}
+            {{ table_cell_status("deleted") }}
+            {{ table_cell("R005", bold=true) }}
+            {{ table_cell("deleted@example.com") }}
+          {% endcall %}
         {% endcall %}
       {% endcall %}') %}
       {% call table(striped=true) %}
@@ -191,6 +196,11 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell_status("withdrawn") }}
             {{ table_cell("R004", bold=true) }}
             {{ table_cell("alice@example.com") }}
+          {% endcall %}
+          {% call table_row(is_odd=true) %}
+            {{ table_cell_status("deleted") }}
+            {{ table_cell("R005", bold=true) }}
+            {{ table_cell("deleted@example.com") }}
           {% endcall %}
         {% endcall %}
       {% endcall %}

--- a/backend/templates/backoffice/showcase/table_component.html
+++ b/backend/templates/backoffice/showcase/table_component.html
@@ -3,7 +3,7 @@ ABOUTME: Showcase section for table component
 ABOUTME: Displays table variants with striped rows, actions, and responsive layout
 #}
 {% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_subtitle, showcase_example, showcase_tokens %}
-{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_link, table_cell_custom, table_cell_yes_no %}
+{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_link, table_cell_custom, table_cell_yes_no, table_cell_status %}
 
 {% macro table_section() %}
   {% call showcase_section() %}
@@ -130,14 +130,82 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
       {% endcall %}
     {% endcall %}
 
+    {{ showcase_subtitle("Status indicator cells") }}
+    {{ showcase_description("Use table_cell_status for colored status text with optional dot indicator. Pool and Confirmed show green, Selected shows gray, Withdrawn shows red.") }}
+
+    {% call showcase_example('{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_status %}
+
+{# Status indicator cells #}
+      {% call table(striped=true) %}
+        {{ table_head([
+        {"label": "Status"},
+        {"label": "Respondent"},
+        {"label": "Email"}
+        ]) }}
+        {% call table_body() %}
+          {% call table_row(is_odd=true) %}
+            {{ table_cell_status("pool") }}
+            {{ table_cell("R001", bold=true) }}
+            {{ table_cell("john@example.com") }}
+          {% endcall %}
+          {% call table_row() %}
+            {{ table_cell_status("selected") }}
+            {{ table_cell("R002", bold=true) }}
+            {{ table_cell("jane@example.com") }}
+          {% endcall %}
+          {% call table_row(is_odd=true) %}
+            {{ table_cell_status("confirmed") }}
+            {{ table_cell("R003", bold=true) }}
+            {{ table_cell("bob@example.com") }}
+          {% endcall %}
+          {% call table_row() %}
+            {{ table_cell_status("withdrawn") }}
+            {{ table_cell("R004", bold=true) }}
+            {{ table_cell("alice@example.com") }}
+          {% endcall %}
+        {% endcall %}
+      {% endcall %}') %}
+      {% call table(striped=true) %}
+        {{ table_head([
+        {"label": "Status"},
+        {"label": "Respondent"},
+        {"label": "Email"}
+        ]) }}
+        {% call table_body() %}
+          {% call table_row(is_odd=true) %}
+            {{ table_cell_status("pool") }}
+            {{ table_cell("R001", bold=true) }}
+            {{ table_cell("john@example.com") }}
+          {% endcall %}
+          {% call table_row() %}
+            {{ table_cell_status("selected") }}
+            {{ table_cell("R002", bold=true) }}
+            {{ table_cell("jane@example.com") }}
+          {% endcall %}
+          {% call table_row(is_odd=true) %}
+            {{ table_cell_status("confirmed") }}
+            {{ table_cell("R003", bold=true) }}
+            {{ table_cell("bob@example.com") }}
+          {% endcall %}
+          {% call table_row() %}
+            {{ table_cell_status("withdrawn") }}
+            {{ table_cell("R004", bold=true) }}
+            {{ table_cell("alice@example.com") }}
+          {% endcall %}
+        {% endcall %}
+      {% endcall %}
+    {% endcall %}
+
     {{ showcase_tokens([
     "--color-tables-cards (table background)",
-    "--color-borders-dividers (borders and dividers)",
+    "--color-borders-dividers (borders/dividers, selected status dot)",
     "--color-headings (header text)",
-    "--color-body-text (cell text)",
-    "--color-subtle-background-panels (striped row background)",
+    "--color-body-text (cell text, status labels)",
+    "--color-subtle-background-panels (header and striped row background)",
     "--color-primary-action (link color)",
-    "--color-active-states (link hover)"
+    "--color-active-states (link hover)",
+    "--color-success-400 (pool/confirmed status dot)",
+    "--color-error-400 (withdrawn status dot)"
     ]) }}
   {% endcall %}
 {% endmacro %}

--- a/backend/templates/backoffice/showcase/table_component.html
+++ b/backend/templates/backoffice/showcase/table_component.html
@@ -131,7 +131,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
     {% endcall %}
 
     {{ showcase_subtitle("Status indicator cells") }}
-    {{ showcase_description("Use table_cell_status for colored status text with optional dot indicator. Pool and Confirmed show green, Selected shows gray, Withdrawn shows red, Deleted shows dark gray.") }}
+    {{ showcase_description("Use table_cell_status for colored status text with optional dot indicator. Uses traffic light pattern: Pool shows gray, Selected shows amber, Confirmed shows green, Withdrawn shows red, Deleted shows light gray.") }}
 
     {% call showcase_example('{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_status %}
 

--- a/backend/templates/backoffice/showcase/table_component.html
+++ b/backend/templates/backoffice/showcase/table_component.html
@@ -1,6 +1,6 @@
 {#
 ABOUTME: Showcase section for table component
-ABOUTME: Displays table variants with striped rows, actions, and responsive layout
+ABOUTME: Displays table variants with hover effect, actions, and responsive layout
 #}
 {% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_subtitle, showcase_example, showcase_tokens %}
 {% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_link, table_cell_custom, table_cell_yes_no, table_cell_status %}
@@ -8,12 +8,12 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
 {% macro table_section() %}
   {% call showcase_section() %}
     {{ showcase_title("Table Component") }}
-    {{ showcase_description("Data tables for displaying structured information. Supports striped rows, alignment options, and action links. Responsive with horizontal scrolling on small screens.") }}
+    {{ showcase_description("Data tables for displaying structured information. Supports hover effect, alignment options, and action links. Responsive with horizontal scrolling on small screens.") }}
 
     {% call showcase_example('{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_link %}
 
-{# Basic striped table with actions #}
-      {% call table(striped=true) %}
+{# Basic table with actions #}
+      {% call table() %}
         {{ table_head([
         {"label": "Name"},
         {"label": "Age"},
@@ -21,7 +21,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
         {"label": "Action", "align": "right"}
         ]) }}
         {% call table_body() %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell("Richard Hendricks", bold=true) }}
             {{ table_cell("30") }}
             {{ table_cell("Pied Piper HQ, Palo Alto") }}
@@ -35,8 +35,8 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
           {% endcall %}
         {% endcall %}
       {% endcall %}', transparent=true) %}
-            {# Striped table example #}
-      {% call table(striped=true) %}
+            {# Table example #}
+      {% call table() %}
         {{ table_head([
         {"label": "Name"},
         {"label": "Age"},
@@ -44,7 +44,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
         {"label": "Action", "align": "right"}
         ]) }}
         {% call table_body() %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell("Richard Hendricks", bold=true) }}
             {{ table_cell("30") }}
             {{ table_cell("Pied Piper HQ, Palo Alto") }}
@@ -56,7 +56,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell("5230 Penfield Ave, Woodland Hills") }}
             {{ table_cell_link("Edit", href="#", align="right") }}
           {% endcall %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell("Monica Hall", bold=true) }}
             {{ table_cell("35") }}
             {{ table_cell("2030 Stewart Drive, Sunnyvale") }}
@@ -68,7 +68,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell("Pied Piper HQ, Palo Alto") }}
             {{ table_cell_link("Edit", href="#", align="right") }}
           {% endcall %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell("Gilfoyle", bold=true) }}
             {{ table_cell("32") }}
             {{ table_cell("Pied Piper HQ, Palo Alto") }}
@@ -84,7 +84,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
     {% call showcase_example('{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_yes_no %}
 
 {# Tri-state boolean cells #}
-      {% call table(striped=true) %}
+      {% call table() %}
         {{ table_head([
         {"label": "Respondent"},
         {"label": "Consent"},
@@ -92,7 +92,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
         {"label": "Can attend"}
         ]) }}
         {% call table_body() %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell("R001", bold=true) }}
             {{ table_cell_yes_no(true) }}
             {{ table_cell_yes_no(true) }}
@@ -106,7 +106,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
           {% endcall %}
         {% endcall %}
       {% endcall %}', transparent=true) %}
-      {% call table(striped=true) %}
+      {% call table() %}
         {{ table_head([
         {"label": "Respondent"},
         {"label": "Consent"},
@@ -114,7 +114,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
         {"label": "Can attend"}
         ]) }}
         {% call table_body() %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell("R001", bold=true) }}
             {{ table_cell_yes_no(true) }}
             {{ table_cell_yes_no(true) }}
@@ -136,14 +136,14 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
     {% call showcase_example('{% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_status %}
 
 {# Status indicator cells #}
-      {% call table(striped=true) %}
+      {% call table() %}
         {{ table_head([
         {"label": "Status"},
         {"label": "Respondent"},
         {"label": "Email"}
         ]) }}
         {% call table_body() %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell_status("pool") }}
             {{ table_cell("R001", bold=true) }}
             {{ table_cell("john@example.com") }}
@@ -153,7 +153,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell("R002", bold=true) }}
             {{ table_cell("jane@example.com") }}
           {% endcall %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell_status("confirmed") }}
             {{ table_cell("R003", bold=true) }}
             {{ table_cell("bob@example.com") }}
@@ -163,21 +163,21 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell("R004", bold=true) }}
             {{ table_cell("alice@example.com") }}
           {% endcall %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell_status("deleted") }}
             {{ table_cell("R005", bold=true) }}
             {{ table_cell("deleted@example.com") }}
           {% endcall %}
         {% endcall %}
       {% endcall %}', transparent=true) %}
-      {% call table(striped=true) %}
+      {% call table() %}
         {{ table_head([
         {"label": "Status"},
         {"label": "Respondent"},
         {"label": "Email"}
         ]) }}
         {% call table_body() %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell_status("pool") }}
             {{ table_cell("R001", bold=true) }}
             {{ table_cell("john@example.com") }}
@@ -187,7 +187,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell("R002", bold=true) }}
             {{ table_cell("jane@example.com") }}
           {% endcall %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell_status("confirmed") }}
             {{ table_cell("R003", bold=true) }}
             {{ table_cell("bob@example.com") }}
@@ -197,7 +197,7 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
             {{ table_cell("R004", bold=true) }}
             {{ table_cell("alice@example.com") }}
           {% endcall %}
-          {% call table_row(is_odd=true) %}
+          {% call table_row() %}
             {{ table_cell_status("deleted") }}
             {{ table_cell("R005", bold=true) }}
             {{ table_cell("deleted@example.com") }}
@@ -208,13 +208,16 @@ ABOUTME: Displays table variants with striped rows, actions, and responsive layo
 
     {{ showcase_tokens([
     "--color-tables-cards (table background)",
-    "--color-borders-dividers (borders/dividers, selected status dot)",
+    "--color-borders-dividers (borders/dividers, deleted status dot)",
     "--color-headings (header text)",
     "--color-body-text (cell text, status labels)",
-    "--color-subtle-background-panels (header and striped row background)",
+    "--color-neutral-50 (header background)",
+    "--color-neutral-100 (row hover background)",
     "--color-primary-action (link color)",
     "--color-active-states (link hover)",
-    "--color-success-400 (pool/confirmed status dot)",
+    "--color-secondary-text (pool status dot)",
+    "--color-warning-400 (selected status dot)",
+    "--color-success-400 (confirmed status dot)",
     "--color-error-400 (withdrawn status dot)"
     ]) }}
   {% endcall %}

--- a/backend/tests/contract/test_respondent_repo.py
+++ b/backend/tests/contract/test_respondent_repo.py
@@ -258,6 +258,51 @@ class TestDeleteAllForAssembly:
         assert respondent_backend.repo.delete_all_for_assembly(uuid.uuid4()) == 0
 
 
+class TestGetByAssemblyIdPaginated:
+    def test_returns_paginated_results(self, respondent_backend: ContractBackend):
+        assembly = respondent_backend.make_assembly()
+        for i in range(5):
+            _make_respondent(respondent_backend, assembly.id, external_id=f"R{i:03d}")
+
+        results, total_count = respondent_backend.repo.get_by_assembly_id_paginated(assembly.id, page=1, per_page=2)
+
+        assert len(results) == 2
+        assert total_count == 5
+
+    def test_returns_correct_page(self, respondent_backend: ContractBackend):
+        assembly = respondent_backend.make_assembly()
+        for i in range(5):
+            _make_respondent(respondent_backend, assembly.id, external_id=f"R{i:03d}")
+
+        page1, _ = respondent_backend.repo.get_by_assembly_id_paginated(assembly.id, page=1, per_page=2)
+        page2, _ = respondent_backend.repo.get_by_assembly_id_paginated(assembly.id, page=2, per_page=2)
+
+        # Pages should have different respondents
+        page1_ids = {r.id for r in page1}
+        page2_ids = {r.id for r in page2}
+        assert page1_ids.isdisjoint(page2_ids)
+
+    def test_filters_by_status(self, respondent_backend: ContractBackend):
+        assembly = respondent_backend.make_assembly()
+        _make_respondent(respondent_backend, assembly.id, external_id="R001", status=RespondentStatus.POOL)
+        _make_respondent(respondent_backend, assembly.id, external_id="R002", status=RespondentStatus.SELECTED)
+        _make_respondent(respondent_backend, assembly.id, external_id="R003", status=RespondentStatus.POOL)
+
+        results, total_count = respondent_backend.repo.get_by_assembly_id_paginated(
+            assembly.id, page=1, per_page=10, status=RespondentStatus.POOL
+        )
+
+        assert len(results) == 2
+        assert total_count == 2
+        assert all(r.selection_status == RespondentStatus.POOL for r in results)
+
+    def test_returns_empty_for_no_respondents(self, respondent_backend: ContractBackend):
+        results, total_count = respondent_backend.repo.get_by_assembly_id_paginated(uuid.uuid4(), page=1, per_page=10)
+
+        assert results == []
+        assert total_count == 0
+
+
 class TestGetAttributeValueCounts:
     def test_returns_value_counts(self, respondent_backend: ContractBackend):
         assembly = respondent_backend.make_assembly()

--- a/backend/tests/e2e/test_targets_pages.py
+++ b/backend/tests/e2e/test_targets_pages.py
@@ -127,11 +127,8 @@ class TestUploadTargetsCsv:
             content_type="multipart/form-data",
             follow_redirects=False,
         )
-        assert response.status_code == 302
-
-        with logged_in_admin.session_transaction() as session:
-            flash_messages = [msg[1] for msg in session.get("_flashes", [])]
-            assert any("CSV import failed" in msg for msg in flash_messages)
+        assert response.status_code == 200
+        assert b"There is a problem" in response.data
 
     def test_upload_no_file_shows_validation_error(self, logged_in_admin, existing_assembly):
         response = logged_in_admin.post(

--- a/backend/tests/fakes.py
+++ b/backend/tests/fakes.py
@@ -518,6 +518,21 @@ class FakeRespondentRepository(FakeRepository, RespondentRepository):
             results = [r for r in results if r.eligible is not False and r.can_attend is not False]
         return results
 
+    def get_by_assembly_id_paginated(
+        self,
+        assembly_id: uuid.UUID,
+        page: int = 1,
+        per_page: int = 50,
+        status: RespondentStatus | None = None,
+    ) -> tuple[list[Respondent], int]:
+        results = [r for r in self._items if r.assembly_id == assembly_id]
+        if status:
+            results = [r for r in results if r.selection_status == status]
+        total_count = len(results)
+        offset = (page - 1) * per_page
+        paginated = results[offset : offset + per_page]
+        return paginated, total_count
+
     def get_by_external_id(self, assembly_id: uuid.UUID, external_id: str) -> Respondent | None:
         for r in self._items:
             if r.assembly_id == assembly_id and r.external_id == external_id:

--- a/backend/tests/unit/test_respondent_service.py
+++ b/backend/tests/unit/test_respondent_service.py
@@ -8,7 +8,7 @@ import pytest
 from opendlp.domain.assembly import Assembly
 from opendlp.domain.respondents import Respondent
 from opendlp.domain.users import User
-from opendlp.domain.value_objects import GlobalRole
+from opendlp.domain.value_objects import GlobalRole, RespondentStatus
 from opendlp.service_layer import respondent_service
 from opendlp.service_layer.exceptions import (
     AssemblyNotFoundError,
@@ -91,3 +91,46 @@ class TestGetRespondent:
 
         with pytest.raises(RespondentNotFoundError):
             respondent_service.get_respondent(uow, user.id, assembly.id, other_respondent.id)
+
+
+class TestGetRespondentsForAssemblyPaginated:
+    def test_returns_paginated_respondents(self):
+        uow = FakeUnitOfWork()
+        user, assembly, _ = _seed(uow)
+        # Add more respondents (seed already adds one)
+        for i in range(4):
+            uow.respondents.add(Respondent(assembly_id=assembly.id, external_id=f"R{i:03d}"))
+
+        results, total_count = respondent_service.get_respondents_for_assembly_paginated(
+            uow, user.id, assembly.id, page=1, per_page=2
+        )
+
+        assert len(results) == 2
+        assert total_count == 5  # 1 from seed + 4 added
+
+    def test_returns_detached_copies(self):
+        uow = FakeUnitOfWork()
+        user, assembly, respondent = _seed(uow)
+
+        results, _ = respondent_service.get_respondents_for_assembly_paginated(
+            uow, user.id, assembly.id, page=1, per_page=10
+        )
+
+        assert results[0] is not respondent
+
+    def test_filters_by_status(self):
+        uow = FakeUnitOfWork()
+        user, assembly, _ = _seed(uow)  # seed adds one POOL respondent
+        # Add a SELECTED respondent
+        selected = Respondent(
+            assembly_id=assembly.id, external_id="R-SELECTED", selection_status=RespondentStatus.SELECTED
+        )
+        uow.respondents.add(selected)
+
+        results, total_count = respondent_service.get_respondents_for_assembly_paginated(
+            uow, user.id, assembly.id, page=1, per_page=10, status=RespondentStatus.SELECTED
+        )
+
+        assert len(results) == 1
+        assert total_count == 1
+        assert results[0].selection_status == RespondentStatus.SELECTED


### PR DESCRIPTION
## Summary

This PR implements the backoffice respondents list feature, allowing organisers to view and manage respondents (registrants) for an assembly.

### Key Features

- **Respondents table**: Display respondents in the backoffice with status, external ID, email, and name columns
- **Pagination**: Server-side pagination (25 rows per page) with reusable pagination component
- **Status filter**: Dropdown filter to filter respondents by status (All, Pool, Selected, Confirmed, Withdrawn)
- **Scroll preservation**: Filter changes preserve scroll position using URL-based scroll parameter
- **View individual respondent**: Detail page for viewing a single respondent's information

### Reusable Components

- **Pagination component** (`components/pagination.html`): Extracted as a reusable Jinja2 macro with scroll preservation support
- **Table component enhancements**: Added header styling and status indicator cells
- **Scroll preservation pattern**: Documented in patterns page with `data-navigate-preserve-scroll` attribute for filter dropdowns

### Technical Changes

- Added `get_by_assembly_id_paginated` repository method for paginated queries
- Added `get_respondents_for_assembly_paginated` service function
- Moved respondent backoffice routes to dedicated `respondents` blueprint
- Added contract and unit tests for pagination and filtering

### Documentation

- Added Scroll Preservation tab to `/backoffice/dev/patterns` documenting:
  - `$preserveScroll` Alpine magic helper
  - `x-scroll-preserve-links` directive
  - `data-navigate-preserve-scroll` for select dropdowns

## Test plan

- [ ] View respondents list with pagination
- [ ] Filter respondents by status
- [ ] Verify scroll position preserved when changing filter
- [ ] View individual respondent details
- [ ] Check patterns page Scroll tab documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)