### PR TITLE
feat(a11y): Data tab accessibility + floating alerts

### DIFF
--- a/backend/docs/agent/657-floating-alerts-scroll-preservation.md
+++ b/backend/docs/agent/657-floating-alerts-scroll-preservation.md
@@ -1,0 +1,167 @@
+# Plan: Floating Alerts + Scroll Preservation for Async Operations
+
+**Branch:** 657-assembly-a11y-2
+**Status:** Ready for implementation
+
+## Overview
+
+Two related accessibility/UX improvements:
+1. **Floating alerts** - Show flash messages at bottom of viewport (not top of page)
+2. **Scroll preservation for forms** - Opt-in parameter to preserve scroll after form submission
+
+## Problem
+
+Currently:
+- Flash messages appear at top of page content, causing scroll-to-top on every async operation
+- Users lose their scroll position after save/delete operations
+- Poor UX especially on long pages
+
+## Part 1: Floating Alerts
+
+### Design
+
+- Fixed position at **bottom-right** of viewport
+- 1.5rem (24px) offset from edges
+- Max width constrained (`max-w-md`)
+- Below modals in z-index (`z-30`)
+- Always dismissible
+- `aria-live="polite"` for screen reader announcements
+- Multiple alerts stack vertically with gap
+
+### Changes
+
+**1. Create `templates/backoffice/components/floating_alerts.html`**
+
+New macro that renders flash messages in a fixed-position container:
+
+```html
+{% macro floating_alerts() %}
+<div id="floating-alerts"
+     class="fixed bottom-6 right-6 z-30 flex flex-col gap-3 max-w-md"
+     aria-live="polite">
+    {% for category, message in get_flashed_messages(with_categories=true) %}
+        {{ alert(message, variant=category_to_variant(category), dismissible=true) }}
+    {% endfor %}
+</div>
+{% endmacro %}
+```
+
+**2. Update `templates/backoffice/base_page.html`**
+
+- Remove `{{ flash_messages() }}` from inside `<main>` (line 29)
+- Add `{{ floating_alerts() }}` after `</main>` but inside the flex container (before footer or after)
+
+**3. Update `templates/backoffice/components/alert.html`**
+
+- Remove `mb-6` margin from alert div when used in floating context (stacking handled by container gap)
+- Option: Add `floating=false` parameter to alert macro, skip margin when true
+
+## Part 2: Scroll Preservation for Form Submissions
+
+### Approach: Data Attribute (CSP-safe)
+
+Add `data-preserve-scroll` attribute to forms that should preserve scroll position after page reload.
+
+This integrates with the existing scroll preservation system in `alpine-scroll-manager.js` which already handles the `?scroll=<position>` URL parameter.
+
+**1. Update `static/backoffice/js/alpine-components.js`**
+
+Modify `$confirm` magic to check for data attribute:
+
+```javascript
+Alpine.magic("confirm", function () {
+    return function (message, formElement) {
+        if (confirm(message)) {
+            if (formElement.hasAttribute("data-preserve-scroll")) {
+                var action = formElement.getAttribute("action") || window.location.href;
+                var scrollPos = Math.round(window.scrollY);
+                formElement.setAttribute("action", urlSetParam(action, "scroll", scrollPos.toString()));
+            }
+            formElement.submit();
+        }
+    };
+});
+```
+
+**2. Add new directive for non-confirmation forms**
+
+```javascript
+Alpine.directive("preserve-scroll-on-submit", function (el) {
+    el.addEventListener("submit", function () {
+        var action = el.getAttribute("action") || window.location.href;
+        var scrollPos = Math.round(window.scrollY);
+        el.setAttribute("action", urlSetParam(action, "scroll", scrollPos.toString()));
+    });
+});
+```
+
+### Template Usage Patterns
+
+```html
+<!-- With confirmation dialog - add data-preserve-scroll attribute -->
+<form method="post" action="{{ url_for('...') }}"
+      x-data
+      data-preserve-scroll
+      @submit.prevent="$confirm('{{ _('Are you sure?') }}', $el)">
+    {{ csrf_token_input() }}
+    {{ button("Delete", type="submit", variant="danger") }}
+</form>
+
+<!-- Without confirmation - use directive -->
+<form method="post" action="{{ url_for('...') }}"
+      x-data
+      x-preserve-scroll-on-submit>
+    {{ csrf_token_input() }}
+    {{ button("Save", type="submit") }}
+</form>
+```
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `templates/backoffice/components/floating_alerts.html` | **Create** - new floating alerts macro |
+| `templates/backoffice/components/alert.html` | **Modify** - add floating parameter or remove margin |
+| `templates/backoffice/base_page.html` | **Modify** - move flash messages to floating position |
+| `static/backoffice/js/alpine-components.js` | **Modify** - enhance `$confirm`, add directive |
+
+## Dependencies
+
+- Existing `alpine-scroll-manager.js` - handles `?scroll=` URL parameter restoration
+- Existing `url-utils.js` - provides `urlSetParam()` function
+
+## Verification
+
+### Manual Testing
+
+1. **Floating alerts**:
+   - Trigger a flash message (e.g., save an assembly)
+   - Alert should appear at bottom-right, not top of page
+   - Scroll down on a long page, trigger action → alert visible without scrolling
+   - Dismiss alert with close button (mouse and keyboard)
+   - Test with screen reader (VoiceOver on Mac: Cmd+F5)
+
+2. **Scroll preservation**:
+   - Add `data-preserve-scroll` to a test form
+   - Scroll down on page, submit form with confirmation
+   - After page reload, scroll position should be restored
+   - Without the attribute, scroll should go to top (default behavior)
+
+### Automated Tests
+
+```bash
+# Run existing scroll preservation tests
+CI=true uv run pytest tests/bdd/test_scroll_preservation.py -v
+```
+
+Consider adding BDD scenarios for:
+- Floating alert visibility after action
+- Form submission with scroll preservation
+
+## Accessibility Considerations
+
+- `role="alert"` on individual alerts (already present)
+- `aria-live="polite"` on container - announces new alerts without interrupting
+- Dismiss button has `aria-label` for screen readers
+- Focus returns to trigger element after dismiss (if applicable)
+- Keyboard accessible close button (Enter/Space)

--- a/backend/src/opendlp/entrypoints/blueprints/db_selection_backoffice.py
+++ b/backend/src/opendlp/entrypoints/blueprints/db_selection_backoffice.py
@@ -11,6 +11,7 @@ from opendlp import bootstrap
 from opendlp.bootstrap import get_url_generator
 from opendlp.entrypoints.decorators import require_assembly_management
 from opendlp.entrypoints.forms import DbSelectionSettingsForm
