### PR TITLE
fix: reorder respondents table columns

### DIFF
--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -107,18 +107,18 @@ ABOUTME: Displays respondent data configuration for assemblies
                     {% call table() %}
                         {{ table_head([
                         {"label": _("Status")},
-                        {"label": _("External ID")},
-                        {"label": _("Email")},
                         {"label": _("Name")},
+                        {"label": _("ID")},
+                        {"label": _("Email")},
                         {"label": _("Actions"), "align": "right"}
                         ]) }}
                         {% call table_body() %}
                             {% for respondent in respondents %}
                                 {% call table_row() %}
                                     {{ table_cell_status(respondent.selection_status) }}
+                                    {{ table_cell(respondent.display_name(assembly.name_fields)) }}
                                     {{ table_cell(respondent.external_id, bold=true) }}
                                     {{ table_cell(respondent.email or "—") }}
-                                    {{ table_cell(respondent.display_name(assembly.name_fields)) }}
                                     {{ table_cell_link(
                                     _("View"),
                                     href=url_for('respondents.view_respondent',


### PR DESCRIPTION
## Summary
- Reorders the respondents table columns to: Status, Name, ID, Email, Actions
- Previously the order was: Status, External ID, Email, Name, Actions

## Test plan
- [ ] Navigate to an assembly's respondents page with CSV data source
- [ ] Verify the table columns appear in the order: Status, Name, ID, Email, Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)