### PR TITLE
Db conn fix

### DIFF
--- a/backend/features/replacement-selection.feature
+++ b/backend/features/replacement-selection.feature
@@ -107,7 +107,7 @@ Feature: Replacement Selection
     And the replacement load task has completed
     When the user clicks Re-check Spreadsheet
     Then a new load task starts
-    And the modal shows loading state
+    And the modal shows the number to select
 
   # =============================================================================
   # Selection History Integration

--- a/backend/src/opendlp/adapters/database.py
+++ b/backend/src/opendlp/adapters/database.py
@@ -36,11 +36,14 @@ def create_session_factory(database_url: str = "", echo: bool = False) -> sessio
     echo = bool_environ_get("DB_ECHO") or echo
     extra_args: dict[str, int | bool] = {}
     if database_url.startswith("postgresql://"):
+        # Sized for 8 connection-opening processes (5 celery workers + beat +
+        # 2 gunicorn workers) against postgres max_connections=100. Worst-case
+        # burst is 8 * (3 + 7) = 80, leaving headroom for psql/admin.
         extra_args = {
             "pool_pre_ping": True,  # Verify connections before use
             "pool_recycle": 3600,  # Recycle connections after 1 hour
-            "pool_size": 10,  # Connection pool size
-            "max_overflow": 20,  # Additional connections beyond pool_size
+            "pool_size": 3,
+            "max_overflow": 7,
         }
     engine = create_engine(database_url, echo=echo, **extra_args)
 

--- a/backend/src/opendlp/bootstrap.py
+++ b/backend/src/opendlp/bootstrap.py
@@ -14,6 +14,8 @@ from opendlp.adapters.url_generator import FlaskURLGenerator, URLGenerator
 from opendlp.config import SMTPEmailCfg, get_config, get_db_uri
 from opendlp.service_layer import unit_of_work
 
