### PR TITLE
WIP: fix gg preview docker build for linux/amd64

### DIFF
--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ deploy-preview-gg:
   fi
   echo "*** Building docker image ***"
   git show --no-patch --format='%cd %h' --date=format:'%Y-%m-%d' HEAD > backend/generated_version.txt
-  docker build -t opendlp:ggpreview backend/
+  docker build --platform linux/amd64 -t opendlp:ggpreview backend/
   # the double-s in pussh is NOT a typo
   echo "*** Pushing docker image to preview server ***"
   docker pussh opendlp:ggpreview opendlp-test


### PR DESCRIPTION
## Summary
- Adds `--platform linux/amd64` to the gg preview docker build command
- Fixes exec format error when deploying from Apple Silicon Mac to x86_64 server

## Test plan
- [x] Deployed successfully to gg.preview after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)