+from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
 from opendlp.service_layer.assembly_service import (
     get_assembly_with_permissions,
     get_csv_upload_status,
@@ -335,7 +336,9 @@ def save_db_settings(assembly_id: uuid.UUID) -> ResponseReturnValue:
             for field_name, errors in form.errors.items():
                 for error in errors:
                     flash(f"{field_name}: {error}", "error")
-            return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+            return redirect_preserving_scroll(
+                url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+            )
 
         # Parse comma-separated columns
         check_same_address_cols = (
@@ -372,7 +375,9 @@ def save_db_settings(assembly_id: uuid.UUID) -> ResponseReturnValue:
             )
 
         flash(_("Selection settings saved successfully."), "success")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
 
     except NotFoundError:
         flash(_("Assembly not found"), "error")
@@ -384,7 +389,9 @@ def save_db_settings(assembly_id: uuid.UUID) -> ResponseReturnValue:
         current_app.logger.error(f"Save DB settings error for assembly {assembly_id}: {e}")
         current_app.logger.exception("Full stacktrace:")
         flash(_("An error occurred while saving settings"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
 
 
 @db_selection_backoffice_bp.route("/assembly/<uuid:assembly_id>/selection/db/reset", methods=["POST"])

--- a/backend/src/opendlp/entrypoints/blueprints/dev.py
+++ b/backend/src/opendlp/entrypoints/blueprints/dev.py
@@ -28,6 +28,16 @@ from opendlp.service_layer.respondent_service import (
 from opendlp.service_layer.user_service import get_user_assemblies
 from opendlp.translations import gettext as _
 
+
+def _is_safe_redirect_url(url: str) -> bool:
+    """Check if a URL is safe for redirection (internal only).
+
+    Prevents open redirect attacks by only allowing relative URLs.
+    """
+    # Only allow relative URLs that start with / but not // (protocol-relative)
+    return url.startswith("/") and not url.startswith("//")
+
+
 dev_bp = Blueprint("dev", __name__)
 
 
@@ -436,5 +446,9 @@ def flash_test() -> ResponseReturnValue:
 
     flash(message, flash_type)
 
-    return_url = request.form.get("return_url", url_for("dev.patterns", tab="floating-alerts"))
+    default_url = url_for("dev.patterns", tab="floating-alerts")
+    return_url = request.form.get("return_url", default_url)
+    # Validate return_url to prevent open redirect attacks
+    if not _is_safe_redirect_url(return_url):
+        return_url = default_url
     return redirect(return_url)

--- a/backend/src/opendlp/entrypoints/blueprints/dev.py
+++ b/backend/src/opendlp/entrypoints/blueprints/dev.py
@@ -399,7 +399,7 @@ def patterns() -> ResponseReturnValue:
 
     # Get active tab from query parameter, default to 'dropdown'
     active_tab = request.args.get("tab", "dropdown")
-    valid_tabs = ["dropdown", "form", "ajax", "file-upload", "progress", "pagination", "scroll"]
+    valid_tabs = ["dropdown", "form", "ajax", "file-upload", "progress", "pagination", "scroll", "floating-alerts"]
     if active_tab not in valid_tabs:
         active_tab = "dropdown"
 
@@ -408,3 +408,33 @@ def patterns() -> ResponseReturnValue:
     assemblies = get_user_assemblies(uow, current_user.id)
 
     return render_template("backoffice/patterns.html", assemblies=assemblies, active_tab=active_tab), 200
+
+
+@dev_bp.route("/dev/flash-test", methods=["POST"])
+@login_required
+def flash_test() -> ResponseReturnValue:
+    """Trigger flash messages for testing floating alerts.
+
+    Admin-only endpoint that creates flash messages of different types.
+    This blueprint is only registered in non-production environments.
+    """
+    if not has_global_admin(current_user):
+        flash(_("You don't have permission to access developer tools"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+
+    flash_type = request.form.get("type", "info")
+    message = request.form.get("message", "")
+
+    if not message:
+        messages = {
+            "success": _("Success! Your changes have been saved."),
+            "warning": _("Warning: Please review the data before continuing."),
+            "error": _("Error: Something went wrong. Please try again."),
+            "info": _("Info: A new feature is available."),
+        }
+        message = messages.get(flash_type, messages["info"])
+
+    flash(message, flash_type)
+
+    return_url = request.form.get("return_url", url_for("dev.patterns", tab="floating-alerts"))
+    return redirect(return_url)

--- a/backend/src/opendlp/entrypoints/blueprints/gsheets.py
+++ b/backend/src/opendlp/entrypoints/blueprints/gsheets.py
@@ -14,6 +14,7 @@ from opendlp.entrypoints.forms import (
     CreateAssemblyGSheetForm,
     EditAssemblyGSheetForm,
 )
+from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
 from opendlp.service_layer.assembly_service import (
     add_assembly_gsheet,
     get_assembly_gsheet,
@@ -984,12 +985,12 @@ def delete_gsheet_config(assembly_id: uuid.UUID) -> ResponseReturnValue:
         remove_assembly_gsheet(uow, assembly_id, current_user.id)
         flash(_("Google Spreadsheet configuration removed successfully"), "success")
         # Redirect without source param - selector will be unlocked allowing user to choose again
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id))
+        return redirect_preserving_scroll(url_for("backoffice.view_assembly_data", assembly_id=assembly_id))
 
     except NotFoundError as e:
         current_app.logger.warning(f"Gsheet config not found for delete: {e}")
         flash(_("Google Spreadsheet configuration not found"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id))
+        return redirect_preserving_scroll(url_for("backoffice.view_assembly_data", assembly_id=assembly_id))
     except InsufficientPermissions as e:
         current_app.logger.warning(f"Insufficient permissions to delete gsheet for assembly {assembly_id}: {e}")
         flash(_("You don't have permission to manage Google Spreadsheet for this assembly"), "error")
@@ -998,4 +999,4 @@ def delete_gsheet_config(assembly_id: uuid.UUID) -> ResponseReturnValue:
         current_app.logger.error(f"Gsheet delete error for assembly {assembly_id}: {e}")
         current_app.logger.exception("Full stacktrace:")
         flash(_("An error occurred while removing the Google Spreadsheet configuration"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id))
+        return redirect_preserving_scroll(url_for("backoffice.view_assembly_data", assembly_id=assembly_id))

--- a/backend/src/opendlp/entrypoints/blueprints/respondents.py
+++ b/backend/src/opendlp/entrypoints/blueprints/respondents.py
@@ -21,6 +21,7 @@ from opendlp.entrypoints.edit_respondent_form import (
     radio_or_none_to_bool,
     radio_to_bool,
 )
+from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
 from opendlp.service_layer.assembly_service import (
     CSVUploadStatus,
     delete_respondents_for_assembly,
@@ -295,14 +296,18 @@ def delete_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
             )
 
         flash(_("Respondents deleted: %(count)d removed", count=count), "success")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
 
     except InsufficientPermissions as e:
         current_app.logger.warning(
             f"Insufficient permissions to delete respondents for assembly {assembly_id} user {current_user.id}: {e}"
         )
         flash(_("You don't have permission to delete respondents"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
     except NotFoundError as e:
         current_app.logger.warning(f"Assembly {assembly_id} not found for respondents deletion: {e}")
         flash(_("Assembly not found"), "error")
@@ -311,7 +316,9 @@ def delete_respondents(assembly_id: uuid.UUID) -> ResponseReturnValue:
         current_app.logger.error(f"Delete respondents error for assembly {assembly_id} user {current_user.id}: {e}")
         current_app.logger.exception("Full stacktrace:")
         flash(_("An error occurred while deleting respondents"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
 
 
 @respondents_bp.route("/assembly/<uuid:assembly_id>/respondents")

--- a/backend/src/opendlp/entrypoints/blueprints/respondents.py
+++ b/backend/src/opendlp/entrypoints/blueprints/respondents.py
@@ -120,12 +120,16 @@ def upload_respondents_csv(assembly_id: uuid.UUID) -> ResponseReturnValue:
     try:
         if "file" not in request.files:
             flash(_("No file selected"), "error")
-            return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+            return redirect_preserving_scroll(
+                url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+            )
 
         file = request.files["file"]
         if file.filename == "":
             flash(_("No file selected"), "error")
-            return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+            return redirect_preserving_scroll(
+                url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+            )
 
         raw = file.read()
         max_bytes = get_max_csv_upload_bytes()
@@ -184,13 +188,17 @@ def upload_respondents_csv(assembly_id: uuid.UUID) -> ResponseReturnValue:
     except InvalidSelection as e:
         current_app.logger.warning(f"Invalid CSV format for respondents upload assembly {assembly_id}: {e}")
         flash(_("Invalid CSV format: %(error)s", error=str(e)), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
     except InsufficientPermissions as e:
         current_app.logger.warning(
             f"Insufficient permissions to upload respondents for assembly {assembly_id} user {current_user.id}: {e}"
         )
         flash(_("You don't have permission to upload respondents"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
     except NotFoundError as e:
         current_app.logger.warning(f"Assembly {assembly_id} not found for respondents upload: {e}")
         flash(_("Assembly not found"), "error")
@@ -199,7 +207,9 @@ def upload_respondents_csv(assembly_id: uuid.UUID) -> ResponseReturnValue:
         current_app.logger.error(f"Upload respondents error for assembly {assembly_id} user {current_user.id}: {e}")
         current_app.logger.exception("Full stacktrace:")
         flash(_("An error occurred while uploading respondents"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
 
 
 @respondents_bp.route("/assembly/<uuid:assembly_id>/data/upload-respondents/confirm-diff", methods=["GET"])

--- a/backend/src/opendlp/entrypoints/blueprints/targets.py
+++ b/backend/src/opendlp/entrypoints/blueprints/targets.py
@@ -8,6 +8,7 @@ from flask.typing import ResponseReturnValue
 from flask_login import current_user, login_required
 
 from opendlp import bootstrap
+from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
 from opendlp.service_layer.assembly_service import (
     CSVUploadStatus,
     add_target_value,
@@ -246,14 +247,18 @@ def delete_targets(assembly_id: uuid.UUID) -> ResponseReturnValue:
             )
 
         flash(_("Targets deleted: %(count)d categories removed", count=count), "success")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
 
     except InsufficientPermissions as e:
         current_app.logger.warning(
             f"Insufficient permissions to delete targets for assembly {assembly_id} user {current_user.id}: {e}"
         )
         flash(_("You don't have permission to delete targets"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
     except NotFoundError as e:
         current_app.logger.warning(f"Assembly {assembly_id} not found for targets deletion: {e}")
         flash(_("Assembly not found"), "error")
@@ -262,7 +267,9 @@ def delete_targets(assembly_id: uuid.UUID) -> ResponseReturnValue:
         current_app.logger.error(f"Delete targets error for assembly {assembly_id} user {current_user.id}: {e}")
         current_app.logger.exception("Full stacktrace:")
         flash(_("An error occurred while deleting targets"), "error")
-        return redirect(url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv"))
+        return redirect_preserving_scroll(
+            url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
+        )
 
 
 @targets_bp.route("/assembly/<uuid:assembly_id>/targets/categories", methods=["POST"])

--- a/backend/src/opendlp/entrypoints/scroll_utils.py
+++ b/backend/src/opendlp/entrypoints/scroll_utils.py
@@ -24,7 +24,16 @@ def redirect_preserving_scroll(url: str) -> ResponseReturnValue:
     """
     scroll = request.args.get("scroll")
     if scroll:
-        # Append scroll parameter to the URL
-        separator = "&" if "?" in url else "?"
-        url = f"{url}{separator}scroll={scroll}"
+        # Handle hash fragments: query params must come before the hash
+        hash_index = url.find("#")
+        if hash_index != -1:
+            base_url = url[:hash_index]
+            hash_fragment = url[hash_index:]
+        else:
+            base_url = url
+            hash_fragment = ""
+
+        # Append scroll parameter to the base URL
+        separator = "&" if "?" in base_url else "?"
+        url = f"{base_url}{separator}scroll={scroll}{hash_fragment}"
     return redirect(url)

--- a/backend/src/opendlp/entrypoints/scroll_utils.py
+++ b/backend/src/opendlp/entrypoints/scroll_utils.py
@@ -23,7 +23,8 @@ def redirect_preserving_scroll(url: str) -> ResponseReturnValue:
         return redirect_preserving_scroll(url_for("my.route", id=item_id))
     """
     scroll = request.args.get("scroll")
-    if scroll:
+    # Validate scroll is a non-negative integer to prevent injection
+    if scroll and scroll.isdigit():
         # Handle hash fragments: query params must come before the hash
         hash_index = url.find("#")
         if hash_index != -1:

--- a/backend/src/opendlp/entrypoints/scroll_utils.py
+++ b/backend/src/opendlp/entrypoints/scroll_utils.py
@@ -1,6 +1,8 @@
 """ABOUTME: Utility functions for scroll preservation across redirects
 ABOUTME: Provides redirect_preserving_scroll to maintain scroll position after form submissions"""
 
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
 from flask import redirect, request
 from flask.typing import ResponseReturnValue
 
@@ -25,16 +27,9 @@ def redirect_preserving_scroll(url: str) -> ResponseReturnValue:
     scroll = request.args.get("scroll")
     # Validate scroll is a non-negative integer to prevent injection
     if scroll and scroll.isdigit():
-        # Handle hash fragments: query params must come before the hash
-        hash_index = url.find("#")
-        if hash_index != -1:
-            base_url = url[:hash_index]
-            hash_fragment = url[hash_index:]
-        else:
-            base_url = url
-            hash_fragment = ""
-
-        # Append scroll parameter to the base URL
-        separator = "&" if "?" in base_url else "?"
-        url = f"{base_url}{separator}scroll={scroll}{hash_fragment}"
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        params["scroll"] = [scroll]
+        new_query = urlencode(params, doseq=True)
+        url = urlunparse(parsed._replace(query=new_query))
     return redirect(url)

--- a/backend/src/opendlp/entrypoints/scroll_utils.py
+++ b/backend/src/opendlp/entrypoints/scroll_utils.py
@@ -1,0 +1,30 @@
+"""ABOUTME: Utility functions for scroll preservation across redirects
+ABOUTME: Provides redirect_preserving_scroll to maintain scroll position after form submissions"""
+
+from flask import redirect, request
+from flask.typing import ResponseReturnValue
+
+
+def redirect_preserving_scroll(url: str) -> ResponseReturnValue:
+    """Redirect to a URL while preserving the scroll parameter from the current request.
+
+    When forms use data-preserve-scroll or x-preserve-scroll-on-submit, the JavaScript
+    adds a scroll=XXX parameter to the form action. This function preserves that parameter
+    in the redirect URL so the browser can restore scroll position after the redirect.
+
+    Args:
+        url: The URL to redirect to
+
+    Returns:
+        A Flask redirect response with scroll parameter preserved if present
+
+    Example:
+        # In a route handler:
+        return redirect_preserving_scroll(url_for("my.route", id=item_id))
+    """
+    scroll = request.args.get("scroll")
+    if scroll:
+        # Append scroll parameter to the URL
+        separator = "&" if "?" in url else "?"
+        url = f"{url}{separator}scroll={scroll}"
+    return redirect(url)

--- a/backend/static/backoffice/js/alpine-components.js
+++ b/backend/static/backoffice/js/alpine-components.js
@@ -5,6 +5,59 @@
 
 
 /* ========================================
+   URL PARAMETER HELPER
+   ======================================== */
+
+/**
+ * Set a query parameter on a URL, replacing any existing value.
+ *
+ * @param {string} url - The base URL
+ * @param {string} param - The parameter name
+ * @param {string} value - The parameter value
+ * @returns {string} URL with parameter set
+ */
+function urlSetParam(url, param, value) {
+    // Split URL into base and hash parts
+    var hashIndex = url.indexOf("#");
+    var hash = "";
+    var baseUrl = url;
+    if (hashIndex !== -1) {
+        hash = url.substring(hashIndex);
+        baseUrl = url.substring(0, hashIndex);
+    }
+
+    // Parse existing query string
+    var queryIndex = baseUrl.indexOf("?");
+    var path = baseUrl;
+    var queryString = "";
+    if (queryIndex !== -1) {
+        path = baseUrl.substring(0, queryIndex);
+        queryString = baseUrl.substring(queryIndex + 1);
+    }
+
+    // Parse and update params
+    var params = [];
+    var replaced = false;
+    if (queryString) {
+        var pairs = queryString.split("&");
+        for (var i = 0; i < pairs.length; i++) {
+            var pair = pairs[i].split("=");
+            if (pair[0] === param) {
+                params.push(param + "=" + encodeURIComponent(value));
+                replaced = true;
+            } else {
+                params.push(pairs[i]);
+            }
+        }
+    }
+    if (!replaced) {
+        params.push(param + "=" + encodeURIComponent(value));
+    }
+
+    return path + "?" + params.join("&") + hash;
+}
+
+/* ========================================
    FOCUS PRESERVATION SYSTEM
    ========================================
 
@@ -30,13 +83,38 @@
        </div>
    ======================================== */
 
+/* ========================================
+   SCROLL PRESERVATION SYSTEM
+   ========================================
+
+   Preserves scroll position across form submissions by encoding the scroll
+   position in a URL query parameter. This improves UX when forms reload
+   the page and the user needs to stay at the same scroll position.
+
+   Components:
+   1. DOMContentLoaded handler - restores scroll position on page load
+   2. data-preserve-scroll attribute - marks forms that should preserve scroll
+   3. x-preserve-scroll-on-submit directive - adds scroll param on submit
+
+   Usage:
+     Option A: With confirmation dialog ($confirm magic)
+       <form method="post" action="..." x-data data-preserve-scroll
+             @submit.prevent="$confirm('Are you sure?', $el)">
+
+     Option B: Without confirmation (directive)
+       <form method="post" action="..." x-data x-preserve-scroll-on-submit>
+   ======================================== */
+
 /**
- * Focus restoration on page load
+ * Focus and scroll restoration on page load
  *
  * Checks for #focus=<focusId> in the URL hash and restores focus to the
  * element with matching data-focus-id attribute.
+ *
+ * Also checks for ?scroll=<position> in query params and restores scroll position.
  */
 document.addEventListener("DOMContentLoaded", function () {
+    // Focus restoration
     var hash = window.location.hash;
     if (hash.startsWith("#focus=")) {
         var focusId = hash.substring(7);
@@ -46,6 +124,23 @@ document.addEventListener("DOMContentLoaded", function () {
             // Clean up the URL hash after restoring focus
             if (window.history.replaceState) {
                 var cleanUrl = window.location.href.split("#")[0];
+                window.history.replaceState(null, "", cleanUrl);
+            }
+        }
+    }
+
+    // Scroll restoration
+    var urlParams = new URLSearchParams(window.location.search);
+    var scrollPos = urlParams.get("scroll");
+    if (scrollPos !== null) {
+        var scrollY = parseInt(scrollPos, 10);
+        if (!isNaN(scrollY)) {
+            window.scrollTo(0, scrollY);
+            // Clean up the URL after restoring scroll
+            if (window.history.replaceState) {
+                urlParams.delete("scroll");
+                var newSearch = urlParams.toString();
+                var cleanUrl = window.location.pathname + (newSearch ? "?" + newSearch : "") + window.location.hash;
                 window.history.replaceState(null, "", cleanUrl);
             }
         }
@@ -101,10 +196,13 @@ document.addEventListener("alpine:init", function () {
      * Confirmation magic helper for form submissions
      *
      * Shows a confirmation dialog before submitting a form. Designed for CSP-safe
-     * Alpine.js usage.
+     * Alpine.js usage. Supports scroll preservation via data-preserve-scroll attribute.
      *
      * Usage:
      *   <form x-data @submit.prevent="$confirm('Are you sure?', $el)">
+     *
+     *   With scroll preservation:
+     *   <form x-data data-preserve-scroll @submit.prevent="$confirm('Are you sure?', $el)">
      *
      * @param {string} message - The confirmation message to display
      * @param {HTMLFormElement} formElement - The form element to submit if confirmed
@@ -112,9 +210,32 @@ document.addEventListener("alpine:init", function () {
     Alpine.magic("confirm", function () {
         return function (message, formElement) {
             if (confirm(message)) {
+                // Check if scroll preservation is requested
+                if (formElement.hasAttribute("data-preserve-scroll")) {
+                    var action = formElement.getAttribute("action") || window.location.href;
+                    var scrollPos = Math.round(window.scrollY);
+                    formElement.setAttribute("action", urlSetParam(action, "scroll", scrollPos.toString()));
+                }
                 formElement.submit();
             }
         };
+    });
+
+    /**
+     * Scroll preservation directive for form submissions
+     *
+     * Automatically adds scroll position to form action URL on submit.
+     * Use this for forms that don't use confirmation dialogs.
+     *
+     * Usage:
+     *   <form method="post" action="..." x-data x-preserve-scroll-on-submit>
+     */
+    Alpine.directive("preserve-scroll-on-submit", function (el) {
+        el.addEventListener("submit", function () {
+            var action = el.getAttribute("action") || window.location.href;
+            var scrollPos = Math.round(window.scrollY);
+            el.setAttribute("action", urlSetParam(action, "scroll", scrollPos.toString()));
+        });
     });
 
     /**

--- a/backend/static/backoffice/js/alpine-components.js
+++ b/backend/static/backoffice/js/alpine-components.js
@@ -10,51 +10,21 @@
 
 /**
  * Set a query parameter on a URL, replacing any existing value.
+ * Uses the built-in URL and URLSearchParams APIs for reliable parsing.
  *
- * @param {string} url - The base URL
+ * @param {string} url - The base URL (can be relative or absolute)
  * @param {string} param - The parameter name
  * @param {string} value - The parameter value
  * @returns {string} URL with parameter set
  */
 function urlSetParam(url, param, value) {
-    // Split URL into base and hash parts
-    var hashIndex = url.indexOf("#");
-    var hash = "";
-    var baseUrl = url;
-    if (hashIndex !== -1) {
-        hash = url.substring(hashIndex);
-        baseUrl = url.substring(0, hashIndex);
+    var urlObj = new URL(url, window.location.origin);
+    urlObj.searchParams.set(param, value);
+    // Return relative URL for relative inputs, absolute for absolute inputs
+    if (url.match(/^(https?:)?\/\//)) {
+        return urlObj.href;
     }
-
-    // Parse existing query string
-    var queryIndex = baseUrl.indexOf("?");
-    var path = baseUrl;
-    var queryString = "";
-    if (queryIndex !== -1) {
-        path = baseUrl.substring(0, queryIndex);
-        queryString = baseUrl.substring(queryIndex + 1);
-    }
-
-    // Parse and update params
-    var params = [];
-    var replaced = false;
-    if (queryString) {
-        var pairs = queryString.split("&");
-        for (var i = 0; i < pairs.length; i++) {
-            var pair = pairs[i].split("=");
-            if (pair[0] === param) {
-                params.push(param + "=" + encodeURIComponent(value));
-                replaced = true;
-            } else {
-                params.push(pairs[i]);
-            }
-        }
-    }
-    if (!replaced) {
-        params.push(param + "=" + encodeURIComponent(value));
-    }
-
-    return path + "?" + params.join("&") + hash;
+    return urlObj.pathname + urlObj.search + urlObj.hash;
 }
 
 /* ========================================

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -233,9 +233,9 @@
         border-color: var(--color-button-primary-bg-hover);
     }
 
-    /* Focus ring for keyboard navigation */
+    /* Focus ring for keyboard navigation - uses browser default for better contrast */
     .checkbox-input:focus-visible + .checkbox-box {
-        outline: 2px solid var(--color-focus-ring);
+        outline: 2px solid;
         outline-offset: 2px;
     }
 
@@ -332,9 +332,9 @@
         border-color: var(--color-button-primary-bg-hover);
     }
 
-    /* Focus ring for keyboard navigation */
+    /* Focus ring for keyboard navigation - uses browser default for better contrast */
     .radio-input:focus-visible + .radio-circle {
-        outline: 2px solid var(--color-focus-ring);
+        outline: 2px solid;
         outline-offset: 2px;
     }
 
@@ -422,9 +422,9 @@
         background-color: var(--color-button-primary-bg-hover);
     }
 
-    /* Focus ring for keyboard navigation */
+    /* Focus ring for keyboard navigation - uses browser default for better contrast */
     .switch-input:focus-visible + .switch-track {
-        outline: 2px solid var(--color-focus-ring);
+        outline: 2px solid;
         outline-offset: 2px;
     }
 

--- a/backend/static/backoffice/tokens/semantic.css
+++ b/backend/static/backoffice/tokens/semantic.css
@@ -38,11 +38,17 @@
 
     /* ========================================
      FOCUS RING
+
+     Currently using browser default focus outline (black/white double
+     outline in Chrome) for better contrast against any background.
+
+     To enable custom focus color across all components, add
+     outline-color: var(--color-focus-ring) to focus styles.
      ======================================== */
 
     --color-focus-ring: var(--color-brand-400);
     --focus-ring-width: 2px;
-    --focus-ring-offset: 4px;
+    --focus-ring-offset: 2px;
 
     /* ========================================
      BUTTON SEMANTIC TOKENS

--- a/backend/templates/backoffice/assembly_data.html
+++ b/backend/templates/backoffice/assembly_data.html
@@ -383,7 +383,9 @@ ABOUTME: Displays data source selection and data management for assemblies
                     <form method="post"
                           action="{{ url_for('respondents.upload_respondents_csv', assembly_id=assembly.id) }}"
                           enctype="multipart/form-data"
-                          class="flex flex-col gap-4">
+                          class="flex flex-col gap-4"
+                          x-data
+                          x-preserve-scroll-on-submit>
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                         {{ file_input(name="file",
                         label=_("CSV File") ,

--- a/backend/templates/backoffice/assembly_data.html
+++ b/backend/templates/backoffice/assembly_data.html
@@ -410,13 +410,10 @@ ABOUTME: Displays data source selection and data management for assemblies
         {% set csv_readonly = csv_mode == "view" %}
         {% set csv_is_edit = csv_mode == "edit" %}
         <section class="mb-8">
-            <div class="flex items-center justify-between mb-4">
+            <div class="mb-4">
                 <h2 id="selection-settings"
                     class="text-heading-lg"
                     style="color: var(--color-headings)">{{ _("Selection Settings") }}</h2>
-                {% if csv_readonly %}
-                    {{ button(_("Edit Settings") , href=url_for('backoffice.view_assembly_data', assembly_id=assembly.id) ~ "?source=csv&mode=edit", variant="outline") }}
-                {% endif %}
             </div>
             <p class="text-body-md mb-6" style="color: var(--color-secondary-text);">
                 {{ _("Configure how the selection algorithm runs for this assembly.") }}
@@ -426,7 +423,9 @@ ABOUTME: Displays data source selection and data management for assemblies
                         border: 1px solid var(--color-borders-dividers)">
                 <form method="post"
                       action="{{ url_for('db_selection_backoffice.save_db_settings', assembly_id=assembly.id) }}"
-                      class="flex flex-col gap-6">
+                      class="flex flex-col gap-6"
+                      x-data
+                      x-preserve-scroll-on-submit>
                     {% if not csv_readonly %}{{ csv_settings_form.hidden_tag() }}{% endif %}
                     {# Check Same Address Checkbox #}
                     {{ checkbox(name="check_same_address",
@@ -500,12 +499,21 @@ ABOUTME: Displays data source selection and data management for assemblies
                             </div>
                         {% endif %}
                     {% endif %}
-                    {# Form Actions - only show in edit mode #}
+                    {# Form Actions #}
                     {% if not csv_readonly %}
                         <div class="flex gap-4 pt-4"
                              style="border-top: 1px solid var(--color-borders-dividers)">
                             {{ button(_("Save Settings") , type="submit", variant="primary") }}
-                            {{ button(_("Cancel") , href=url_for('backoffice.view_assembly_data', assembly_id=assembly.id) ~ "?source=csv", variant="outline") }}
+                            <span x-data x-scroll-preserve-links>
+                                {{ button(_("Cancel") , href=url_for('backoffice.view_assembly_data', assembly_id=assembly.id) ~ "?source=csv", variant="outline") }}
+                            </span>
+                        </div>
+                    {% else %}
+                        <div class="flex justify-end pt-4"
+                             style="border-top: 1px solid var(--color-borders-dividers)">
+                            <span x-data x-scroll-preserve-links>
+                                {{ button(_("Edit Settings") , href=url_for('backoffice.view_assembly_data', assembly_id=assembly.id) ~ "?source=csv&mode=edit", variant="outline") }}
+                            </span>
                         </div>
                     {% endif %}
                 </form>

--- a/backend/templates/backoffice/assembly_data.html
+++ b/backend/templates/backoffice/assembly_data.html
@@ -76,6 +76,7 @@ ABOUTME: Displays data source selection and data management for assemblies
                           action="{{ url_for('gsheets.delete_gsheet_config', assembly_id=assembly.id) }}"
                           class="inline"
                           x-data
+                          data-preserve-scroll
                           @submit.prevent="$confirm('{{ _("Are you sure you want to delete this Google Spreadsheet configuration? This action cannot be undone.") }}', $el)">
                         {{ gsheet_form.hidden_tag() }}
                         {{ button(_("Delete") , type="submit", variant="danger") }}
@@ -273,6 +274,7 @@ ABOUTME: Displays data source selection and data management for assemblies
                     <form method="post"
                           action="{{ url_for('gsheets.delete_gsheet_config', assembly_id=assembly.id) }}"
                           x-data
+                          data-preserve-scroll
                           @submit.prevent="$confirm('{{ _("Are you sure you want to delete this Google Spreadsheet configuration? This action cannot be undone.") }}', $el)">
                         {{ gsheet_form.hidden_tag() }}
                         {{ button(_("Delete Configuration") , type="submit", variant="danger") }}
@@ -322,6 +324,7 @@ ABOUTME: Displays data source selection and data management for assemblies
                     <form method="post"
                           action="{{ url_for('targets.delete_targets', assembly_id=assembly.id) }}"
                           x-data
+                          data-preserve-scroll
                           @submit.prevent="$confirm('{{ _("Are you sure you want to delete all targets? This action cannot be undone.") }}', $el)">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                         {{ button(_("Delete Targets") , type="submit", variant="danger") }}
@@ -370,6 +373,7 @@ ABOUTME: Displays data source selection and data management for assemblies
                     <form method="post"
                           action="{{ url_for('respondents.delete_respondents', assembly_id=assembly.id) }}"
                           x-data
+                          data-preserve-scroll
                           @submit.prevent="$confirm('{{ _("Are you sure you want to delete all respondents? This action cannot be undone.") }}', $el)">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                         {{ button(_("Delete Respondents") , type="submit", variant="danger") }}

--- a/backend/templates/backoffice/base_page.html
+++ b/backend/templates/backoffice/base_page.html
@@ -5,7 +5,7 @@ ABOUTME: Provides navigation, flash messages, breadcrumbs slot, content slot, an
 {% extends "backoffice/base.html" %}
 {% from "backoffice/components/navigation.html" import navigation %}
 {% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
-{% from "backoffice/components/alert.html" import flash_messages %}
+{% from "backoffice/components/floating_alerts.html" import floating_alerts %}
 {% from "backoffice/components/footer.html" import footer with context %}
 
 {% block body %}
@@ -26,12 +26,12 @@ ABOUTME: Provides navigation, flash messages, breadcrumbs slot, content slot, an
         ) }}
 
         <main class="max-w-screen-2xl mx-auto px-6 py-8 flex-1 w-full">
-            {{ flash_messages() }}
-
             {% block breadcrumb_section %}{% endblock %}
 
             {% block page_content %}{% endblock %}
         </main>
+
+        {{ floating_alerts() }}
 
         {{ footer() }}
     </div>

--- a/backend/templates/backoffice/components/alert.html
+++ b/backend/templates/backoffice/components/alert.html
@@ -3,7 +3,7 @@ ABOUTME: Alert/flash message component macro for backoffice design system
 ABOUTME: Supports success, warning, error, info variants with semantic styling
 #}
 
-{% macro alert(message="", variant="info", dismissible=false, id="", use_caller=false) %}
+{% macro alert(message="", variant="info", dismissible=false, id="", use_caller=false, floating=false) %}
     {#
     Alert component for displaying messages/notifications.
 
@@ -13,6 +13,7 @@ ABOUTME: Supports success, warning, error, info variants with semantic styling
         dismissible: Boolean to show close button (requires Alpine.js)
         id: Optional id attribute
         use_caller: Boolean to use caller block for HTML content (default: false)
+        floating: Boolean to remove bottom margin (for floating alerts container)
 
     Usage:
         alert("Changes saved successfully", variant="success")
@@ -24,6 +25,9 @@ ABOUTME: Supports success, warning, error, info variants with semantic styling
         call alert(variant="warning", use_caller=true)
             Message with link
         endcall
+
+        For floating alerts (no bottom margin):
+        alert("Saved", variant="success", dismissible=true, floating=true)
     #}
     {% set variant_styles = {
     "success": {
@@ -56,7 +60,7 @@ ABOUTME: Supports success, warning, error, info variants with semantic styling
     <div
         {% if id %}id="{{ id }}"{% endif %}
         {% if dismissible %}x-data="{ show: true }" x-show="show" x-transition{% endif %}
-        class="mb-6 rounded-lg p-4 flex items-center gap-3"
+        class="{{ 'mb-6 ' if not floating else '' }}rounded-lg p-4 flex items-center gap-3"
         style="background-color: {{ styles.bg }}; border: 1px solid {{ styles.border }};"
         role="alert"
     >

--- a/backend/templates/backoffice/components/floating_alerts.html
+++ b/backend/templates/backoffice/components/floating_alerts.html
@@ -1,0 +1,40 @@
+{#
+ABOUTME: Floating alert component for flash messages at bottom-right of viewport
+ABOUTME: Provides accessible notifications that don't require scrolling to top
+#}
+{% from "backoffice/components/alert.html" import alert %}
+
+{% macro floating_alerts() %}
+    {#
+    Renders Flask flash messages in a fixed-position container at bottom-right.
+
+    Features:
+    - Fixed position at bottom-right of viewport
+    - z-30: Below modals (z-40/z-50) but above page content
+    - aria-live="polite": Screen readers announce new alerts
+    - All alerts are dismissible
+
+    Usage:
+        {{ floating_alerts() }}
+
+    Place this after </main> but inside the page container.
+    #}
+    {% set messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        <div id="floating-alerts"
+             class="fixed bottom-6 right-6 z-30 flex flex-col gap-3 max-w-md"
+             aria-live="polite">
+            {% for category, message in messages %}
+                {% if category == "success" %}
+                    {{ alert(message, variant="success", dismissible=true, floating=true) }}
+                {% elif category == "error" %}
+                    {{ alert(message, variant="error", dismissible=true, floating=true) }}
+                {% elif category == "warning" %}
+                    {{ alert(message, variant="warning", dismissible=true, floating=true) }}
+                {% else %}
+                    {{ alert(message, variant="info", dismissible=true, floating=true) }}
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}

--- a/backend/templates/backoffice/components/input.html
+++ b/backend/templates/backoffice/components/input.html
@@ -97,12 +97,11 @@ ABOUTME: Supports text, email, password, number, textarea, select, checkbox, rad
                 {% if required %}required{% endif %}
                 {% if disabled %}disabled{% endif %}
                 {% if attrs %}{{ attrs | safe }}{% endif %}
-                class="text-body-md px-4 py-2.5 rounded-lg w-full transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 {{ classes }}"
+                class="text-body-md px-4 py-2.5 rounded-lg w-full transition-all duration-150 {{ classes }}"
                 style="
                        background-color: var(--color-page-background);
                        border: 1px solid {% if has_error %}var(--color-primary-action){% else %}var(--color-borders-dividers){% endif %};
                        color: var(--color-body-text);
-                       --tw-ring-color: {% if has_error %}var(--color-primary-action){% else %}var(--color-focus-ring){% endif %};
                        {% if disabled %}
                            background-color: var(--color-subtle-background-panels);
                            {% if dim %}color: var(--color-placeholder-text);{% endif %}
@@ -115,12 +114,11 @@ ABOUTME: Supports text, email, password, number, textarea, select, checkbox, rad
                     type="button"
                     data-toggle-password="{{ input_id }}"
                     aria-label="Show password"
-                    class="text-body-sm px-3 py-2.5 rounded-lg whitespace-nowrap cursor-pointer transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                    class="text-body-sm px-3 py-2.5 rounded-lg whitespace-nowrap cursor-pointer transition-all duration-150"
                     style="
                            background-color: var(--color-subtle-background-panels);
                            border: 1px solid var(--color-borders-dividers);
                            color: var(--color-body-text);
-                           --tw-ring-color: var(--color-focus-ring);
                           "
                 >Show</button>
                 </div>
@@ -185,12 +183,11 @@ ABOUTME: Supports text, email, password, number, textarea, select, checkbox, rad
             {% if required %}required{% endif %}
             {% if disabled %}disabled{% endif %}
             {% if attrs %}{{ attrs | safe }}{% endif %}
-            class="text-body-md px-4 py-2.5 rounded-lg w-full transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 resize-y {{ classes }}"
+            class="text-body-md px-4 py-2.5 rounded-lg w-full transition-all duration-150 resize-y {{ classes }}"
             style="
                    background-color: var(--color-page-background);
                    border: 1px solid {% if has_error %}var(--color-primary-action){% else %}var(--color-borders-dividers){% endif %};
                    color: var(--color-body-text);
-                   --tw-ring-color: {% if has_error %}var(--color-primary-action){% else %}var(--color-focus-ring){% endif %};
                    {% if disabled %}
                        background-color: var(--color-subtle-background-panels);
                        {% if dim %}color: var(--color-placeholder-text);{% endif %}
@@ -259,12 +256,11 @@ ABOUTME: Supports text, email, password, number, textarea, select, checkbox, rad
             {% if required %}required{% endif %}
             {% if disabled %}disabled{% endif %}
             {% if attrs %}{{ attrs | safe }}{% endif %}
-            class="text-body-md px-4 py-2.5 rounded-lg w-full transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 cursor-pointer {{ classes }}"
+            class="text-body-md px-4 py-2.5 rounded-lg w-full transition-all duration-150 cursor-pointer {{ classes }}"
             style="
                    background-color: var(--color-page-background);
                    border: 1px solid {% if has_error %}var(--color-primary-action){% else %}var(--color-borders-dividers){% endif %};
                    color: var(--color-body-text);
-                   --tw-ring-color: {% if has_error %}var(--color-primary-action){% else %}var(--color-focus-ring){% endif %};
                    {% if disabled %}
                        background-color: var(--color-subtle-background-panels);
                        color: var(--color-placeholder-text);
@@ -500,10 +496,9 @@ ABOUTME: Supports text, email, password, number, textarea, select, checkbox, rad
                 {% if required %}required{% endif %}
                 {% if disabled %}disabled{% endif %}
                 {% if attrs %}{{ attrs | safe }}{% endif %}
-                class="text-body-md w-full transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 file:mr-4 file:py-2.5 file:px-4 file:rounded-lg file:border-0 file:text-button-md file:cursor-pointer {{ classes }}"
+                class="text-body-md w-full transition-all duration-150 file:mr-4 file:py-2.5 file:px-4 file:rounded-lg file:border-0 file:text-button-md file:cursor-pointer {{ classes }}"
                 style="
                        color: var(--color-body-text);
-                       --tw-ring-color: {% if has_error %}var(--color-primary-action){% else %}var(--color-focus-ring){% endif %};
                        {% if disabled %}
                            color: var(--color-placeholder-text);
                            cursor: not-allowed;

--- a/backend/templates/backoffice/patterns.html
+++ b/backend/templates/backoffice/patterns.html
@@ -47,7 +47,8 @@ ABOUTME: Documents Alpine.js patterns, form handling, and AJAX with live example
         {"key": "progress", "label": _("Progress"), "href": url_for('dev.patterns', tab='progress'), "active": active_tab == 'progress'},
         {"key": "pagination", "label": _("Pagination"), "href": url_for('dev.patterns', tab='pagination'), "active": active_tab == 'pagination'},
         {"key": "scroll", "label": _("Scroll"), "href": url_for('dev.patterns', tab='scroll'), "active": active_tab == 'scroll'},
-        {"key": "focus", "label": _("Focus"), "href": url_for('dev.patterns', tab='focus'), "active": active_tab == 'focus'}
+        {"key": "focus", "label": _("Focus"), "href": url_for('dev.patterns', tab='focus'), "active": active_tab == 'focus'},
+        {"key": "floating-alerts", "label": _("Floating Alerts"), "href": url_for('dev.patterns', tab='floating-alerts'), "active": active_tab == 'floating-alerts'}
         ],
         aria_label=_("Pattern categories"),
         preserve_scroll=true
@@ -1022,8 +1023,16 @@ def list_items():
                                             <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Alpine directive for auto-applying to all links in a container") }}</td>
                                         </tr>
                                         <tr>
-                                            <td class="px-3 py-2 font-mono"><code>data-navigate-preserve-scroll</code></td>
-                                            <td class="px-3 py-2">{{ _("Add to select elements with data-navigate-base-url") }}</td>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);"><code>data-navigate-preserve-scroll</code></td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Add to select elements with data-navigate-base-url") }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);"><code>data-preserve-scroll</code></td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Form attribute for use with $confirm magic") }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono"><code>x-preserve-scroll-on-submit</code></td>
+                                            <td class="px-3 py-2">{{ _("Alpine directive for forms without confirmation") }}</td>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -1036,6 +1045,7 @@ def list_items():
                             <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
                                 <li><code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">static/js/alpine-scroll-manager.js</code> — {{ _("$preserveScroll magic and x-scroll-preserve-links directive") }}</li>
                                 <li><code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">static/js/utilities.js</code> — {{ _("data-navigate-* handlers for select elements") }}</li>
+                                <li><code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">static/backoffice/js/alpine-components.js</code> — {{ _("$confirm magic with data-preserve-scroll, x-preserve-scroll-on-submit directive") }}</li>
                             </ul>
                         </div>
                     {% endcall %}
@@ -1251,6 +1261,155 @@ def list_items():
                         </div>
                     {% endcall %}
                 {% endcall %}
+
+                {# Form Scroll Preservation Pattern #}
+                {% call card(title="Form Scroll Preservation", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("For forms that submit and reload the page, use these patterns to preserve scroll position. Useful for forms with confirmation dialogs or inline actions.") }}
+                        </p>
+
+                        {# When to Use #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("When to Use") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li>{{ _("Delete buttons with confirmation dialogs") }}</li>
+                                <li>{{ _("Inline action forms (approve, reject, toggle)") }}</li>
+                                <li>{{ _("Any form where the user should stay at their current position") }}</li>
+                            </ul>
+                        </div>
+
+                        {# Available Tools #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">
+                                <span class="mr-2">🧰</span>{{ _("Available Tools") }}
+                            </h4>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-body-sm" style="border: 1px solid var(--color-borders-dividers);">
+                                    <thead style="background-color: var(--color-subtle-background-panels);">
+                                        <tr>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Tool") }}</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Use Case") }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono" style="border-bottom: 1px solid var(--color-borders-dividers);"><code>data-preserve-scroll</code></td>
+                                            <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Form attribute for use with $confirm magic") }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono"><code>x-preserve-scroll-on-submit</code></td>
+                                            <td class="px-3 py-2">{{ _("Alpine directive for forms without confirmation") }}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        {# Code Example: With Confirmation #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("With Confirmation Dialog") }}</h4>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{# Form with confirmation - uses data-preserve-scroll attribute #}
+&lt;form method="post"
+      action="{% raw %}{{ url_for('my.delete_item', id=item.id) }}{% endraw %}"
+      x-data
+      data-preserve-scroll
+      @submit.prevent="$confirm('Are you sure?', $el)"&gt;
+    &lt;input type="hidden" name="csrf_token" value="{% raw %}{{ csrf_token() }}{% endraw %}"&gt;
+    &lt;button type="submit"&gt;Delete&lt;/button&gt;
+&lt;/form&gt;
+
+{# The $confirm magic checks for data-preserve-scroll and adds scroll param #}</pre>
+                        </div>
+
+                        {# Code Example: Without Confirmation #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Without Confirmation Dialog") }}</h4>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{# Form without confirmation - uses x-preserve-scroll-on-submit directive #}
+&lt;form method="post"
+      action="{% raw %}{{ url_for('my.toggle_item', id=item.id) }}{% endraw %}"
+      x-data
+      x-preserve-scroll-on-submit&gt;
+    &lt;input type="hidden" name="csrf_token" value="{% raw %}{{ csrf_token() }}{% endraw %}"&gt;
+    &lt;button type="submit"&gt;Toggle&lt;/button&gt;
+&lt;/form&gt;
+
+{# The directive adds scroll param on submit event #}</pre>
+                        </div>
+
+                        {# Live Example #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">
+                                <span class="mr-2">🧪</span>{{ _("Live Example") }}
+                            </h4>
+                            <div class="p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
+                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                    {{ _("Scroll down, then submit one of these forms. Notice how scroll position is preserved.") }}
+                                </p>
+                                <div class="flex gap-4 flex-wrap">
+                                    <form action="{{ url_for('dev.flash_test') }}" method="post" x-data data-preserve-scroll
+                                          @submit.prevent="$confirm('Confirm with scroll preservation?', $el)">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <input type="hidden" name="type" value="success">
+                                        <input type="hidden" name="message" value="Form submitted with scroll preserved!">
+                                        <input type="hidden" name="return_url" value="{{ url_for('dev.patterns', tab='scroll') }}">
+                                        <button type="submit"
+                                                class="px-4 py-2 rounded-lg text-button-md"
+                                                style="background-color: var(--color-primary-action); color: var(--color-button-primary-text);">
+                                            {{ _("With Confirmation") }}
+                                        </button>
+                                    </form>
+                                    <form action="{{ url_for('dev.flash_test') }}" method="post" x-data x-preserve-scroll-on-submit>
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <input type="hidden" name="type" value="info">
+                                        <input type="hidden" name="message" value="Form submitted with scroll preserved (no confirmation)!">
+                                        <input type="hidden" name="return_url" value="{{ url_for('dev.patterns', tab='scroll') }}">
+                                        <button type="submit"
+                                                class="px-4 py-2 rounded-lg text-button-md"
+                                                style="background-color: var(--color-button-secondary-bg); color: var(--color-button-secondary-text); border: 1px solid var(--color-borders-dividers);">
+                                            {{ _("Without Confirmation") }}
+                                        </button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+
+                        {# Key Points #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-warning-600);">⚠️ {{ _("Key Points") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><strong>data-preserve-scroll</strong> — {{ _("Boolean attribute, works with $confirm magic") }}</li>
+                                <li><strong>x-preserve-scroll-on-submit</strong> — {{ _("Alpine directive, works on form submit event") }}</li>
+                                <li><strong>{{ _("URL cleanup") }}</strong> — {{ _("Scroll param is removed automatically after restoration") }}</li>
+                                <li><strong>{{ _("CSP-safe") }}</strong> — {{ _("No inline scripts required") }}</li>
+                            </ul>
+                        </div>
+
+                        {# Implementation Index #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">
+                                <span class="mr-2">📍</span>{{ _("Source File") }}
+                            </h4>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-body-sm" style="border: 1px solid var(--color-borders-dividers);">
+                                    <thead style="background-color: var(--color-subtle-background-panels);">
+                                        <tr>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("File") }}</th>
+                                            <th class="px-3 py-2 text-left" style="border-bottom: 1px solid var(--color-borders-dividers);">{{ _("Usage") }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="px-3 py-2 font-mono">static/backoffice/js/alpine-components.js</td>
+                                            <td class="px-3 py-2">$confirm magic with data-preserve-scroll, x-preserve-scroll-on-submit directive</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
             </div>
         {% endif %}
 
@@ -1442,12 +1601,160 @@ def list_items():
             </div>
         {% endif %}
 
+        {# ===== FLOATING ALERTS PATTERN ===== #}
+        {% if active_tab == 'floating-alerts' %}
+            <div class="space-y-6">
+                {# Overview Card #}
+                {% call card(title="Floating Alerts Overview", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Flash messages in the backoffice appear as floating alerts at the bottom-right of the viewport. This ensures users see feedback without scrolling to the top of the page.") }}
+                        </p>
+
+                        {# Philosophy #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("Design Philosophy") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><strong>{{ _("Visible anywhere") }}:</strong> {{ _("Users don't need to scroll to see feedback messages") }}</li>
+                                <li><strong>{{ _("Non-blocking") }}:</strong> {{ _("Positioned at bottom-right to avoid covering content") }}</li>
+                                <li><strong>{{ _("Dismissible") }}:</strong> {{ _("All floating alerts can be closed by the user") }}</li>
+                                <li><strong>{{ _("Accessible") }}:</strong> {{ _("Uses aria-live='polite' for screen reader announcements") }}</li>
+                            </ul>
+                        </div>
+
+                        {# Where it's defined #}
+                        <div class="p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">📍 {{ _("Source Files") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">templates/backoffice/components/floating_alerts.html</code> — {{ _("Floating alerts macro") }}</li>
+                                <li><code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">templates/backoffice/components/alert.html</code> — {{ _("Alert component with floating parameter") }}</li>
+                                <li><code class="px-2 py-0.5 rounded" style="background-color: var(--color-page-background);">templates/backoffice/base_page.html</code> — {{ _("Includes floating_alerts() after main content") }}</li>
+                            </ul>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+
+                {# Test Floating Alerts #}
+                {% call card(title="Test Floating Alerts", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Click the buttons below to trigger flash messages. The alerts will appear at the bottom-right of the viewport.") }}
+                        </p>
+
+                        {# Test Buttons #}
+                        <div class="flex flex-wrap gap-3 mb-6">
+                            <form action="{{ url_for('dev.flash_test') }}" method="post" class="inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <input type="hidden" name="type" value="success">
+                                <input type="hidden" name="return_url" value="{{ url_for('dev.patterns', tab='floating-alerts') }}">
+                                <button type="submit"
+                                        class="px-4 py-2 rounded-lg text-button-md transition-colors"
+                                        style="background-color: var(--color-success-100); color: var(--color-success-600); border: 1px solid var(--color-success-400);">
+                                    ✓ {{ _("Success Alert") }}
+                                </button>
+                            </form>
+                            <form action="{{ url_for('dev.flash_test') }}" method="post" class="inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <input type="hidden" name="type" value="warning">
+                                <input type="hidden" name="return_url" value="{{ url_for('dev.patterns', tab='floating-alerts') }}">
+                                <button type="submit"
+                                        class="px-4 py-2 rounded-lg text-button-md transition-colors"
+                                        style="background-color: var(--color-warning-100); color: var(--color-warning-600); border: 1px solid var(--color-warning-400);">
+                                    ⚠ {{ _("Warning Alert") }}
+                                </button>
+                            </form>
+                            <form action="{{ url_for('dev.flash_test') }}" method="post" class="inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <input type="hidden" name="type" value="error">
+                                <input type="hidden" name="return_url" value="{{ url_for('dev.patterns', tab='floating-alerts') }}">
+                                <button type="submit"
+                                        class="px-4 py-2 rounded-lg text-button-md transition-colors"
+                                        style="background-color: var(--color-error-100); color: var(--color-error-600); border: 1px solid var(--color-error-400);">
+                                    ✕ {{ _("Error Alert") }}
+                                </button>
+                            </form>
+                            <form action="{{ url_for('dev.flash_test') }}" method="post" class="inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <input type="hidden" name="type" value="info">
+                                <input type="hidden" name="return_url" value="{{ url_for('dev.patterns', tab='floating-alerts') }}">
+                                <button type="submit"
+                                        class="px-4 py-2 rounded-lg text-button-md transition-colors"
+                                        style="background-color: var(--color-info-100); color: var(--color-info-600); border: 1px solid var(--color-info-400);">
+                                    ℹ {{ _("Info Alert") }}
+                                </button>
+                            </form>
+                        </div>
+
+                        {# Key Points #}
+                        <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-warning-600);">⚠️ {{ _("Key Points") }}</h4>
+                            <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
+                                <li><strong>z-30</strong> — {{ _("Below modals (z-40/z-50) but above page content") }}</li>
+                                <li><strong>aria-live=\"polite\"</strong> — {{ _("Screen readers announce new alerts without interrupting") }}</li>
+                                <li><strong>{{ _("Dismissible") }}</strong> — {{ _("All floating alerts have a close button") }}</li>
+                                <li><strong>{{ _("No bottom margin") }}</strong> — {{ _("Uses floating=true parameter; gap handled by container") }}</li>
+                            </ul>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+
+                {# Usage Code #}
+                {% call card(title="Usage", composed=true) %}
+                    {% call card_body() %}
+                        {# Description #}
+                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                            {{ _("Floating alerts are automatically included in <code>base_page.html</code>. Just use Flask's <code>flash()</code> function.") | safe }}
+                        </p>
+
+                        {# Code Example #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Python (Route Handler)") }}</h4>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">from flask import flash
+
+@bp.route("/save", methods=["POST"])
+def save_item():
+    # ... save logic ...
+    flash(_("Changes saved successfully!"), "success")
+    return redirect(url_for("my.route"))</pre>
+                        </div>
+
+                        {# Template Code #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Template (Automatic in base_page.html)") }}</h4>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{% raw %}{# In base_page.html - already included #}
+{% from "backoffice/components/floating_alerts.html" import floating_alerts %}
+
+<main>
+    {# Page content #}
+</main>
+
+{{ floating_alerts() }}  {# After </main> #}{% endraw %}</pre>
+                        </div>
+
+                        {# Alert Component Code #}
+                        <div class="mb-6">
+                            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Alert Component Options") }}</h4>
+                            <pre class="text-body-sm font-mono p-4 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{% raw %}{% from "backoffice/components/alert.html" import alert %}
+
+{# Standard alert (with bottom margin) #}
+{{ alert("Message", variant="success") }}
+
+{# Floating alert (no bottom margin, used in floating_alerts.html) #}
+{{ alert("Message", variant="success", dismissible=true, floating=true) }}{% endraw %}</pre>
+                        </div>
+                    {% endcall %}
+                {% endcall %}
+            </div>
+        {% endif %}
+
         {# Toast Notification #}
         <div x-cloak x-show="toast.show" x-transition
              class="fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg"
-             :style="toast.type === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-info-100); border: 1px solid var(--color-info-400); color: var(--color-info-600);'">
-            <span x-text="toast.message"></span>
-        </div>
+             :style="toast.type === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-info-100); border: 1px solid var(--color-info-400); color: var(--color-info-600);'"
+             <span x-text="toast.message"></span>
+    </div>
     </div>
 
     <script nonce="{{ csp_nonce }}">

--- a/backend/templates/backoffice/showcase/alert_component.html
+++ b/backend/templates/backoffice/showcase/alert_component.html
@@ -1,6 +1,6 @@
 {#
 ABOUTME: Showcase section for alert component
-ABOUTME: Displays alert variants and flash message helper
+ABOUTME: Displays alert variants and floating alerts documentation
 #}
 {% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_example, showcase_tokens %}
 {% from "backoffice/components/alert.html" import alert %}
@@ -8,26 +8,40 @@ ABOUTME: Displays alert variants and flash message helper
 {% macro alert_section() %}
     {% call showcase_section() %}
         {{ showcase_title("Alert Component") }}
-        {{ showcase_description("Alerts for displaying feedback messages. Includes a flash_messages() helper for Flask flash messages.") }}
+        {{ showcase_description("Alerts for displaying feedback messages. Flash messages appear as floating alerts at the bottom-right of the viewport.") }}
 
-        {% call showcase_example('{% from "backoffice/components/alert.html" import alert, flash_messages %}
+        {# Floating Alerts Note #}
+        <div class="mb-8 p-4 rounded-lg" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+            <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">Floating Alerts</h4>
+            <p class="text-body-sm mb-2" style="color: var(--color-body-text);">
+                In the backoffice, flash messages now appear as <strong>floating alerts</strong> at the bottom-right of the viewport.
+                This ensures users see feedback without scrolling to the top of the page.
+            </p>
+            <p class="text-body-sm" style="color: var(--color-body-text);">
+                <strong>Test it:</strong> Visit
+                <a href="{{ url_for('dev.patterns', tab='floating-alerts') }}" class="underline" style="color: var(--color-link-text);">/backoffice/dev/patterns?tab=floating-alerts</a>
+                to trigger test alerts interactively.
+            </p>
+        </div>
 
-            {# Individual alerts #}
+        {% call showcase_example('{% from "backoffice/components/alert.html" import alert %}
+
+{# Individual alerts - variants #}
             {{ alert("Success message", variant="success") }}
             {{ alert("Warning message", variant="warning") }}
             {{ alert("Error message", variant="error") }}
             {{ alert("Info message", variant="info") }}
 
-            {# Dismissible alert (requires Alpine.js) #}
+{# Dismissible alert (requires Alpine.js) #}
             {{ alert("Can be closed", variant="info", dismissible=true) }}
 
-            {# Alert with HTML content (use caller block) #}
+{# Floating alert (no bottom margin, used in floating_alerts.html) #}
+            {{ alert("Floating alert", variant="success", dismissible=true, floating=true) }}
+
+{# Alert with HTML content (use caller block) #}
             {% call alert(variant="warning", use_caller=true) %}
                 Message with <a href="...">link</a>
-            {% endcall %}
-
-            {# Render all Flask flash messages automatically #}
-            {{ flash_messages() }}') %}
+            {% endcall %}') %}
             <div class="space-y-4">
                 <div>
                     <span class="text-caption mb-2 block" style="color: var(--color-secondary-text);">Success</span>

--- a/backend/tests/unit/test_dev_security.py
+++ b/backend/tests/unit/test_dev_security.py
@@ -1,0 +1,40 @@
+"""ABOUTME: Unit tests for dev.py security functions
+ABOUTME: Tests URL validation to prevent open redirect attacks"""
+
+from opendlp.entrypoints.blueprints.dev import _is_safe_redirect_url
+
+
+class TestIsSafeRedirectUrl:
+    def test_relative_url_is_safe(self) -> None:
+        """Relative URLs starting with / are safe."""
+        assert _is_safe_redirect_url("/some/path") is True
+        assert _is_safe_redirect_url("/") is True
+        assert _is_safe_redirect_url("/backoffice/dev/patterns") is True
+
+    def test_relative_url_with_query_string_is_safe(self) -> None:
+        """Relative URLs with query strings are safe."""
+        assert _is_safe_redirect_url("/path?tab=floating-alerts") is True
+        assert _is_safe_redirect_url("/path?foo=bar&baz=qux") is True
+
+    def test_protocol_relative_url_is_not_safe(self) -> None:
+        """Protocol-relative URLs (//example.com) are not safe."""
+        assert _is_safe_redirect_url("//evil.com/path") is False
+        assert _is_safe_redirect_url("//example.com") is False
+
+    def test_absolute_url_is_not_safe(self) -> None:
+        """Absolute URLs with protocol are not safe."""
+        assert _is_safe_redirect_url("https://evil.com/path") is False
+        assert _is_safe_redirect_url("http://example.com") is False
+
+    def test_javascript_url_is_not_safe(self) -> None:
+        """JavaScript URLs are not safe."""
+        assert _is_safe_redirect_url("javascript:alert(1)") is False
+
+    def test_empty_url_is_not_safe(self) -> None:
+        """Empty URL is not safe."""
+        assert _is_safe_redirect_url("") is False
+
+    def test_relative_path_without_leading_slash_is_not_safe(self) -> None:
+        """Relative paths without leading slash are not safe."""
+        assert _is_safe_redirect_url("path/to/page") is False
+        assert _is_safe_redirect_url("../evil") is False

--- a/backend/tests/unit/test_floating_alerts.py
+++ b/backend/tests/unit/test_floating_alerts.py
@@ -1,0 +1,154 @@
+"""ABOUTME: Jinja render tests for the floating_alerts and alert macros
+ABOUTME: Verifies floating alerts rendering with proper accessibility attributes"""
+
+from flask import Flask, render_template_string
+
+from opendlp import config
+from opendlp.translations import gettext
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__, template_folder=str(config.get_templates_path()))
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret-key"  # pragma: allowlist secret
+    app.jinja_env.globals["_"] = gettext
+    app.jinja_env.globals["gettext"] = gettext
+    return app
+
+
+def _render_alert(message: str, variant: str = "info", dismissible: bool = False, floating: bool = False) -> str:
+    app = _make_app()
+    with app.test_request_context("/"):
+        return render_template_string(
+            """{% from "backoffice/components/alert.html" import alert %}
+            {{ alert(message, variant=variant, dismissible=dismissible, floating=floating) }}""",
+            message=message,
+            variant=variant,
+            dismissible=dismissible,
+            floating=floating,
+        )
+
+
+def _render_floating_alerts_with_flash(messages: list[tuple[str, str]]) -> str:
+    """Render floating_alerts macro with mocked flash messages."""
+    app = _make_app()
+    with app.test_request_context("/"):
+        # Mock get_flashed_messages
+        app.jinja_env.globals["get_flashed_messages"] = lambda with_categories=False: messages
+        return render_template_string(
+            """{% from "backoffice/components/floating_alerts.html" import floating_alerts %}
+            {{ floating_alerts() }}"""
+        )
+
+
+class TestAlertMacro:
+    def test_alert_renders_message(self) -> None:
+        html = _render_alert("Test message")
+        assert "Test message" in html
+        assert 'role="alert"' in html
+
+    def test_alert_success_variant(self) -> None:
+        html = _render_alert("Success!", variant="success")
+        assert "Success!" in html
+        assert "success" in html.lower() or "var(--color-success" in html
+
+    def test_alert_warning_variant(self) -> None:
+        html = _render_alert("Warning!", variant="warning")
+        assert "Warning!" in html
+        assert "warning" in html.lower() or "var(--color-warning" in html
+
+    def test_alert_error_variant(self) -> None:
+        html = _render_alert("Error!", variant="error")
+        assert "Error!" in html
+        assert "error" in html.lower() or "var(--color-error" in html
+
+    def test_alert_info_variant(self) -> None:
+        html = _render_alert("Info!", variant="info")
+        assert "Info!" in html
+        assert "info" in html.lower() or "var(--color-info" in html
+
+    def test_alert_dismissible_has_close_button(self) -> None:
+        html = _render_alert("Dismissible alert", dismissible=True)
+        assert "Dismissible alert" in html
+        assert "x-data" in html
+        assert "x-show" in html
+        # Close button should have aria-label
+        assert "Dismiss" in html or "dismiss" in html.lower()
+
+    def test_alert_non_dismissible_no_close_button(self) -> None:
+        html = _render_alert("Non-dismissible alert", dismissible=False)
+        assert "Non-dismissible alert" in html
+        assert "x-data" not in html
+
+    def test_alert_floating_no_margin(self) -> None:
+        """Floating alerts should not have bottom margin class."""
+        html = _render_alert("Floating alert", floating=True)
+        assert "Floating alert" in html
+        # mb-6 should not be present for floating alerts
+        assert "mb-6" not in html
+
+    def test_alert_non_floating_has_margin(self) -> None:
+        """Non-floating alerts should have bottom margin class."""
+        html = _render_alert("Normal alert", floating=False)
+        assert "Normal alert" in html
+        assert "mb-6" in html
+
+
+class TestFloatingAlertsMacro:
+    def test_floating_alerts_empty_when_no_messages(self) -> None:
+        """When no flash messages, container should not be rendered."""
+        html = _render_floating_alerts_with_flash([])
+        # Should be empty or minimal whitespace
+        assert "floating-alerts" not in html
+
+    def test_floating_alerts_renders_success_message(self) -> None:
+        html = _render_floating_alerts_with_flash([("success", "Changes saved!")])
+        assert "floating-alerts" in html
+        assert "Changes saved!" in html
+        assert 'aria-live="polite"' in html
+
+    def test_floating_alerts_renders_error_message(self) -> None:
+        html = _render_floating_alerts_with_flash([("error", "Something went wrong")])
+        assert "floating-alerts" in html
+        assert "Something went wrong" in html
+
+    def test_floating_alerts_renders_warning_message(self) -> None:
+        html = _render_floating_alerts_with_flash([("warning", "Please review")])
+        assert "floating-alerts" in html
+        assert "Please review" in html
+
+    def test_floating_alerts_renders_info_message(self) -> None:
+        html = _render_floating_alerts_with_flash([("info", "New feature available")])
+        assert "floating-alerts" in html
+        assert "New feature available" in html
+
+    def test_floating_alerts_renders_multiple_messages(self) -> None:
+        html = _render_floating_alerts_with_flash([
+            ("success", "Item saved"),
+            ("warning", "Please review settings"),
+        ])
+        assert "floating-alerts" in html
+        assert "Item saved" in html
+        assert "Please review settings" in html
+
+    def test_floating_alerts_has_fixed_positioning(self) -> None:
+        html = _render_floating_alerts_with_flash([("info", "Test")])
+        assert "fixed" in html
+        assert "bottom-6" in html
+        assert "right-6" in html
+
+    def test_floating_alerts_has_z_index(self) -> None:
+        html = _render_floating_alerts_with_flash([("info", "Test")])
+        assert "z-30" in html
+
+    def test_floating_alerts_are_dismissible(self) -> None:
+        """All floating alerts should be dismissible."""
+        html = _render_floating_alerts_with_flash([("success", "Test")])
+        assert "x-data" in html
+        assert "x-show" in html
+
+    def test_floating_alerts_unknown_category_defaults_to_info(self) -> None:
+        """Unknown flash categories should render as info variant."""
+        html = _render_floating_alerts_with_flash([("unknown_category", "Unknown type")])
+        assert "floating-alerts" in html
+        assert "Unknown type" in html

--- a/backend/tests/unit/test_scroll_utils.py
+++ b/backend/tests/unit/test_scroll_utils.py
@@ -83,3 +83,30 @@ class TestRedirectPreservingScroll:
             response = redirect_preserving_scroll("/target/url?source=csv&mode=edit")
             assert response.status_code == 302
             assert response.location == "/target/url?source=csv&mode=edit&scroll=100"
+
+    def test_redirect_with_non_numeric_scroll_is_ignored(self, app: Flask) -> None:
+        """Non-numeric scroll values are ignored for security."""
+        with app.test_request_context("/some/path?scroll=abc"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url"
+
+    def test_redirect_with_negative_scroll_is_ignored(self, app: Flask) -> None:
+        """Negative scroll values are ignored (isdigit returns False for -)."""
+        with app.test_request_context("/some/path?scroll=-100"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url"
+
+    def test_redirect_with_injection_attempt_is_ignored(self, app: Flask) -> None:
+        """Potential injection attempts in scroll param are ignored."""
+        with app.test_request_context("/some/path?scroll=100&evil=true"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            # Only the numeric scroll value should be preserved
+            assert response.location == "/target/url?scroll=100"
+        # Try actual malicious value
+        with app.test_request_context("/some/path?scroll=<script>"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url"

--- a/backend/tests/unit/test_scroll_utils.py
+++ b/backend/tests/unit/test_scroll_utils.py
@@ -110,3 +110,45 @@ class TestRedirectPreservingScroll:
             response = redirect_preserving_scroll("/target/url")
             assert response.status_code == 302
             assert response.location == "/target/url"
+
+    def test_redirect_with_external_url_in_scroll_is_ignored(self, app: Flask) -> None:
+        """Attempts to inject external URLs via scroll param are rejected."""
+        # Full URL attempt
+        with app.test_request_context("/some/path?scroll=https://evil.com"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url"
+            assert "evil.com" not in response.location
+
+        # Protocol-relative URL attempt
+        with app.test_request_context("/some/path?scroll=//evil.com"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url"
+            assert "evil.com" not in response.location
+
+    def test_redirect_with_url_encoded_injection_is_ignored(self, app: Flask) -> None:
+        """URL-encoded injection attempts in scroll param are rejected."""
+        # Encoded newline + Location header injection attempt
+        with app.test_request_context("/some/path?scroll=100%0d%0aLocation:http://evil.com"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert "evil.com" not in response.location
+
+        # Encoded characters that look like numbers
+        with app.test_request_context("/some/path?scroll=%31%30%30"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            # URL-encoded "100" is decoded by Flask, so this should work
+            # but if it doesn't decode, it should be rejected
+            # Either way, no external redirect should occur
+            assert "evil" not in response.location.lower()
+
+    def test_redirect_rejects_scroll_with_path_traversal(self, app: Flask) -> None:
+        """Path traversal attempts in scroll param are rejected."""
+        with app.test_request_context("/some/path?scroll=../../../etc/passwd"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url"
+            assert "etc" not in response.location
+            assert "passwd" not in response.location

--- a/backend/tests/unit/test_scroll_utils.py
+++ b/backend/tests/unit/test_scroll_utils.py
@@ -1,0 +1,85 @@
+"""ABOUTME: Unit tests for scroll_utils module
+ABOUTME: Tests redirect_preserving_scroll function for scroll position preservation"""
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
+
+
+class TestRedirectPreservingScroll:
+    @pytest.fixture
+    def app(self) -> Flask:
+        """Create a minimal Flask app for testing."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        return app
+
+    @pytest.fixture
+    def client(self, app: Flask) -> FlaskClient:
+        return app.test_client()
+
+    def test_redirect_without_scroll_param(self, app: Flask) -> None:
+        """When no scroll param in request, redirect URL is unchanged."""
+        with app.test_request_context("/some/path"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url"
+
+    def test_redirect_with_scroll_param(self, app: Flask) -> None:
+        """When scroll param exists, it's appended to redirect URL."""
+        with app.test_request_context("/some/path?scroll=500"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url?scroll=500"
+
+    def test_redirect_with_scroll_param_and_existing_query_string(self, app: Flask) -> None:
+        """When scroll param exists and target URL has query string, scroll is appended with &."""
+        with app.test_request_context("/some/path?scroll=750"):
+            response = redirect_preserving_scroll("/target/url?source=csv")
+            assert response.status_code == 302
+            assert response.location == "/target/url?source=csv&scroll=750"
+
+    def test_redirect_with_zero_scroll(self, app: Flask) -> None:
+        """Scroll value of 0 is preserved (user at top of page)."""
+        with app.test_request_context("/some/path?scroll=0"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url?scroll=0"
+
+    def test_redirect_with_large_scroll_value(self, app: Flask) -> None:
+        """Large scroll values are preserved correctly."""
+        with app.test_request_context("/some/path?scroll=99999"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url?scroll=99999"
+
+    def test_redirect_with_other_params_preserved(self, app: Flask) -> None:
+        """Other request params don't affect scroll preservation."""
+        with app.test_request_context("/some/path?other=value&scroll=300&another=param"):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            assert response.location == "/target/url?scroll=300"
+
+    def test_redirect_with_empty_scroll_param(self, app: Flask) -> None:
+        """Empty scroll param is treated as no scroll (falsy value)."""
+        with app.test_request_context("/some/path?scroll="):
+            response = redirect_preserving_scroll("/target/url")
+            assert response.status_code == 302
+            # Empty string is falsy, so no scroll param added
+            assert response.location == "/target/url"
+
+    def test_redirect_preserves_target_url_hash(self, app: Flask) -> None:
+        """Hash fragment in target URL is preserved."""
+        with app.test_request_context("/some/path?scroll=200"):
+            response = redirect_preserving_scroll("/target/url#section")
+            assert response.status_code == 302
+            assert response.location == "/target/url?scroll=200#section"
+
+    def test_redirect_with_complex_target_url(self, app: Flask) -> None:
+        """Complex target URL with multiple params works correctly."""
+        with app.test_request_context("/some/path?scroll=100"):
+            response = redirect_preserving_scroll("/target/url?source=csv&mode=edit")
+            assert response.status_code == 302
+            assert response.location == "/target/url?source=csv&mode=edit&scroll=100"


### PR DESCRIPTION
## Summary

- **Floating alerts**: Flash messages now appear at bottom-right of viewport instead of top of page, ensuring users see feedback without scrolling
- **Scroll preservation**: Added scroll position preservation for form submissions and navigation on the Data tab
- **Focus outline**: Use browser default focus outline for better contrast

## Changes

### Floating Alerts
- New `floating_alerts.html` component with `aria-live="polite"` for screen reader announcements
- Added `floating` parameter to alert component (removes bottom margin for stacking)
- Updated `base_page.html` to render floating alerts after main content
- Added interactive test page at `/backoffice/dev/patterns?tab=floating-alerts`

### Scroll Preservation for Data Tab
- Delete operations (targets, respondents, Google Sheets config) preserve scroll position
- People CSV upload preserves scroll position
- Selection Settings edit flow (Edit, Save, Cancel) preserves scroll position
- New `scroll_utils.py` with `redirect_preserving_scroll` helper
- New `x-preserve-scroll-on-submit` Alpine directive for forms
- Enhanced `$confirm` magic to support `data-preserve-scroll` attribute

### Focus Improvements
- Use browser default focus outline for better contrast across themes

## Test plan

- [ ] Trigger flash messages → alerts appear at bottom-right, dismissible, announced by screen reader
- [ ] Delete targets/respondents → scroll position preserved after confirmation
- [ ] Upload people CSV → scroll position preserved after upload
- [ ] Edit/Save/Cancel Selection Settings → scroll position preserved
- [ ] Tab through interactive elements → visible focus outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)