+_session_factory_cache: dict[str, sessionmaker] = {}
+
 
 def bootstrap_session_factory(
     start_orm: bool = True,
@@ -23,9 +25,28 @@ def bootstrap_session_factory(
         database.start_mappers()
 
     if session_factory is None:
-        session_factory = database.create_session_factory(get_db_uri())
+        db_uri = get_db_uri()
+        cached = _session_factory_cache.get(db_uri)
+        if cached is None:
+            cached = database.create_session_factory(db_uri)
+            _session_factory_cache[db_uri] = cached
+        session_factory = cached
 
     return session_factory
+
+
+def dispose_cached_engines() -> None:
+    """Dispose all engines cached by ``bootstrap_session_factory`` and clear the cache.
+
+    Call this from post-fork hooks (Celery ``worker_process_init``, gunicorn
+    ``post_fork``). SQLAlchemy connection pools must not be shared across a
+    fork: the child inherits the parent's open file descriptors, so parent
+    and children would race on the same TCP sockets. After disposal each
+    child rebuilds its own pool on first use.
+    """
+    for factory in _session_factory_cache.values():
+        factory.kw["bind"].dispose()
+    _session_factory_cache.clear()
 
 
 def bootstrap(

--- a/backend/src/opendlp/entrypoints/blueprints/gsheets.py
+++ b/backend/src/opendlp/entrypoints/blueprints/gsheets.py
@@ -9,6 +9,7 @@ from flask_login import current_user, login_required
 from sortition_algorithms.features import maximum_selection, minimum_selection
 
 from opendlp import bootstrap
+from opendlp.domain.value_objects import SelectionTaskType
 from opendlp.entrypoints.decorators import require_assembly_management
 from opendlp.entrypoints.forms import (
     CreateAssemblyGSheetForm,
@@ -99,19 +100,38 @@ def _get_selection_modal_context(
     return None, None, [], ""
 
 
+def _load_features_pending(run_record: object, result: object) -> bool:
+    """True when a load task is COMPLETED in postgres but Celery's result backend
+    hasn't surfaced the typed return value yet.
+
+    The load task commits ``status=COMPLETED`` to postgres before its return value
+    lands in the Celery result backend (Redis). A GET that arrives in that window
+    sees the run record as finished but ``get_selection_run_status`` cannot build
+    a ``LoadRunResult`` — so min/max can't be computed and the replacement modal
+    would render in the "result" state with no form and no polling. Detect that
+    state so the caller can keep the modal polling until the next tick.
+    """
+    if getattr(run_record, "task_type", None) != SelectionTaskType.LOAD_REPLACEMENT_GSHEET:
+        return False
+    if not getattr(run_record, "is_completed", False):
+        return False
+    return not (isinstance(result, LoadRunResult) and result.features is not None and result.success)
+
+
 def _get_replacement_modal_context(
     uow: AbstractUnitOfWork,
     assembly_id: uuid.UUID,
     replacement_param: str | None,
     initial_min_select: int | None,
     initial_max_select: int | None,
-) -> tuple[uuid.UUID | None, object | None, list, str, int | None, int | None]:
+) -> tuple[uuid.UUID | None, object | None, list, str, int | None, int | None, bool]:
     """Get context for displaying the replacement selection modal.
 
-    Returns (current_replacement, run_record, log_messages, translated_report_html, min_select, max_select).
+    Returns (current_replacement, run_record, log_messages, translated_report_html,
+    min_select, max_select, features_pending).
     """
     if not replacement_param:
-        return None, None, [], "", initial_min_select, initial_max_select
+        return None, None, [], "", initial_min_select, initial_max_select, False
 
     try:
         current_replacement = uuid.UUID(replacement_param)
@@ -133,11 +153,12 @@ def _get_replacement_modal_context(
                 translate_run_report_to_html(result.run_report) if result.run_report else "",
                 min_select,
                 max_select,
+                _load_features_pending(result.run_record, result),
             )
     except (ValueError, TypeError):
         current_app.logger.debug("Invalid replacement_param for _get_replacement_modal_context: %r", replacement_param)
 
-    return None, None, [], "", initial_min_select, initial_max_select
+    return None, None, [], "", initial_min_select, initial_max_select, False
 
 
 # --- Selection views ---
@@ -176,6 +197,7 @@ def view_assembly_selection(assembly_id: uuid.UUID) -> ResponseReturnValue:
                 replacement_translated_report_html,
                 replacement_min_select,
                 replacement_max_select,
+                replacement_features_pending,
             ) = _get_replacement_modal_context(
                 uow,
                 assembly_id,
@@ -278,6 +300,7 @@ def view_assembly_selection(assembly_id: uuid.UUID) -> ResponseReturnValue:
             replacement_translated_report_html=replacement_translated_report_html,
             replacement_min_select=replacement_min_select,
             replacement_max_select=replacement_max_select,
+            replacement_features_pending=replacement_features_pending,
             edit_number_modal_open=edit_number_modal_open,
             data_source=data_source,
             targets_enabled=targets_enabled,
@@ -398,6 +421,7 @@ def replacement_progress_modal(assembly_id: uuid.UUID, run_id: uuid.UUID) -> Res
             current_replacement=run_id,
             replacement_min_select=replacement_min_select,
             replacement_max_select=replacement_max_select,
+            replacement_features_pending=_load_features_pending(result.run_record, result),
         ), 200
     except NotFoundError:
         return "", 404

--- a/backend/src/opendlp/entrypoints/celery/app.py
+++ b/backend/src/opendlp/entrypoints/celery/app.py
@@ -1,8 +1,10 @@
 import logging
+from typing import Any
 
 from celery import Celery, Task
+from celery.signals import worker_process_init
 
-from opendlp import config
+from opendlp import bootstrap, config
 
 
 def get_celery_app(redis_host: str = "", redis_port: int = 0, old_app: Celery | None = None) -> Celery:
@@ -59,6 +61,18 @@ def reset_celery_app() -> None:
 
 
 app = get_celery_app()
+
+
+@worker_process_init.connect
+def reset_db_connections_after_fork(**_: Any) -> None:
+    """Drop any SQLAlchemy engines inherited from the parent celery process.
+
+    With the default prefork pool each worker is forked from the master.
+    Any engine the master built before forking would have its file
+    descriptors shared by every child, so concurrent queries from
+    different workers would corrupt each other's TCP traffic.
+    """
+    bootstrap.dispose_cached_engines()
 
 
 class CeleryContextHandler(logging.Handler):

--- a/backend/src/opendlp/entrypoints/forms.py
+++ b/backend/src/opendlp/entrypoints/forms.py
@@ -19,12 +19,12 @@ from wtforms import (
 )
 from wtforms.validators import DataRequired, EqualTo, InputRequired, Length, Optional, ValidationError
 
+from opendlp.bootstrap import bootstrap
 from opendlp.domain.selection_settings import OTHER_TEAM
 from opendlp.domain.users import User
 from opendlp.domain.validators import GoogleSpreadsheetURLValidator
 from opendlp.domain.value_objects import AssemblyRole, GlobalRole, assembly_role_options, global_role_options
 from opendlp.domain.value_objects import validate_email as domain_validate_email
-from opendlp.service_layer.unit_of_work import SqlAlchemyUnitOfWork
 from opendlp.translations import gettext as _
 from opendlp.translations import lazy_gettext as _l
 
@@ -69,7 +69,7 @@ class EmailDoesNotExistValidator:
         if not field.data:
             return
         try:
-            with SqlAlchemyUnitOfWork() as uow:
+            with bootstrap() as uow:
                 existing_user = uow.users.get_by_email(field.data)
         except Exception:  # noqa: S110
             # If we can't check (e.g., database error), allow form to continue
@@ -154,7 +154,7 @@ class RegistrationForm(FlaskForm):  # type: ignore[no-any-unimported]
         if not invite_code.data:
             return
         try:
-            with SqlAlchemyUnitOfWork() as uow:
+            with bootstrap() as uow:
                 invite = uow.user_invites.get_by_code(invite_code.data)
                 if not invite or not invite.is_valid():
                     raise ValidationError(_("Invalid or expired invite code."))
@@ -526,7 +526,7 @@ class OAuthRegistrationForm(FlaskForm):  # type: ignore[no-any-unimported]
         if not invite_code.data:
             return
         try:
-            with SqlAlchemyUnitOfWork() as uow:
+            with bootstrap() as uow:
                 invite = uow.user_invites.get_by_code(invite_code.data)
                 if not invite or not invite.is_valid():
                     raise ValidationError(_("Invalid or expired invite code."))

--- a/backend/src/opendlp/service_layer/db_utils.py
+++ b/backend/src/opendlp/service_layer/db_utils.py
@@ -43,7 +43,7 @@ def drop_tables(engine: Engine) -> None:
 
 
 def seed_database(
-    session_factory: sessionmaker | None = None,
+    session_factory: sessionmaker,
 ) -> tuple[Iterable[tuple[User, str]], Iterable[UserInvite], Iterable[Assembly]]:
     """Seed the database with test data."""
     with SqlAlchemyUnitOfWork(session_factory) as uow:

--- a/backend/src/opendlp/service_layer/unit_of_work.py
+++ b/backend/src/opendlp/service_layer/unit_of_work.py
@@ -8,7 +8,6 @@ from types import TracebackType
 
 from sqlalchemy.orm import Session, sessionmaker
 
-from opendlp.adapters.database import create_session_factory
 from opendlp.adapters.sql_repository import (
     SqlAlchemyAssemblyGSheetRepository,
     SqlAlchemyAssemblyRepository,
@@ -96,14 +95,11 @@ class AbstractUnitOfWork(abc.ABC):
         raise NotImplementedError
 
 
-DEFAULT_SESSION_FACTORY = create_session_factory()
-
-
 class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
     """SQLAlchemy implementation of Unit of Work pattern."""
 
-    def __init__(self, session_factory: sessionmaker | None = None) -> None:
-        self.session_factory = session_factory or DEFAULT_SESSION_FACTORY
+    def __init__(self, session_factory: sessionmaker) -> None:
+        self.session_factory = session_factory
         self._session: Session | None = None
 
     @property

--- a/backend/templates/backoffice/components/replacement_modal.html
+++ b/backend/templates/backoffice/components/replacement_modal.html
@@ -3,8 +3,12 @@
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/modal.html" import progress_modal, modal_footer_start, modal_footer_end, spinner, status_badge, message_log, labeled_value %}
 {% set close_url = url_for('gsheets.view_assembly_selection', assembly_id=assembly.id) %}
-{% set is_task_running = replacement_run_record and not replacement_run_record.has_finished %}
-{% set task_finished = replacement_run_record and replacement_run_record.has_finished %}
+{% set features_pending = replacement_features_pending|default(false) %}
+{# features_pending: postgres has the load task as COMPLETED but Celery's result
+   backend hasn't surfaced features yet, so min/max can't be computed. Treat as
+   still running so HTMX keeps polling; the next tick picks up the features. #}
+{% set is_task_running = replacement_run_record and (not replacement_run_record.has_finished or features_pending) %}
+{% set task_finished = replacement_run_record and replacement_run_record.has_finished and not features_pending %}
 {% set has_min_max = replacement_min_select and replacement_max_select %}
 {% set can_close = not is_task_running %}
 {% set htmx_poll_url = url_for('gsheets.replacement_progress_modal', assembly_id=assembly.id, run_id=current_replacement) if is_task_running else "" %}

--- a/backend/tests/bdd/test_replacement_selection.py
+++ b/backend/tests/bdd/test_replacement_selection.py
@@ -1,6 +1,7 @@
 """ABOUTME: BDD tests for Replacement Selection Modal
 ABOUTME: Tests the replacement selection workflow from the selection page"""
 
+import re
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -196,14 +197,23 @@ def user_clicks_close(admin_logged_in_page: Page):
     page.wait_for_load_state()
 
 
-@when("the user clicks Re-check Spreadsheet")
-def user_clicks_recheck(admin_logged_in_page: Page):
-    """Click the Re-check Spreadsheet button in the modal."""
+@when("the user clicks Re-check Spreadsheet", target_fixture="previous_replacement_run_id")
+def user_clicks_recheck(admin_logged_in_page: Page) -> str:
+    """Click the Re-check Spreadsheet button in the modal.
+
+    Returns the ``current_replacement`` run_id from the URL before the click so
+    follow-up steps can confirm a new task was started.
+    """
     page = admin_logged_in_page
+    match = re.search(r"current_replacement=([0-9a-fA-F-]+)", page.url)
+    assert match is not None, f"expected current_replacement in URL, got {page.url}"
+    old_run_id = match.group(1)
+
     modal = page.locator("#replacement-modal")
     btn = modal.get_by_role("button", name="Re-check Spreadsheet")
     expect(btn).to_be_visible()
     btn.click()
+    return old_run_id
 
 
 # =============================================================================
@@ -370,21 +380,31 @@ def modal_cannot_close_via_backdrop(admin_logged_in_page: Page):
 
 
 @then("a new load task starts")
-def new_load_task_starts(admin_logged_in_page: Page):
-    """Verify a new load task has started."""
+def new_load_task_starts(admin_logged_in_page: Page, previous_replacement_run_id: str):
+    """Verify a new load task has started by waiting for the URL to point to a new run.
+
+    The task itself can complete in <50ms once SQLAlchemy engines are cached, so we
+    cannot rely on catching the spinner. Instead we verify the redirect chain has
+    landed on a different ``current_replacement`` than before the click.
+    """
     page = admin_logged_in_page
-    modal = page.locator("#replacement-modal")
-    # Should see the status change or spinner appear
-    spinner = modal.locator(".animate-spin")
-    expect(spinner.first).to_be_visible()
+    expect(page).not_to_have_url(re.compile(rf"current_replacement={previous_replacement_run_id}"))
+    expect(page).to_have_url(re.compile(r"current_replacement=[0-9a-fA-F-]+"))
 
 
-@then("the modal shows loading state")
-def modal_shows_loading(admin_logged_in_page: Page):
-    """Verify modal shows loading state."""
+@then("the modal shows the number to select")
+def modal_shows_number_to_select(admin_logged_in_page: Page):
+    """Verify the modal eventually settles on the loaded form for the new task.
+
+    The task can complete in ~25ms with warm engine caches, so the spinner may
+    never be visible. We instead wait for the eventual loaded state — the modal
+    keeps polling whenever features aren't yet in Celery's result backend, so
+    this reliably converges on the number input regardless of the task/render
+    race.
+    """
     page = admin_logged_in_page
     modal = page.locator("#replacement-modal")
-    expect(modal.get_by_text("Processing...")).to_be_visible()
+    expect(modal.get_by_label("Number of people to select")).to_be_visible(timeout=30_000)
 
 
 @then("the selection history shows the replacement task")

--- a/backend/tests/unit/test_bootstrap_session_factory.py
+++ b/backend/tests/unit/test_bootstrap_session_factory.py
@@ -1,0 +1,103 @@
+"""ABOUTME: Unit tests for bootstrap_session_factory engine memoization
+ABOUTME: Verifies engines are cached per URI and disposed correctly post-fork"""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+from opendlp import bootstrap
+
+
+@pytest.fixture(autouse=True)
+def reset_session_factory_cache() -> Iterator[None]:
+    """Ensure each test starts with an empty cache and leaves it empty."""
+    bootstrap._session_factory_cache.clear()
+    yield
+    bootstrap._session_factory_cache.clear()
+
+
+class TestBootstrapSessionFactory:
+    def test_repeated_calls_return_same_factory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The same db_uri must reuse the same engine instead of creating new ones."""
+        monkeypatch.setattr(bootstrap, "get_db_uri", lambda: "postgresql://example/db")
+
+        created_engines: list[MagicMock] = []
+
+        def fake_create(db_uri: str) -> sessionmaker:
+            engine = MagicMock(name=f"engine_for_{db_uri}")
+            created_engines.append(engine)
+            return sessionmaker(bind=engine)
+
+        monkeypatch.setattr(bootstrap.database, "create_session_factory", fake_create)
+        monkeypatch.setattr(bootstrap.database, "start_mappers", lambda: None)
+
+        factory_a = bootstrap.bootstrap_session_factory()
+        factory_b = bootstrap.bootstrap_session_factory()
+
+        assert factory_a is factory_b
+        assert len(created_engines) == 1
+
+    def test_different_db_uri_produces_different_factory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A different URI must create its own engine (supports test DB URI overrides)."""
+        uris = iter(["postgresql://one/db", "postgresql://two/db"])
+        monkeypatch.setattr(bootstrap, "get_db_uri", lambda: next(uris))
+
+        created_engines: list[MagicMock] = []
+
+        def fake_create(db_uri: str) -> sessionmaker:
+            engine = MagicMock(name=f"engine_for_{db_uri}")
+            created_engines.append(engine)
+            return sessionmaker(bind=engine)
+
+        monkeypatch.setattr(bootstrap.database, "create_session_factory", fake_create)
+        monkeypatch.setattr(bootstrap.database, "start_mappers", lambda: None)
+
+        factory_a = bootstrap.bootstrap_session_factory()
+        factory_b = bootstrap.bootstrap_session_factory()
+
+        assert factory_a is not factory_b
+        assert len(created_engines) == 2
+
+    def test_explicit_session_factory_bypasses_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicitly supplied session_factory must be returned untouched and not cached."""
+        monkeypatch.setattr(bootstrap, "get_db_uri", lambda: "postgresql://example/db")
+
+        def fail_create(db_uri: str) -> sessionmaker:
+            pytest.fail("create_session_factory should not be called when session_factory is supplied")
+
+        monkeypatch.setattr(bootstrap.database, "create_session_factory", fail_create)
+        monkeypatch.setattr(bootstrap.database, "start_mappers", lambda: None)
+
+        supplied = sessionmaker(bind=MagicMock())
+        returned = bootstrap.bootstrap_session_factory(session_factory=supplied)
+
+        assert returned is supplied
+        assert bootstrap._session_factory_cache == {}
+
+    def test_dispose_cached_engines_disposes_and_clears(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """dispose_cached_engines must call engine.dispose() and empty the cache."""
+        monkeypatch.setattr(bootstrap, "get_db_uri", lambda: "postgresql://example/db")
+
+        engines: list[MagicMock] = []
+
+        def fake_create(db_uri: str) -> sessionmaker:
+            engine = MagicMock(name=f"engine_for_{db_uri}")
+            engines.append(engine)
+            return sessionmaker(bind=engine)
+
+        monkeypatch.setattr(bootstrap.database, "create_session_factory", fake_create)
+        monkeypatch.setattr(bootstrap.database, "start_mappers", lambda: None)
+
+        bootstrap.bootstrap_session_factory()
+        assert len(engines) == 1
+
+        bootstrap.dispose_cached_engines()
+
+        engines[0].dispose.assert_called_once()
+        assert bootstrap._session_factory_cache == {}
+
+        # Subsequent call rebuilds the engine instead of returning a disposed one.
+        bootstrap.bootstrap_session_factory()
+        assert len(engines) == 2

--- a/backend/tests/unit/test_celery_app_signals.py
+++ b/backend/tests/unit/test_celery_app_signals.py
@@ -1,0 +1,36 @@
+"""ABOUTME: Unit tests for Celery worker_process_init signal handler
+ABOUTME: Verifies post-fork hook disposes SQLAlchemy engines inherited from parent"""
+
+import pytest
+from celery.signals import worker_process_init
+
+from opendlp import bootstrap
+from opendlp.entrypoints.celery import app as celery_app_module
+
+
+class TestResetDbConnectionsAfterFork:
+    def test_handler_calls_dispose_cached_engines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Direct invocation of the handler must dispose cached engines."""
+        called: list[bool] = []
+
+        def fake_dispose() -> None:
+            called.append(True)
+
+        monkeypatch.setattr(bootstrap, "dispose_cached_engines", fake_dispose)
+
+        celery_app_module.reset_db_connections_after_fork()
+
+        assert called == [True]
+
+    def test_handler_is_wired_to_worker_process_init(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sending the worker_process_init signal must trigger our handler."""
+        called: list[bool] = []
+
+        def fake_dispose() -> None:
+            called.append(True)
+
+        monkeypatch.setattr(bootstrap, "dispose_cached_engines", fake_dispose)
+
+        worker_process_init.send(sender=None)
+
+        assert called, "worker_process_init signal did not invoke the connected handler"


### PR DESCRIPTION
To prevent the db connections all being used up. We were creating many engines, each with a pool of 10 connections, so exhausting the limit of 100. This pull resolves the issues.