### PR TITLE
Image upload UI on the registration tab

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -230,14 +230,14 @@
         "filename": "backend/src/opendlp/config.py",
         "hashed_secret": "93fe6070639765bfcc100adfdbbd2c170e972942",
         "is_verified": false,
-        "line_number": 473
+        "line_number": 494
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/src/opendlp/config.py",
         "hashed_secret": "f1bb7852ec6d55f5c9701fa44dc2403395647e7f",
         "is_verified": false,
-        "line_number": 505
+        "line_number": 526
       }
     ],
     "backend/templates/base.html": [
@@ -558,5 +558,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-12T12:15:08Z"
+  "generated_at": "2026-06-18T14:17:12Z"
 }

--- a/backend/docs/agent/672-upload-images/frontend-plan.md
+++ b/backend/docs/agent/672-upload-images/frontend-plan.md
@@ -1,0 +1,253 @@
+<!-- ABOUTME: Implementation summary for the frontend/upload-route half of registration image uploads (PR #175). -->
+<!-- ABOUTME: Covers Assets panel UI, JSON routes, button-macro extension, dev tools tab, and review follow-ups. -->
+
+# Registration image uploads — frontend implementation summary
+
+**Issue:** 672 · **Companion:** [data-service-plan.md](data-service-plan.md), [research.md](research.md)
+**Date:** 2026-06-17 · **Branch:** `672-image-upload-frontend` · **PR:** [#175](https://github.com/sortitionfoundation/opendlp/pull/175)
+
+> **Status: ✅ implemented and in review.** All endpoints, UI, dev-tools tab,
+> and button-macro extension are committed; 27 new happy-path unit tests pass.
+> A preliminary review pass has been done — two small follow-up fixes pushed
+> (commit `adad23b`), and the remaining notes posted as a PR comment for
+> @foobacca to scrutinise.
+
+## 1. Scope
+
+This is the **upload route + UI** half of the registration-image feature,
+built on top of the data/service layer landed via [#171](https://github.com/sortitionfoundation/opendlp/pull/171)
+(see [data-service-plan.md](data-service-plan.md)). The service seam
+already existed (`add_registration_image`, `list_registration_images`,
+`delete_registration_image`, `set_registration_image_alt`,
+`list_image_snippets`, `get_registration_image_for_serving`); this work
+wired them into the backoffice and exposed them in dev tooling.
+
+**In scope**
+
+- Three JSON endpoints under `/backoffice/assembly/<id>/registration/images`
+  (POST upload, PATCH alt, DELETE).
+- An **Assets panel** rendered on the registration tab, alongside the HTML
+  editor — list, upload modal, copy-`<img>`-snippet, details/edit-alt modal,
+  delete.
+- An **Images tab** in `/backoffice/dev/service-docs` exercising all six
+  service-layer functions via interactive forms.
+- A new `alpine_disabled` parameter on the shared `button` macro that
+  reactively toggles `disabled`, `aria-disabled`, and a runtime CSS class
+  from an Alpine expression.
+- Happy-path unit coverage for the route helpers, the JSON routes (with
+  `LOGIN_DISABLED`), the dev handlers, and the macro extension.
+
+**Out of scope**
+
+- Replacing the headline UX flow with full e2e/BDD coverage (see §7).
+- A modal-based delete confirmation (still `confirm()`).
+- Configuration of `MAX_CONTENT_LENGTH` at the app level (see §7).
+
+## 2. Architecture decisions
+
+### 2.1 Assets panel lives outside the editor `<form>`
+
+The HTML editor (`<textarea name="html_content">`) lives inside a `<form>`
+that POSTs to `save_assembly_registration`. The Assets panel sits in a
+sibling column **outside** that form so its buttons never submit the editor.
+Uploads/deletes mutate the Alpine `images` array in place — no page reload
+means uncommitted edits in the textarea survive any asset-panel action.
+This is the headline UX promise of the PR.
+
+Layout: `<div class="flex flex-col lg:flex-row gap-6">` with the editor on
+the left (`flex-1 min-w-0`) and a fixed-width column on the right
+(`w-full lg:w-[400px]`, `lg:flex-shrink-0`).
+
+### 2.2 Server-rendered list, client-mutated state
+
+The first render emits the full image list as JSON into Alpine state
+(`images: {{ images|tojson }}`). All subsequent mutations happen client-side:
+
+- **Upload** → POST multipart → server returns image dict → push (or splice
+  in place if dedup returned an existing row).
+- **Edit alt** → PATCH JSON → server returns updated image → splice in place.
+- **Delete** → DELETE → 204 → filter out client-side.
+
+This keeps the round-trip count low and avoids re-rendering the editor.
+
+### 2.3 Alt text required at every entry point
+
+- Modal Upload button stays muted until `imageAlt.trim()` is non-empty
+  (via `alpine_disabled`).
+- Server-side: every endpoint that takes alt rejects empty/whitespace with
+  `400 {"error": "Alt text is required for accessibility"}`.
+- The Details modal won't save with blank alt.
+
+### 2.4 Dedup quirk: `_add_image_honouring_alt`
+
+`add_registration_image` collapses identical bytes to one row and KEEPS the
+first upload's alt. If the user supplies a different alt for a row that
+already exists (typically replacing an empty legacy alt), the upload route
+follows up with `set_registration_image_alt` so the snippet they copy
+reflects what they typed. **Two distinct UoWs** — see §7.1.
+
+### 2.5 `button` macro gains `alpine_disabled`
+
+Compile-time `disabled=true` already existed; the new `alpine_disabled`
+parameter takes an Alpine expression and emits:
+
+```html
+:disabled="<expr>"
+:aria-disabled="(<expr>) ? 'true' : 'false'"
+:class="{ 'btn-runtime-disabled': (<expr>) }"
+```
+
+A new `.btn-runtime-disabled` class in `main.css` layers the muted look on
+top of the variant's inline style (CSS-class merge, not `:style` replace),
+so padding and base styles survive.
+
+The expression is rendered inside double-quoted attributes; Jinja
+autoescape handles any `"` inside the expression, but authors should prefer
+single quotes for string literals to keep the rendered HTML readable
+(documented in the macro docstring).
+
+### 2.6 Per-image URL contract
+
+PATCH/DELETE share a URL pattern (`…/images/<uuid:image_id>`); only the
+HTTP method differs. The template renders the URL **once** via `url_for`
+with a sentinel UUID (`00000000-0000-0000-0000-000000000000`) and a small
+`imageItemUrl(id)` helper swaps in the real id at call time. This keeps the
+route-name dependency explicit instead of implying the URL hierarchy
+(`upload_url + "/" + id` is what the v1 attempt did, fixed in commit
+`adad23b`).
+
+## 3. Endpoints added
+
+| Method | Path | View | Returns |
+|---|---|---|---|
+| `POST` | `/backoffice/assembly/<assembly_id>/registration/images` | `upload_registration_image` | `201 {"image": {…}}` / `4xx {"error": "…"}` |
+| `PATCH` | `/backoffice/assembly/<assembly_id>/registration/images/<image_id>` | `update_assembly_registration_image` | `200 {"image": {…}}` / `4xx {"error": "…"}` |
+| `DELETE` | `/backoffice/assembly/<assembly_id>/registration/images/<image_id>` | `delete_assembly_registration_image` | `204` / `4xx {"error": "…"}` |
+
+All three require `@login_required` and accept `X-CSRFToken` header. Error
+mapping:
+
+- `ImageValidationError` → 400 (includes `reason` field)
+- `ImageQuotaExceeded` → 400
+- `RegistrationPageNotFoundError` / `RegistrationImageNotFoundError` → 400/404
+- `InsufficientPermissions` → 403
+- `NotFoundError` → 404
+- Catch-all → 500 with generic message; traceback logged
+
+## 4. Files touched
+
+| File | Adds | Notes |
+|---|---|---|
+| `src/opendlp/entrypoints/blueprints/backoffice_registration.py` | +175 | Three new routes + `_image_to_dict`, `_add_image_honouring_alt`, `_resolve_page_url_slug` helpers |
+| `src/opendlp/entrypoints/blueprints/dev.py` | +190 | Six `_handle_*` functions + `_serialise_image`; wired into `_SERVICE_HANDLERS` and `valid_tabs` |
+| `static/backoffice/src/main.css` | +11 | `.btn-runtime-disabled` runtime-muted class |
+| `templates/backoffice/assembly_registration.html` | +595 / −140 | Two-column layout; Upload modal; Details/Edit modal; Alpine data + methods; URL contract via `imageItemUrl(id)` |
+| `templates/backoffice/components/button.html` | +14 / −3 | `alpine_disabled` macro param + docstring |
+| `templates/backoffice/service_docs.html` | +105 / −4 | "Images" tab + Alpine state + execute methods + base64 file-reader helper |
+| `templates/backoffice/service_docs/_images.html` | +456 (new) | Interactive cards for all six service functions |
+| `templates/backoffice/showcase/button_component.html` | +20 / −2 | Demo of reactive `Disabled (Alpine)` paired with a switch |
+| `tests/unit/test_backoffice_registration_images.py` | +271 (new) | `_image_to_dict`, `_add_image_honouring_alt`, route happy paths |
+| `tests/unit/test_button_macro_alpine_disabled.py` | +54 (new) | Macro render assertions |
+| `tests/unit/test_dev_image_handlers.py` | +242 (new) | All six dev handler happy paths |
+
+Total: ~2.1k additions / ~150 deletions across 11 files.
+
+## 5. Tests added (27 happy-path)
+
+- `_image_to_dict`: slug present/absent, blank-alt fallback to short-sha
+  filename.
+- `_add_image_honouring_alt`: no-dedup pass-through, dedup follow-up
+  triggering `set_registration_image_alt`.
+- Anonymous-user redirect on all three routes (sanity check that auth is
+  wired).
+- POST happy path with file + alt → 201 with image dict; rejects missing
+  alt; rejects missing file.
+- PATCH happy path with alt → 200 with image dict; rejects missing alt.
+- DELETE happy path → 204 with empty body.
+- All six dev handlers: serialisation, base64 decode (incl. `data:` URL
+  strip), and the snippet handler's URL builder.
+- Macro: emits Alpine bindings when `alpine_disabled` is set; doesn't
+  otherwise; static `disabled=true` still produces the muted look and
+  HTML attribute; padding/base styles survive when `alpine_disabled` is
+  paired with a variant.
+
+Authenticated routes use `app.config["LOGIN_DISABLED"] = True` +
+`patch(current_user)` — a deliberate unit-test shortcut. See §7.2 for
+the trade-off.
+
+## 6. Review pass (PR #175)
+
+A preliminary review was conducted on 2026-06-17 covering correctness,
+project conventions, performance, test coverage, and security. Two small
+follow-up fixes were pushed:
+
+- **Commit `adad23b`** — explicit `url_for` for per-image PATCH/DELETE URLs
+  (§2.6) and a docstring clarification on `alpine_disabled` autoescape
+  behaviour (§2.5). All 27 tests still pass; `url_for` with the sentinel
+  UUID renders it verbatim so the JS string-replace contract is sound.
+
+The remaining notes were posted as
+[PR comment #4728112593](https://github.com/sortitionfoundation/opendlp/pull/175#issuecomment-4728112593),
+summarised in §7 below.
+
+## 7. Known trade-offs and follow-ups
+
+### 7.1 `_add_image_honouring_alt` runs two separate UoWs
+
+```python
+image = add_registration_image(bootstrap.bootstrap(), …, alt=alt)
+if image.alt != alt:
+    image = set_registration_image_alt(bootstrap.bootstrap(), …, alt=alt)
+```
+
+Distinct transactions. If the alt-update fails (race, transient DB error,
+perms change mid-call), the image **is already stored** but the user gets a
+500 with a misleading message. Low blast radius (alt text being wrong) but
+worth either:
+
+- catching the second-call failure and returning the stored image with a
+  soft warning, or
+- consolidating dedup-honours-alt into the service layer in a single
+  transaction.
+
+### 7.2 Test coverage relies on `LOGIN_DISABLED`
+
+Unit tests bypass real auth via `LOGIN_DISABLED = True` + mocked
+`current_user`. **The real `can_manage_assembly` / `can_view_assembly`
+gates are never exercised** in this test layer. Worth following up with
+integration tests for:
+
+- An unauthorised user gets a 403 JSON response (not a redirect / HTML).
+- Error-path JSON shapes for `ImageQuotaExceeded`,
+  `ImageValidationError`, `RegistrationPageNotFoundError` — the frontend
+  reads `data.error` and surfaces it inline; the shape contract matters.
+- A browser-level smoke test confirming the textarea survives an upload
+  (the headline UX promise).
+
+### 7.3 `upload.read()` reads the full body before any size check
+
+The service layer enforces `max_image_upload_mb`, but Flask reads the
+multipart body into memory first. Worth confirming `MAX_CONTENT_LENGTH`
+is set at the app level so a multi-GB upload never reaches the route
+code. Not visible in this PR's diff; recommend a separate audit.
+
+### 7.4 Minor
+
+- `_handle_list_image_snippets` in `dev.py` opens its own bootstrap UoW
+  to look up the page URL slug, mirroring `_resolve_page_url_slug` in
+  `backoffice_registration.py`. Candidate for a shared helper.
+- Delete uses native `confirm()` — fine for v1, but inconsistent with
+  the modal pattern used elsewhere on the same page.
+- DELETE returns `("", 204)` on success but JSON on error. Frontend
+  handles both; flagging the asymmetry.
+
+## 8. Things verified and happy with
+
+- CSRF token sent in headers on all three new endpoints.
+- `images|tojson` in the template properly escapes the seed.
+- i18n: every user-facing string wrapped in `_()`.
+- Generic 500 messages with full tracebacks logged server-side (no info
+  leak).
+- The Assets panel sitting outside the editor `<form>` cleanly solves the
+  unsaved-state problem.
+- All 27 unit tests pass; pre-commit hooks clean.

--- a/backend/migrations/versions/b7c2f1a4d8e3_add_original_filename_to_registration_images.py
+++ b/backend/migrations/versions/b7c2f1a4d8e3_add_original_filename_to_registration_images.py
@@ -1,0 +1,31 @@
+"""add original_filename to registration_images
+
+Revision ID: b7c2f1a4d8e3
+Revises: a644849bb5d2
+Create Date: 2026-06-17 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c2f1a4d8e3"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "a644849bb5d2"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "registration_images",
+        sa.Column("original_filename", sa.String(length=255), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("registration_images", "original_filename")

--- a/backend/src/opendlp/adapters/orm.py
+++ b/backend/src/opendlp/adapters/orm.py
@@ -650,6 +650,7 @@ registration_images = Table(
     Column("sha256", String(64), nullable=False),
     Column("data", LargeBinary, nullable=False),
     Column("alt", String, nullable=False, server_default=""),
+    Column("original_filename", String(255), nullable=False, server_default=""),
     Column("created_by", PostgresUUID(as_uuid=True), ForeignKey("users.id"), nullable=True),
     Column("created_at", TZAwareDatetime(), nullable=False, default=aware_utcnow),
     Index("ix_registration_images_page_sha_unique", "registration_page_id", "sha256", unique=True),

--- a/backend/src/opendlp/config.py
+++ b/backend/src/opendlp/config.py
@@ -7,6 +7,7 @@ import logging.config
 import os
 import tempfile
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import cache
@@ -274,6 +275,26 @@ def get_max_image_upload_bytes() -> int:
     return get_max_image_upload_mb() * 1024 * 1024
 
 
+# Register every per-upload-type limit here so get_max_content_length() stays
+# correct automatically. Add a new entry whenever a new upload type is introduced.
+_UPLOAD_SIZE_CONTRIBUTORS: list[Callable[[], int]] = [
+    get_max_csv_upload_bytes,
+    get_max_image_upload_bytes,
+    get_registration_form_html_max_bytes,
+    get_registration_thank_you_html_max_bytes,
+]
+
+
+def get_max_content_length() -> int:
+    """Flask MAX_CONTENT_LENGTH: the largest request body any endpoint accepts.
+
+    Derived as the maximum of all per-upload-type limits so the WSGI gateway
+    rejects obviously oversized requests while each route still enforces its own
+    tighter limit. Add new upload types to ``_UPLOAD_SIZE_CONTRIBUTORS`` above.
+    """
+    return max(f() for f in _UPLOAD_SIZE_CONTRIBUTORS)
+
+
 def get_registration_image_max_edge_px() -> int:
     """Maximum length of a registration image's longest edge, in pixels.
 
@@ -407,10 +428,10 @@ class FlaskBaseConfig:
         self.LOGIN_RATE_LIMIT_PER_IP: int = int(os.environ.get("LOGIN_RATE_LIMIT_PER_IP", "20"))
         self.LOGIN_RATE_LIMIT_WINDOW_MINUTES: int = int(os.environ.get("LOGIN_RATE_LIMIT_WINDOW_MINUTES", "15"))
 
-        # File upload limit — driven by MAX_CSV_UPLOAD_MB so the WSGI layer
-        # rejects oversize requests before we allocate memory. CSV upload is
-        # the largest expected request body; smaller forms are unaffected.
-        self.MAX_CONTENT_LENGTH = get_max_csv_upload_bytes()
+        # File upload limit — the maximum across all per-upload-type limits so
+        # the WSGI layer rejects obviously oversized requests before allocating
+        # memory. Each route still enforces its own tighter limit.
+        self.MAX_CONTENT_LENGTH = get_max_content_length()
 
         # Deployment configuration
         self.APPLICATION_ROOT = os.environ.get("APPLICATION_ROOT", "/")

--- a/backend/src/opendlp/domain/registration_image.py
+++ b/backend/src/opendlp/domain/registration_image.py
@@ -2,6 +2,7 @@
 ABOUTME: Holds a stored registration image plus pure <img> HTML generation"""
 
 import html as html_lib
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -9,6 +10,25 @@ from datetime import UTC, datetime
 IMAGE_CONTENT_TYPE = "image/png"
 IMAGE_FILE_EXTENSION = "png"
 ALLOWED_INPUT_FORMATS = {"PNG", "JPEG", "WEBP"}
+
+# Bound on the stored original filename to stop an oversized name bloating the row.
+MAX_ORIGINAL_FILENAME_LENGTH = 255
+
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def sanitise_original_filename(name: str) -> str:
+    """Reduce an uploaded filename to a safe, readable, bounded basename.
+
+    Strips any directory components (handling both ``/`` and ``\\`` separators) and
+    control characters, then truncates to ``MAX_ORIGINAL_FILENAME_LENGTH``. Spaces,
+    unicode and case are preserved so the name still reflects what the user called
+    the file.
+    """
+    # Take the basename relative to either separator so a Windows path doesn't slip through.
+    basename = re.split(r"[\\/]", name)[-1]
+    cleaned = _CONTROL_CHARS.sub("", basename).strip()
+    return cleaned[:MAX_ORIGINAL_FILENAME_LENGTH]
 
 
 class ImageValidationError(Exception):
@@ -39,6 +59,7 @@ class RegistrationImage:
         sha256: str,
         data: bytes,
         alt: str = "",
+        original_filename: str = "",
         created_by: uuid.UUID | None = None,
         image_id: uuid.UUID | None = None,
         created_at: datetime | None = None,
@@ -51,6 +72,7 @@ class RegistrationImage:
         self.sha256 = sha256
         self.data = data
         self.alt = alt
+        self.original_filename = original_filename
         self.created_by = created_by
         self.created_at = created_at or datetime.now(UTC)
 
@@ -61,6 +83,7 @@ class RegistrationImage:
         processed: ProcessedImage,
         created_by: uuid.UUID | None = None,
         alt: str = "",
+        original_filename: str = "",
     ) -> "RegistrationImage":
         return cls(
             registration_page_id=registration_page_id,
@@ -70,6 +93,7 @@ class RegistrationImage:
             sha256=processed.sha256,
             data=processed.data,
             alt=alt,
+            original_filename=original_filename,
             created_by=created_by,
         )
 
@@ -82,6 +106,7 @@ class RegistrationImage:
             sha256=self.sha256,
             data=self.data,
             alt=self.alt,
+            original_filename=self.original_filename,
             created_by=self.created_by,
             image_id=self.id,
             created_at=self.created_at,

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -1,8 +1,8 @@
 """ABOUTME: Backoffice registration-page editor routes
-ABOUTME: View / save / create / skeleton / QR-download routes for the assembly registration tab"""
+ABOUTME: View / save / create / skeleton / QR-download / image upload routes for the assembly registration tab"""
 
 import uuid
-from typing import cast
+from typing import Any, cast
 
 from flask import Blueprint, Response, abort, current_app, flash, jsonify, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
@@ -10,6 +10,13 @@ from flask_login import current_user, login_required
 from werkzeug.exceptions import HTTPException
 
 from opendlp import bootstrap
+from opendlp.config import get_max_image_upload_mb
+from opendlp.domain.registration_image import (
+    ALLOWED_INPUT_FORMATS,
+    IMAGE_FILE_EXTENSION,
+    ImageValidationError,
+    RegistrationImage,
+)
 from opendlp.domain.registration_page import (
     RegistrationPageHtml,
     RegistrationPageNotReady,
@@ -19,11 +26,18 @@ from opendlp.entrypoints.blueprints.registration import registration_url, short_
 from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
 from opendlp.service_layer.assembly_service import get_assembly_nav_context
 from opendlp.service_layer.exceptions import (
+    ImageQuotaExceeded,
     InsufficientPermissions,
     NotFoundError,
+    RegistrationImageNotFoundError,
     RegistrationPageNotFoundError,
 )
 from opendlp.service_layer.qr_codes import generate_qr_code_base64, generate_qr_code_png
+from opendlp.service_layer.registration_image_service import (
+    add_registration_image,
+    delete_registration_image,
+    list_registration_images,
+)
 from opendlp.service_layer.registration_page_service import (
     close_registration_page,
     create_registration_page_with_slugs,
@@ -37,6 +51,33 @@ from opendlp.service_layer.registration_page_service import (
 from opendlp.translations import gettext as _
 
 backoffice_registration_bp = Blueprint("backoffice_registration", __name__)
+
+
+def _image_to_dict(image: RegistrationImage, url_slug: str) -> dict[str, Any]:
+    """Serialise an image for the Assets panel.
+
+    ``public_url`` is the public ``/register/<slug>/assets/<sha>.png`` route. If the
+    page has no slug yet (newly created), we return a placeholder so the front-end
+    can still render the row.
+    """
+    file_name = f"{image.sha256}.{IMAGE_FILE_EXTENSION}"
+    public_url = (
+        url_for("registration.serve_registration_image", url_slug=url_slug, image_name=file_name) if url_slug else ""
+    )
+    display_name = (
+        image.alt.strip() if image.alt and image.alt.strip() else f"{image.sha256[:8]}.{IMAGE_FILE_EXTENSION}"
+    )
+    return {
+        "id": str(image.id),
+        "alt": image.alt,
+        "file_name": file_name,
+        "display_name": display_name,
+        "public_url": public_url,
+        "img_snippet": f'<img src="{public_url}" alt="{image.alt}">' if public_url else "",
+        "width": image.width,
+        "height": image.height,
+        "byte_size": image.byte_size,
+    }
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration")
@@ -78,6 +119,13 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
                 registration_short_url = short_url(registration_page.short_url_slug)
                 qr_code_data_url = generate_qr_code_base64(registration_short_url)
 
+        # Load registration images for the Assets panel
+        images: list[dict[str, Any]] = []
+        if has_registration_page and registration_page:
+            uow = bootstrap.bootstrap()
+            stored_images = list_registration_images(uow, current_user.id, assembly_id)
+            images = [_image_to_dict(image, registration_page.url_slug) for image in stored_images]
+
         return render_template(
             "backoffice/assembly_registration.html",
             assembly=nav.assembly,
@@ -94,6 +142,9 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             html_content=html_content,
             thank_you_html=thank_you_html,
             has_registration_page=has_registration_page,
+            images=images,
+            max_image_upload_mb=get_max_image_upload_mb(),
+            allowed_image_formats=sorted(ALLOWED_INPUT_FORMATS),
         ), 200
     except InsufficientPermissions as e:
         current_app.logger.warning(f"Insufficient permissions for assembly {assembly_id} user {current_user.id}: {e}")
@@ -294,3 +345,81 @@ def download_registration_qr_code(assembly_id: uuid.UUID) -> ResponseReturnValue
         current_app.logger.error(f"Download QR code error for assembly {assembly_id} user {current_user.id}: {e}")
         flash(_("An error occurred while generating QR code"), "error")
         return redirect(url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id))
+
+
+def _resolve_page_url_slug(assembly_id: uuid.UUID) -> str:
+    """Look up the registration page's url_slug for serialising image URLs.
+
+    Returns an empty string when the page doesn't exist yet — the caller can
+    decide whether to omit the public URL.
+    """
+    uow = bootstrap.bootstrap()
+    result = get_registration_page_with_source(uow, current_user.id, assembly_id)
+    if result is None:
+        return ""
+    return result[0].url_slug
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images", methods=["POST"])
+@login_required
+def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Accept a multipart image upload and return the stored image metadata as JSON.
+
+    The Assets panel calls this from the registration tab so uploads don't disturb
+    the HTML editor's unsaved state — no full-page reload is required.
+    """
+    upload = request.files.get("image")
+    if upload is None or not upload.filename:
+        return jsonify({"error": _("No file was selected")}), 400
+
+    try:
+        raw = upload.read()
+    except Exception as e:
+        current_app.logger.warning(f"Failed to read uploaded image for assembly {assembly_id}: {e}")
+        return jsonify({"error": _("Failed to read the uploaded file")}), 400
+
+    alt = (request.form.get("alt") or "").strip()
+
+    try:
+        uow = bootstrap.bootstrap()
+        image = add_registration_image(uow, current_user.id, assembly_id, raw, alt=alt)
+    except ImageValidationError as e:
+        return jsonify({"error": e.message, "reason": e.reason}), 400
+    except ImageQuotaExceeded as e:
+        return jsonify({"error": str(e)}), 400
+    except RegistrationPageNotFoundError:
+        return jsonify({"error": _("Please create a registration page first from the Details tab.")}), 400
+    except InsufficientPermissions:
+        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
+    except NotFoundError:
+        return jsonify({"error": _("Assembly not found")}), 404
+    except Exception as e:
+        current_app.logger.error(f"Image upload error for assembly {assembly_id}: {e}")
+        current_app.logger.exception("Full traceback:")
+        return jsonify({"error": _("An error occurred while uploading the image")}), 500
+
+    return jsonify({"image": _image_to_dict(image, _resolve_page_url_slug(assembly_id))}), 201
+
+
+@backoffice_registration_bp.route(
+    "/assembly/<uuid:assembly_id>/registration/images/<uuid:image_id>", methods=["DELETE"]
+)
+@login_required
+def delete_assembly_registration_image(assembly_id: uuid.UUID, image_id: uuid.UUID) -> ResponseReturnValue:
+    """Delete a registration image. Returns 204 on success."""
+    try:
+        uow = bootstrap.bootstrap()
+        delete_registration_image(uow, current_user.id, assembly_id, image_id)
+    except RegistrationImageNotFoundError:
+        return jsonify({"error": _("Image not found")}), 404
+    except RegistrationPageNotFoundError:
+        return jsonify({"error": _("Registration page not found")}), 404
+    except InsufficientPermissions:
+        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
+    except NotFoundError:
+        return jsonify({"error": _("Assembly not found")}), 404
+    except Exception as e:
+        current_app.logger.error(f"Delete image error for assembly {assembly_id} image {image_id}: {e}")
+        return jsonify({"error": _("An error occurred while deleting the image")}), 500
+
+    return "", 204

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -66,12 +66,16 @@ def _image_to_dict(image: RegistrationImage, url_slug: str) -> dict[str, Any]:
     public_url = (
         url_for("registration.serve_registration_image", url_slug=url_slug, image_name=file_name) if url_slug else ""
     )
-    display_name = (
-        image.alt.strip() if image.alt and image.alt.strip() else f"{image.sha256[:8]}.{IMAGE_FILE_EXTENSION}"
-    )
+    if image.alt and image.alt.strip():
+        display_name = image.alt.strip()
+    elif image.original_filename:
+        display_name = image.original_filename
+    else:
+        display_name = f"{image.sha256[:8]}.{IMAGE_FILE_EXTENSION}"
     return {
         "id": str(image.id),
         "alt": image.alt,
+        "original_filename": image.original_filename,
         "file_name": file_name,
         "display_name": display_name,
         "public_url": public_url,
@@ -362,7 +366,9 @@ def _resolve_page_url_slug(assembly_id: uuid.UUID) -> str:
     return result[0].url_slug
 
 
-def _add_image_honouring_alt(assembly_id: uuid.UUID, raw: bytes, alt: str) -> RegistrationImage:
+def _add_image_honouring_alt(
+    assembly_id: uuid.UUID, raw: bytes, alt: str, original_filename: str = ""
+) -> RegistrationImage:
     """Add an image and, on dedup, ensure the stored alt matches the user's input.
 
     ``add_registration_image`` collapses identical bytes to one row and KEEPS the
@@ -370,7 +376,9 @@ def _add_image_honouring_alt(assembly_id: uuid.UUID, raw: bytes, alt: str) -> Re
     image (typically replacing an empty legacy alt), we follow up with
     ``set_registration_image_alt`` so the snippet they copy reflects what they typed.
     """
-    image = add_registration_image(bootstrap.bootstrap(), current_user.id, assembly_id, raw, alt=alt)
+    image = add_registration_image(
+        bootstrap.bootstrap(), current_user.id, assembly_id, raw, alt=alt, original_filename=original_filename
+    )
     if image.alt != alt:
         image = set_registration_image_alt(bootstrap.bootstrap(), current_user.id, assembly_id, image.id, alt=alt)
     return image
@@ -399,7 +407,7 @@ def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
         return jsonify({"error": _("Alt text is required for accessibility")}), 400
 
     try:
-        image = _add_image_honouring_alt(assembly_id, raw, alt)
+        image = _add_image_honouring_alt(assembly_id, raw, alt, original_filename=upload.filename or "")
     except ImageValidationError as e:
         return jsonify({"error": e.message, "reason": e.reason}), 400
     except ImageQuotaExceeded as e:

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -16,6 +16,7 @@ from opendlp.domain.registration_image import (
     IMAGE_FILE_EXTENSION,
     ImageValidationError,
     RegistrationImage,
+    generate_image_html,
 )
 from opendlp.domain.registration_page import (
     RegistrationPageHtml,
@@ -37,6 +38,7 @@ from opendlp.service_layer.registration_image_service import (
     add_registration_image,
     delete_registration_image,
     list_registration_images,
+    set_registration_image_alt,
 )
 from opendlp.service_layer.registration_page_service import (
     close_registration_page,
@@ -73,7 +75,7 @@ def _image_to_dict(image: RegistrationImage, url_slug: str) -> dict[str, Any]:
         "file_name": file_name,
         "display_name": display_name,
         "public_url": public_url,
-        "img_snippet": f'<img src="{public_url}" alt="{image.alt}">' if public_url else "",
+        "img_snippet": generate_image_html(public_url, alt=image.alt) if public_url else "",
         "width": image.width,
         "height": image.height,
         "byte_size": image.byte_size,
@@ -360,6 +362,20 @@ def _resolve_page_url_slug(assembly_id: uuid.UUID) -> str:
     return result[0].url_slug
 
 
+def _add_image_honouring_alt(assembly_id: uuid.UUID, raw: bytes, alt: str) -> RegistrationImage:
+    """Add an image and, on dedup, ensure the stored alt matches the user's input.
+
+    ``add_registration_image`` collapses identical bytes to one row and KEEPS the
+    first upload's alt. When the user supplies a different alt for an already-stored
+    image (typically replacing an empty legacy alt), we follow up with
+    ``set_registration_image_alt`` so the snippet they copy reflects what they typed.
+    """
+    image = add_registration_image(bootstrap.bootstrap(), current_user.id, assembly_id, raw, alt=alt)
+    if image.alt != alt:
+        image = set_registration_image_alt(bootstrap.bootstrap(), current_user.id, assembly_id, image.id, alt=alt)
+    return image
+
+
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images", methods=["POST"])
 @login_required
 def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
@@ -379,10 +395,11 @@ def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
         return jsonify({"error": _("Failed to read the uploaded file")}), 400
 
     alt = (request.form.get("alt") or "").strip()
+    if not alt:
+        return jsonify({"error": _("Alt text is required for accessibility")}), 400
 
     try:
-        uow = bootstrap.bootstrap()
-        image = add_registration_image(uow, current_user.id, assembly_id, raw, alt=alt)
+        image = _add_image_honouring_alt(assembly_id, raw, alt)
     except ImageValidationError as e:
         return jsonify({"error": e.message, "reason": e.reason}), 400
     except ImageQuotaExceeded as e:
@@ -399,6 +416,33 @@ def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
         return jsonify({"error": _("An error occurred while uploading the image")}), 500
 
     return jsonify({"image": _image_to_dict(image, _resolve_page_url_slug(assembly_id))}), 201
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images/<uuid:image_id>", methods=["PATCH"])
+@login_required
+def update_assembly_registration_image(assembly_id: uuid.UUID, image_id: uuid.UUID) -> ResponseReturnValue:
+    """Update an image's alt text. Returns the updated image metadata as JSON."""
+    data = request.get_json(silent=True) or {}
+    alt = (data.get("alt") or "").strip()
+    if not alt:
+        return jsonify({"error": _("Alt text is required for accessibility")}), 400
+
+    try:
+        uow = bootstrap.bootstrap()
+        image = set_registration_image_alt(uow, current_user.id, assembly_id, image_id, alt=alt)
+    except RegistrationImageNotFoundError:
+        return jsonify({"error": _("Image not found")}), 404
+    except RegistrationPageNotFoundError:
+        return jsonify({"error": _("Registration page not found")}), 404
+    except InsufficientPermissions:
+        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
+    except NotFoundError:
+        return jsonify({"error": _("Assembly not found")}), 404
+    except Exception as e:
+        current_app.logger.error(f"Update image alt error for assembly {assembly_id} image {image_id}: {e}")
+        return jsonify({"error": _("An error occurred while updating the image")}), 500
+
+    return jsonify({"image": _image_to_dict(image, _resolve_page_url_slug(assembly_id))}), 200
 
 
 @backoffice_registration_bp.route(

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -366,24 +366,6 @@ def _resolve_page_url_slug(assembly_id: uuid.UUID) -> str:
     return result[0].url_slug
 
 
-def _add_image_honouring_alt(
-    assembly_id: uuid.UUID, raw: bytes, alt: str, original_filename: str = ""
-) -> RegistrationImage:
-    """Add an image and, on dedup, ensure the stored alt matches the user's input.
-
-    ``add_registration_image`` collapses identical bytes to one row and KEEPS the
-    first upload's alt. When the user supplies a different alt for an already-stored
-    image (typically replacing an empty legacy alt), we follow up with
-    ``set_registration_image_alt`` so the snippet they copy reflects what they typed.
-    """
-    image = add_registration_image(
-        bootstrap.bootstrap(), current_user.id, assembly_id, raw, alt=alt, original_filename=original_filename
-    )
-    if image.alt != alt:
-        image = set_registration_image_alt(bootstrap.bootstrap(), current_user.id, assembly_id, image.id, alt=alt)
-    return image
-
-
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images", methods=["POST"])
 @login_required
 def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
@@ -407,7 +389,9 @@ def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
         return jsonify({"error": _("Alt text is required for accessibility")}), 400
 
     try:
-        image = _add_image_honouring_alt(assembly_id, raw, alt, original_filename=upload.filename or "")
+        image = add_registration_image(
+            bootstrap.bootstrap(), current_user.id, assembly_id, raw, alt=alt, original_filename=upload.filename or ""
+        )
     except ImageValidationError as e:
         return jsonify({"error": e.message, "reason": e.reason}), 400
     except ImageQuotaExceeded as e:

--- a/backend/src/opendlp/entrypoints/blueprints/dev.py
+++ b/backend/src/opendlp/entrypoints/blueprints/dev.py
@@ -878,6 +878,7 @@ def _serialise_image(image: RegistrationImage) -> dict[str, Any]:
         "created_by": str(image.created_by) if image.created_by else None,
         "created_at": image.created_at.isoformat() if image.created_at else None,
         "file_name": f"{image.sha256}.{IMAGE_FILE_EXTENSION}",
+        "original_filename": image.original_filename,
     }
 
 
@@ -889,6 +890,7 @@ def _handle_add_registration_image(uow: Any, params: dict[str, Any]) -> dict[str
     """
     assembly_id = uuid.UUID(params["assembly_id"])
     alt = params.get("alt", "")
+    original_filename = params.get("original_filename", "")
     raw_b64 = params.get("image_base64", "")
     if "," in raw_b64 and raw_b64.startswith("data:"):
         raw_b64 = raw_b64.split(",", 1)[1]
@@ -906,6 +908,7 @@ def _handle_add_registration_image(uow: Any, params: dict[str, Any]) -> dict[str
             assembly_id=assembly_id,
             raw=raw_bytes,
             alt=alt,
+            original_filename=original_filename,
         )
         return {"status": "success", "image": _serialise_image(image)}
     except ImageValidationError as e:

--- a/backend/src/opendlp/entrypoints/blueprints/dev.py
+++ b/backend/src/opendlp/entrypoints/blueprints/dev.py
@@ -1,6 +1,8 @@
 """ABOUTME: Developer tools routes for interactive testing and documentation
 ABOUTME: Provides /backoffice/dev/* routes - only registered in non-production environments"""
 
+import base64
+import binascii
 import uuid
 from collections.abc import Callable
 from typing import Any, cast
@@ -10,6 +12,7 @@ from flask.typing import ResponseReturnValue
 from flask_login import current_user, login_required
 
 from opendlp import bootstrap
+from opendlp.domain.registration_image import IMAGE_FILE_EXTENSION, ImageValidationError, RegistrationImage
 from opendlp.domain.registration_page import RegistrationPageHtml
 from opendlp.domain.respondent_field_schema import (
     ChoiceOption,
@@ -28,8 +31,22 @@ from opendlp.service_layer.assembly_service import (
     update_csv_config,
     update_selection_settings,
 )
-from opendlp.service_layer.exceptions import InsufficientPermissions, InvalidSelection, NotFoundError
+from opendlp.service_layer.exceptions import (
+    ImageQuotaExceeded,
+    InsufficientPermissions,
+    InvalidSelection,
+    NotFoundError,
+    RegistrationImageNotFoundError,
+)
 from opendlp.service_layer.permissions import has_global_admin
+from opendlp.service_layer.registration_image_service import (
+    add_registration_image,
+    delete_registration_image,
+    get_registration_image_for_serving,
+    list_image_snippets,
+    list_registration_images,
+    set_registration_image_alt,
+)
 from opendlp.service_layer.registration_page_service import (
     close_registration_page,
     create_registration_page,
@@ -108,7 +125,7 @@ def service_docs() -> ResponseReturnValue:
 
     # Get active tab from query parameter, default to 'respondents'
     active_tab = request.args.get("tab", "respondents")
-    valid_tabs = ["respondents", "targets", "config", "selection", "assembly", "registration", "fields"]
+    valid_tabs = ["respondents", "targets", "config", "selection", "assembly", "registration", "fields", "images"]
     if active_tab not in valid_tabs:
         active_tab = "respondents"
 
@@ -849,6 +866,171 @@ def _handle_add_field(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
             return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
 
 
+def _serialise_image(image: RegistrationImage) -> dict[str, Any]:
+    return {
+        "id": str(image.id),
+        "registration_page_id": str(image.registration_page_id),
+        "byte_size": image.byte_size,
+        "width": image.width,
+        "height": image.height,
+        "sha256": image.sha256,
+        "alt": image.alt,
+        "created_by": str(image.created_by) if image.created_by else None,
+        "created_at": image.created_at.isoformat() if image.created_at else None,
+        "file_name": f"{image.sha256}.{IMAGE_FILE_EXTENSION}",
+    }
+
+
+def _handle_add_registration_image(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle add_registration_image service call.
+
+    The image bytes are expected as a base64-encoded string under ``image_base64``
+    (a ``data:`` URL prefix is stripped if present).
+    """
+    assembly_id = uuid.UUID(params["assembly_id"])
+    alt = params.get("alt", "")
+    raw_b64 = params.get("image_base64", "")
+    if "," in raw_b64 and raw_b64.startswith("data:"):
+        raw_b64 = raw_b64.split(",", 1)[1]
+    try:
+        raw_bytes = base64.b64decode(raw_b64, validate=True)
+    except (binascii.Error, ValueError):
+        return {"status": "error", "error": "image_base64 is not valid base64", "error_type": "ValidationError"}
+    if not raw_bytes:
+        return {"status": "error", "error": "image_base64 is empty", "error_type": "ValidationError"}
+
+    try:
+        image = add_registration_image(
+            uow=uow,
+            user_id=current_user.id,
+            assembly_id=assembly_id,
+            raw=raw_bytes,
+            alt=alt,
+        )
+        return {"status": "success", "image": _serialise_image(image)}
+    except ImageValidationError as e:
+        return {"status": "error", "error": e.message, "error_type": "ImageValidationError", "reason": e.reason}
+    except ImageQuotaExceeded as e:
+        return {"status": "error", "error": str(e), "error_type": "ImageQuotaExceeded"}
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_list_registration_images(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle list_registration_images service call."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+    try:
+        images = list_registration_images(uow=uow, user_id=current_user.id, assembly_id=assembly_id)
+        return {
+            "status": "success",
+            "total_count": len(images),
+            "images": [_serialise_image(image) for image in images],
+        }
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_delete_registration_image(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle delete_registration_image service call."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+    image_id = uuid.UUID(params["image_id"])
+    try:
+        delete_registration_image(
+            uow=uow,
+            user_id=current_user.id,
+            assembly_id=assembly_id,
+            image_id=image_id,
+        )
+        return {"status": "success", "deleted_image_id": str(image_id)}
+    except RegistrationImageNotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "RegistrationImageNotFoundError"}
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_set_registration_image_alt(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle set_registration_image_alt service call."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+    image_id = uuid.UUID(params["image_id"])
+    alt = params.get("alt", "")
+    try:
+        image = set_registration_image_alt(
+            uow=uow,
+            user_id=current_user.id,
+            assembly_id=assembly_id,
+            image_id=image_id,
+            alt=alt,
+        )
+        return {"status": "success", "image": _serialise_image(image)}
+    except RegistrationImageNotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "RegistrationImageNotFoundError"}
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_list_image_snippets(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle list_image_snippets service call.
+
+    Uses the same URL builder as the public registration route so the snippets
+    show the URL the public page would render.
+    """
+    assembly_id = uuid.UUID(params["assembly_id"])
+
+    page_repo_uow = bootstrap.bootstrap()
+    with page_repo_uow:
+        page = page_repo_uow.registration_pages.get_by_assembly_id(assembly_id)
+    url_slug = page.url_slug if page else ""
+
+    def url_for_image(image: RegistrationImage) -> str:
+        if url_slug:
+            return url_for(
+                "registration.serve_registration_image",
+                url_slug=url_slug,
+                image_name=f"{image.sha256}.{IMAGE_FILE_EXTENSION}",
+            )
+        return f"<no-slug>/{image.sha256}.{IMAGE_FILE_EXTENSION}"
+
+    try:
+        pairs = list_image_snippets(
+            uow=uow,
+            user_id=current_user.id,
+            assembly_id=assembly_id,
+            url_for_image=url_for_image,
+        )
+        return {
+            "status": "success",
+            "total_count": len(pairs),
+            "snippets": [{"image": _serialise_image(image), "html": html_snippet} for image, html_snippet in pairs],
+        }
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_get_registration_image_for_serving(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle get_registration_image_for_serving service call.
+
+    Bytes are not returned in the JSON response - we report metadata and whether
+    the lookup succeeded. Use the public /register/<slug>/assets/<image_name>
+    route to actually fetch the image.
+    """
+    url_slug = params.get("url_slug", "")
+    image_name = params.get("image_name", "")
+    image = get_registration_image_for_serving(uow, url_slug, image_name)
+    if image is None:
+        return {"status": "success", "found": False, "image": None}
+    return {"status": "success", "found": True, "image": _serialise_image(image)}
+
+
 # Mapping of service names to their handler functions
 _SERVICE_HANDLERS: dict[str, Callable[[Any, dict[str, Any]], dict[str, Any]]] = {
     "import_respondents_from_csv": _handle_import_respondents,
@@ -871,6 +1053,12 @@ _SERVICE_HANDLERS: dict[str, Callable[[Any, dict[str, Any]], dict[str, Any]]] = 
     "reopen_registration_page": _handle_reopen_registration_page,
     "submit_registration": _handle_submit_registration,
     "add_field": _handle_add_field,
+    "add_registration_image": _handle_add_registration_image,
+    "list_registration_images": _handle_list_registration_images,
+    "delete_registration_image": _handle_delete_registration_image,
+    "set_registration_image_alt": _handle_set_registration_image_alt,
+    "list_image_snippets": _handle_list_image_snippets,
+    "get_registration_image_for_serving": _handle_get_registration_image_for_serving,
 }
 
 

--- a/backend/src/opendlp/service_layer/registration_image_service.py
+++ b/backend/src/opendlp/service_layer/registration_image_service.py
@@ -10,7 +10,11 @@ from opendlp.config import (
     get_registration_image_max_edge_px,
 )
 from opendlp.domain.assembly import Assembly
-from opendlp.domain.registration_image import RegistrationImage, generate_image_html
+from opendlp.domain.registration_image import (
+    RegistrationImage,
+    generate_image_html,
+    sanitise_original_filename,
+)
 from opendlp.domain.registration_page import RegistrationPage
 from opendlp.domain.users import User
 
@@ -50,7 +54,12 @@ def _load_page(uow: AbstractUnitOfWork, assembly_id: uuid.UUID) -> RegistrationP
 
 
 def add_registration_image(
-    uow: AbstractUnitOfWork, user_id: uuid.UUID, assembly_id: uuid.UUID, raw: bytes, alt: str = ""
+    uow: AbstractUnitOfWork,
+    user_id: uuid.UUID,
+    assembly_id: uuid.UUID,
+    raw: bytes,
+    alt: str = "",
+    original_filename: str = "",
 ) -> RegistrationImage:
     with uow:
         user, assembly = _load_user_and_assembly(uow, user_id, assembly_id)
@@ -64,7 +73,8 @@ def add_registration_image(
             max_edge_px=get_registration_image_max_edge_px(),
         )
         # Content-addressed dedup: identical bytes on a page collapse to one row.
-        # The first upload's alt text is kept; change it via set_registration_image_alt.
+        # The first upload's alt text and original filename are kept; change the alt
+        # via set_registration_image_alt.
         existing = uow.registration_images.get_by_page_and_sha(page.id, processed.sha256)
         if existing is not None:
             return existing.create_detached_copy()
@@ -73,7 +83,13 @@ def add_registration_image(
         if uow.registration_images.count_by_page_id(page.id) >= limit:
             raise ImageQuotaExceeded(limit)
 
-        image = RegistrationImage.from_processed(page.id, processed, created_by=user.id, alt=alt)
+        image = RegistrationImage.from_processed(
+            page.id,
+            processed,
+            created_by=user.id,
+            alt=alt,
+            original_filename=sanitise_original_filename(original_filename),
+        )
         uow.registration_images.add(image)
         page.record_edit(user.id, "Added a registration image")
         uow.commit()

--- a/backend/src/opendlp/service_layer/registration_image_service.py
+++ b/backend/src/opendlp/service_layer/registration_image_service.py
@@ -73,10 +73,13 @@ def add_registration_image(
             max_edge_px=get_registration_image_max_edge_px(),
         )
         # Content-addressed dedup: identical bytes on a page collapse to one row.
-        # The first upload's alt text and original filename are kept; change the alt
-        # via set_registration_image_alt.
+        # The original filename is kept; the caller's alt always wins on re-upload.
         existing = uow.registration_images.get_by_page_and_sha(page.id, processed.sha256)
         if existing is not None:
+            if existing.alt != alt:
+                existing.alt = alt
+                page.record_edit(user.id, "Updated a registration image caption")
+                uow.commit()
             return existing.create_detached_copy()
 
         limit = get_max_images_per_registration_page()

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -141,6 +141,17 @@
         background-color: var(--color-button-danger-bg-hover) !important;
     }
 
+    /* Runtime-disabled look (toggled by Alpine via the button macro's
+       `alpine_disabled` param). Layers on top of the variant's inline style
+       without touching padding/base styles. */
+    .btn-runtime-disabled {
+        background-color: var(--color-disabled-borders) !important;
+        color: var(--color-placeholder-text) !important;
+        border: none !important;
+        cursor: not-allowed !important;
+        opacity: 0.5 !important;
+    }
+
     /* Focus ring for buttons - use browser default outline for keyboard navigation */
     /* The .btn-focus class enables :focus-visible styling (no custom override needed) */
 

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -64,168 +64,255 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </div>
             </div>
         {% else %}
-        {# Registration Configuration Form #}
-            <form method="post"
-                  action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
-                  class="space-y-8"
-                  x-data
-                  x-preserve-scroll-on-submit>
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        {# Editor (form) takes the remaining width on the left, Assets panel is a
+           fixed-width column on the right. The panel sits OUTSIDE the form so
+           uploading or deleting an image never submits the HTML editor — unsaved
+           edits in the textarea are preserved. #}
+            <div class="flex flex-col lg:flex-row gap-6">
+                <div class="flex-1 min-w-0">
+                    <form method="post"
+                          action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
+                          x-data
+                          x-preserve-scroll-on-submit>
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
             {# Registration Form HTML Section #}
-                <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                    <div class="flex items-center justify-between mb-4">
-                        <div class="flex items-center gap-3">
-                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration Form HTML") }}</h2>
+                        <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                            <div class="flex items-center justify-between mb-4">
+                                <div class="flex items-center gap-3">
+                                    <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration Form HTML") }}</h2>
 
                         {# Publication status indicator (tri-state). Wrapped in a fixed-min-width slot so the
                            variable badge width ("Test" / "Published" / "Closed") doesn't shift everything to
                            its right as the status changes. #}
-                            <div class="inline-flex items-center" style="min-width: 7rem;">
-                                {% if registration_status == "PUBLISHED" %}
-                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                          style="background-color: var(--color-success-100); color: var(--color-success-600);">
-                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-success-400);"></span>
-                                        {{ _("Published") }}
-                                    </span>
-                                {% elif registration_status == "CLOSED" %}
-                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                          style="background-color: var(--color-error-100); color: var(--color-error-600);">
-                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-error-400);"></span>
-                                        {{ _("Closed") }}
-                                    </span>
-                                {% else %}
+                                    <div class="inline-flex items-center" style="min-width: 7rem;">
+                                        {% if registration_status == "PUBLISHED" %}
+                                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
+                                                  style="background-color: var(--color-success-100); color: var(--color-success-600);">
+                                                <span class="w-2 h-2 rounded-full" style="background-color: var(--color-success-400);"></span>
+                                                {{ _("Published") }}
+                                            </span>
+                                        {% elif registration_status == "CLOSED" %}
+                                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
+                                                  style="background-color: var(--color-error-100); color: var(--color-error-600);">
+                                                <span class="w-2 h-2 rounded-full" style="background-color: var(--color-error-400);"></span>
+                                                {{ _("Closed") }}
+                                            </span>
+                                        {% else %}
                                 {# TEST status (default) #}
-                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                          style="background-color: var(--color-warning-100); color: var(--color-warning-600);">
-                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-warning-400);"></span>
-                                        {{ _("Test") }}
-                                    </span>
-                                {% endif %}
-                            </div>
+                                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
+                                                  style="background-color: var(--color-warning-100); color: var(--color-warning-600);">
+                                                <span class="w-2 h-2 rounded-full" style="background-color: var(--color-warning-400);"></span>
+                                                {{ _("Test") }}
+                                            </span>
+                                        {% endif %}
+                                    </div>
 
                         {# Change status dropdown — items are named after the TARGET state, with a one-line
                            explanation of what visitors will see. Forbidden jumps (TEST↔CLOSED) are simply
                            absent from the menu. #}
-                            {% if registration_status == "TEST" %}
-                                {% set status_items = [
-                                {
-                                "text": _("Published"),
-                                "description": _("Form goes live; submissions enter the selection pool."),
-                                "dot_color": "var(--color-success-400)",
-                                "attrs": 'name="action" value="publish"'
-                                },
-                                ] %}
-                            {% elif registration_status == "PUBLISHED" %}
-                                {% set status_items = [
-                                {
-                                "text": _("Closed for Submissions"),
-                                "description": _("Visitors are redirected to a registration-closed page; no new submissions are accepted."),
-                                "dot_color": "var(--color-error-400)",
-                                "attrs": 'name="action" value="close"'
-                                },
-                                {
-                                "text": _("Test"),
-                                "description": _("Form stays public, but new submissions are flagged as test entries and skipped from the pool."),
-                                "dot_color": "var(--color-warning-400)",
-                                "attrs": 'name="action" value="unpublish"'
-                                },
-                                ] %}
-                            {% else %}
-                                {% set status_items = [
-                                {
-                                "text": _("Published"),
-                                "description": _("Form goes live again; new submissions enter the selection pool."),
-                                "dot_color": "var(--color-success-400)",
-                                "attrs": 'name="action" value="reopen"'
-                                },
-                                ] %}
-                            {% endif %}
-                            {{ dropdown_button(
-                            label=_("Change status"),
-                            items=status_items,
-                            variant="secondary",
-                            id="status-control",
-                            ) }}
-                        </div>
+                                    {% if registration_status == "TEST" %}
+                                        {% set status_items = [
+                                        {
+                                        "text": _("Published"),
+                                        "description": _("Form goes live; submissions enter the selection pool."),
+                                        "dot_color": "var(--color-success-400)",
+                                        "attrs": 'name="action" value="publish"'
+                                        },
+                                        ] %}
+                                    {% elif registration_status == "PUBLISHED" %}
+                                        {% set status_items = [
+                                        {
+                                        "text": _("Closed for Submissions"),
+                                        "description": _("Visitors are redirected to a registration-closed page; no new submissions are accepted."),
+                                        "dot_color": "var(--color-error-400)",
+                                        "attrs": 'name="action" value="close"'
+                                        },
+                                        {
+                                        "text": _("Test"),
+                                        "description": _("Form stays public, but new submissions are flagged as test entries and skipped from the pool."),
+                                        "dot_color": "var(--color-warning-400)",
+                                        "attrs": 'name="action" value="unpublish"'
+                                        },
+                                        ] %}
+                                    {% else %}
+                                        {% set status_items = [
+                                        {
+                                        "text": _("Published"),
+                                        "description": _("Form goes live again; new submissions enter the selection pool."),
+                                        "dot_color": "var(--color-success-400)",
+                                        "attrs": 'name="action" value="reopen"'
+                                        },
+                                        ] %}
+                                    {% endif %}
+                                    {{ dropdown_button(
+                                    label=_("Change status"),
+                                    items=status_items,
+                                    variant="secondary",
+                                    id="status-control",
+                                    ) }}
+                                </div>
                      {# Header right: editorial helper only (status controls live on the left next to the badge) #}
-                        <div class="flex items-center gap-2">
-                            {% set code_icon %}
+                                <div class="flex items-center gap-2">
+                                    {% set code_icon %}
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                                        </svg>
+                                    {% endset %}
+                                    {{ button(
+                                    _("Show Form Skeleton"),
+                                    variant="tertiary",
+                                    leading_icon=code_icon,
+                                    attrs='@click="fetchSkeleton()" :disabled="skeletonLoading"'
+                                    ) }}
+                                </div>
+                            </div>
+
+                            <div class="space-y-4">
+                                <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                                    {{ _("Paste your HTML form code below. The only required placeholders are {{ form_action }} for the form's action attribute and {{ csrf_form_element }} for CSRF protection.") }}
+                                </p>
+
+                    {# HTML Textarea with monospace font #}
+                                {{ textarea(
+                                name="html_content",
+                                label="",
+                                value=html_content,
+                                placeholder="<form action=\"{{ form_action }}\" method=\"POST\">\n  {{ csrf_form_element }}\n  <div>\n    <label for=\"first_name\">First Name</label>\n    <input type=\"text\" id=\"first_name\" name=\"first_name\" required />\n  </div>\n  <!-- Add more fields here -->\n  <button type=\"submit\">Register</button>\n</form>",
+                                rows=25,
+                                attrs="style=\"font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;\""
+                                ) }}
+
+                    {# Footer: review the form + save edits. Status transitions live in the header dropdown. #}
+                                <div class="flex justify-end gap-3">
+                        {# Preview / Share lives next to Save — "view what you just edited" pairs with "save it" #}
+                                    {% if registration_status == "TEST" %}
+                                        {% set eye_icon %}
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        {% endset %}
+                                        {{ button(
+                                        _("Preview and Test Responses"),
+                                        variant="tertiary",
+                                        leading_icon=eye_icon,
+                                        attrs='@click="openPreviewModal()"'
+                                        ) }}
+                                        {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                    {% else %}
+                                        {% set link_icon %}
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                                            </svg>
+                                        {% endset %}
+                                        {% if registration_status == "PUBLISHED" %}
+                                            {{ button(
+                                            _("Share Form"),
+                                            variant="tertiary",
+                                            leading_icon=link_icon,
+                                            attrs='@click="openPreviewModal()"'
+                                            ) }}
+                                            {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                        {% else %}
+                                {# CLOSED: no save (form is redirecting), but keep Share Form visible-but-disabled so the user can see why #}
+                                            {{ button(
+                                            _("Share Form"),
+                                            variant="tertiary",
+                                            leading_icon=link_icon,
+                                            disabled=true,
+                                            aria_label=_("Registration is closed — the form URL redirects to the closed page"),
+                                            attrs='title="' ~ _("Registration is closed — the form URL redirects to the closed page") ~ '"'
+                                            ) }}
+                                        {% endif %}
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </section>
+                    </form>
+                </div>
+
+            {# Assets panel (image library). Lives outside the editor form so its
+               buttons never submit the HTML editor. Initial list is rendered
+               server-side; uploads/deletes mutate the Alpine `images` array in
+               place, no page reload required. #}
+                <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
+                    <section class="rounded-lg p-6 sticky top-4 w-full"
+                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                        <div class="flex items-center justify-between mb-4">
+                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
+                            {% set upload_icon %}
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
                                 </svg>
                             {% endset %}
                             {{ button(
-                            _("Show Form Skeleton"),
+                            _("Upload"),
                             variant="tertiary",
-                            leading_icon=code_icon,
-                            attrs='@click="fetchSkeleton()" :disabled="skeletonLoading"'
+                            leading_icon=upload_icon,
+                            attrs='type="button" @click="openImageUploadModal()"'
                             ) }}
                         </div>
-                    </div>
 
-                    <div class="space-y-4">
-                        <p class="text-body-sm" style="color: var(--color-secondary-text);">
-                            {{ _("Paste your HTML form code below. The only required placeholders are {{ form_action }} for the form's action attribute and {{ csrf_form_element }} for CSRF protection.") }}
-                        </p>
-
-                    {# HTML Textarea with monospace font #}
-                        {{ textarea(
-                        name="html_content",
-                        label="",
-                        value=html_content,
-                        placeholder="<form action=\"{{ form_action }}\" method=\"POST\">\n  {{ csrf_form_element }}\n  <div>\n    <label for=\"first_name\">First Name</label>\n    <input type=\"text\" id=\"first_name\" name=\"first_name\" required />\n  </div>\n  <!-- Add more fields here -->\n  <button type=\"submit\">Register</button>\n</form>",
-                        rows=25,
-                        attrs="style=\"font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;\""
-                        ) }}
-
-                    {# Footer: review the form + save edits. Status transitions live in the header dropdown. #}
-                        <div class="flex justify-end gap-3">
-                        {# Preview / Share lives next to Save — "view what you just edited" pairs with "save it" #}
-                            {% if registration_status == "TEST" %}
-                                {% set eye_icon %}
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                                    </svg>
-                                {% endset %}
-                                {{ button(
-                                _("Preview and Test Responses"),
-                                variant="tertiary",
-                                leading_icon=eye_icon,
-                                attrs='@click="openPreviewModal()"'
-                                ) }}
-                                {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
-                            {% else %}
-                                {% set link_icon %}
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                                    </svg>
-                                {% endset %}
-                                {% if registration_status == "PUBLISHED" %}
-                                    {{ button(
-                                    _("Share Form"),
-                                    variant="tertiary",
-                                    leading_icon=link_icon,
-                                    attrs='@click="openPreviewModal()"'
-                                    ) }}
-                                    {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
-                                {% else %}
-                                {# CLOSED: no save (form is redirecting), but keep Share Form visible-but-disabled so the user can see why #}
-                                    {{ button(
-                                    _("Share Form"),
-                                    variant="tertiary",
-                                    leading_icon=link_icon,
-                                    disabled=true,
-                                    aria_label=_("Registration is closed — the form URL redirects to the closed page"),
-                                    attrs='title="' ~ _("Registration is closed — the form URL redirects to the closed page") ~ '"'
-                                    ) }}
-                                {% endif %}
-                            {% endif %}
+                    {# Format / size hint #}
+                        <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
+                             style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                            <p class="text-body-sm" style="color: var(--color-info-700);">
+                                {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
+                            </p>
                         </div>
-                    </div>
-                </section>
-            </form>
+
+                    {# Empty state #}
+                        <template x-if="!images.length">
+                            <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
+                                {{ _("No images uploaded yet.") }}
+                            </p>
+                        </template>
+
+                    {# Image list #}
+                        <ul class="space-y-2" x-show="images.length" x-cloak>
+                            <template x-for="image in images" :key="image.id">
+                                <li class="rounded-md px-3 py-2 flex items-center justify-between"
+                                    style="background-color: var(--color-subtle-background-panels);">
+                                    <a :href="image.public_url"
+                                       :title="image.alt || image.file_name"
+                                       target="_blank"
+                                       rel="noopener"
+                                       class="text-body-sm truncate flex-1 mr-2"
+                                       style="color: var(--color-body-text);"
+                                       x-text="image.display_name"></a>
+                                    <div class="flex items-center gap-1 flex-shrink-0">
+                                    {# Copy <img> snippet to clipboard #}
+                                        <button type="button"
+                                                @click="copyImageSnippet(image)"
+                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                style="color: var(--color-secondary-text);"
+                                                :aria-label="'{{ _('Copy <img> snippet for') }} ' + image.display_name">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                            </svg>
+                                        </button>
+                                    {# Delete #}
+                                        <button type="button"
+                                                @click="deleteImage(image)"
+                                                :disabled="imageBeingDeletedId === image.id"
+                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                style="color: var(--color-secondary-text);"
+                                                :aria-label="'{{ _('Delete') }} ' + image.display_name">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </li>
+                            </template>
+                        </ul>
+                    </section>
+                </aside>
+            </div>
         {% endif %}
 
         {# Form Skeleton Modal - only shown when registration page exists #}
@@ -397,6 +484,95 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </template>
             {% endif %}
 
+        {# Image Upload Modal #}
+            <template x-if="imageUploadModalOpen">
+                <div x-cloak>
+                {# Backdrop overlay #}
+                    <div class="fixed inset-0 z-40"
+                         style="background-color: rgba(0, 0, 0, 0.5)"
+                         @click="closeImageUploadModalIfAllowed()"
+                         @keydown.escape.window="closeImageUploadModalIfAllowed()"></div>
+                {# Modal panel #}
+                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                         role="dialog"
+                         aria-modal="true"
+                         aria-labelledby="image-upload-modal-title">
+                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
+                             @click.stop>
+                        {# Header #}
+                            <div class="px-6 py-4 flex items-center justify-between"
+                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                <h2 id="image-upload-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                                    {{ _("Upload image") }}
+                                </h2>
+                                <button type="button"
+                                        @click="closeImageUploadModalIfAllowed()"
+                                        :disabled="imageUploading"
+                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
+                                        style="color: var(--color-secondary-text);"
+                                        aria-label="{{ _('Close') }}">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                    </svg>
+                                </button>
+                            </div>
+                        {# Content #}
+                            <div class="px-6 py-4">
+                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                    {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. Files are downscaled and re-encoded to PNG on upload.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
+                                </p>
+
+                                <div class="space-y-4">
+                                    <div>
+                                        <label for="image-upload-file" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                                            {{ _("Image file") }}
+                                        </label>
+                                        <input type="file"
+                                               id="image-upload-file"
+                                               x-ref="imageFileInput"
+                                               accept="image/png,image/jpeg,image/webp"
+                                               @change="onImageFileSelected($event)"
+                                               :disabled="imageUploading"
+                                               class="w-full px-3 py-2 rounded-md text-body-sm"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        <p x-show="imageFileName" x-cloak class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                            <span x-text="imageFileName"></span>
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <label for="image-upload-alt" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                                            {{ _("Alt text") }}
+                                            <span class="font-normal" style="color: var(--color-secondary-text);">({{ _("optional") }})</span>
+                                        </label>
+                                        <input type="text"
+                                               id="image-upload-alt"
+                                               x-model="imageAlt"
+                                               :disabled="imageUploading"
+                                               class="w-full px-3 py-2 rounded-md text-body-sm"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                            {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
+                                        </p>
+                                    </div>
+                                {# Inline error #}
+                                    <div x-show="imageUploadError" x-cloak class="rounded-md p-3"
+                                         style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
+                                        <p class="text-body-sm" style="color: var(--color-error-600);" x-text="imageUploadError"></p>
+                                    </div>
+                                </div>
+                            </div>
+                        {# Footer #}
+                            <div class="px-6 py-3 flex gap-2 justify-end"
+                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageUploadModalIfAllowed()" :disabled="imageUploading"') }}
+                                {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitImageUpload()" :disabled="!imageFile || imageUploading"') }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
         {# Toast notification #}
             <div x-cloak
                  x-show="toastVisible"
@@ -424,6 +600,17 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     toastVisible: false,
                     toastMessage: '',
                     toastType: 'success',
+
+                    // Assets panel state. `images` is seeded from server-side render and mutated in place
+                    // so the page never reloads — uncommitted edits in the HTML editor survive.
+                    images: {{ images|tojson }},
+                    imageUploadModalOpen: false,
+                    imageUploading: false,
+                    imageFile: null,
+                    imageFileName: '',
+                    imageAlt: '',
+                    imageUploadError: '',
+                    imageBeingDeletedId: '',
 
                     fetchSkeleton() {
                         this.skeletonLoading = true;
@@ -478,6 +665,102 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         setTimeout(() => {
                             this.toastVisible = false;
                         }, 3000);
+                    },
+
+                    openImageUploadModal() {
+                        this.imageFile = null;
+                        this.imageFileName = '';
+                        this.imageAlt = '';
+                        this.imageUploadError = '';
+                        this.imageUploadModalOpen = true;
+                    },
+
+                    closeImageUploadModalIfAllowed() {
+                        if (this.imageUploading) return;
+                        this.imageUploadModalOpen = false;
+                    },
+
+                    onImageFileSelected(event) {
+                        const file = event.target.files && event.target.files[0];
+                        this.imageFile = file || null;
+                        this.imageFileName = file ? file.name : '';
+                        this.imageUploadError = '';
+                    },
+
+                    submitImageUpload() {
+                        if (!this.imageFile || this.imageUploading) return;
+                        this.imageUploading = true;
+                        this.imageUploadError = '';
+                        const formData = new FormData();
+                        formData.append('image', this.imageFile);
+                        formData.append('alt', this.imageAlt);
+                        fetch('{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}', {
+                            method: 'POST',
+                            headers: {
+                                'X-CSRFToken': '{{ csrf_token() }}'
+                            },
+                            body: formData
+                        })
+                            .then(async (response) => {
+                                const data = await response.json().catch(() => ({}));
+                                if (!response.ok) {
+                                    this.imageUploadError = data.error || '{{ _("Upload failed") }}';
+                                    return;
+                                }
+                                // Dedup against existing list (server returns the existing row when bytes match)
+                                const existing = this.images.findIndex(img => img.id === data.image.id);
+                                if (existing >= 0) {
+                                    this.images.splice(existing, 1, data.image);
+                                } else {
+                                    this.images.push(data.image);
+                                }
+                                this.imageUploadModalOpen = false;
+                                this.showToast('{{ _("Image uploaded") }}', 'success');
+                            })
+                            .catch(() => {
+                                this.imageUploadError = '{{ _("Network error while uploading the image") }}';
+                            })
+                            .finally(() => {
+                                this.imageUploading = false;
+                            });
+                    },
+
+                    deleteImage(image) {
+                        if (!image || this.imageBeingDeletedId) return;
+                        if (!confirm('{{ _("Delete this image?") }} ' + (image.display_name || ''))) return;
+                        this.imageBeingDeletedId = image.id;
+                        const url = '{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}/' + encodeURIComponent(image.id);
+                        fetch(url, {
+                            method: 'DELETE',
+                            headers: {
+                                'X-CSRFToken': '{{ csrf_token() }}'
+                            }
+                        })
+                            .then(async (response) => {
+                                if (!response.ok) {
+                                    const data = await response.json().catch(() => ({}));
+                                    this.showToast(data.error || '{{ _("Failed to delete image") }}', 'error');
+                                    return;
+                                }
+                                this.images = this.images.filter(img => img.id !== image.id);
+                                this.showToast('{{ _("Image deleted") }}', 'success');
+                            })
+                            .catch(() => {
+                                this.showToast('{{ _("Network error while deleting the image") }}', 'error');
+                            })
+                            .finally(() => {
+                                this.imageBeingDeletedId = '';
+                            });
+                    },
+
+                    copyImageSnippet(image) {
+                        if (!image || !image.img_snippet) {
+                            this.showToast('{{ _("No public URL available yet") }}', 'error');
+                            return;
+                        }
+                        navigator.clipboard.writeText(image.img_snippet)
+                            .then(() => this.showToast('{{ _("Snippet copied to clipboard") }}', 'success'))
+                            .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
                     }
                 }));
             });

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -703,6 +703,18 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     // Assets panel state. `images` is seeded from server-side render and mutated in place
                     // so the page never reloads — uncommitted edits in the HTML editor survive.
                     images: {{ images|tojson }},
+                    // URL contract: the upload endpoint is its own POST URL; the per-image
+                    // PATCH/DELETE URL is rendered once via url_for with a sentinel UUID,
+                    // and imageItemUrl() swaps in the real id at call time. This keeps the
+                    // route-name dependency explicit instead of implying the URL hierarchy.
+                    uploadImageUrl: '{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}',
+                    imageItemUrlTemplate: '{{ url_for("backoffice_registration.update_assembly_registration_image", assembly_id=assembly.id, image_id="00000000-0000-0000-0000-000000000000") }}',
+                    imageItemUrl(id) {
+                        return this.imageItemUrlTemplate.replace(
+                            '00000000-0000-0000-0000-000000000000',
+                            encodeURIComponent(id),
+                        );
+                    },
                     imageUploadModalOpen: false,
                     imageUploading: false,
                     imageFile: null,
@@ -804,7 +816,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         const formData = new FormData();
                         formData.append('image', this.imageFile);
                         formData.append('alt', alt);
-                        fetch('{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}', {
+                        fetch(this.uploadImageUrl, {
                             method: 'POST',
                             headers: {
                                 'X-CSRFToken': '{{ csrf_token() }}'
@@ -839,8 +851,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         if (!image || this.imageBeingDeletedId) return;
                         if (!confirm('{{ _("Delete this image?") }} ' + (image.display_name || ''))) return;
                         this.imageBeingDeletedId = image.id;
-                        const url = '{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}/' + encodeURIComponent(image.id);
-                        fetch(url, {
+                        fetch(this.imageItemUrl(image.id), {
                             method: 'DELETE',
                             headers: {
                                 'X-CSRFToken': '{{ csrf_token() }}'
@@ -898,8 +909,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         }
                         this.imageEditing = true;
                         this.imageEditError = '';
-                        const url = '{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}/' + encodeURIComponent(this.editingImage.id);
-                        fetch(url, {
+                        fetch(this.imageItemUrl(this.editingImage.id), {
                             method: 'PATCH',
                             headers: {
                                 'Content-Type': 'application/json',

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -623,7 +623,21 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 <div class="rounded-md p-3 mb-4 grid grid-cols-3 gap-y-1 gap-x-3 text-body-sm"
                                      style="background-color: var(--color-subtle-background-panels);">
                                     <span class="font-medium" style="color: var(--color-headings);">{{ _("File name") }}</span>
-                                    <span class="col-span-2 font-mono truncate" style="color: var(--color-body-text);" x-text="editingImage.file_name"></span>
+                                    <span class="col-span-2 font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.file_name" x-text="editingImage.file_name"></span>
+
+                                    <template x-if="editingImage.original_filename">
+                                        <span class="contents">
+                                            <span class="font-medium" style="color: var(--color-headings);">{{ _("Original filename") }}</span>
+                                            <span class="col-span-2 font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.original_filename" x-text="editingImage.original_filename"></span>
+                                        </span>
+                                    </template>
+
+                                    <template x-if="editingImage.public_url">
+                                        <span class="contents">
+                                            <span class="font-medium" style="color: var(--color-headings);">{{ _("URL") }}</span>
+                                            <span class="col-span-2 font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.public_url" x-text="editingImage.public_url"></span>
+                                        </span>
+                                    </template>
 
                                     <span class="font-medium" style="color: var(--color-headings);">{{ _("Dimensions") }}</span>
                                     <span class="col-span-2" style="color: var(--color-body-text);">

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -636,6 +636,13 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     </div>
                                     <div class="flex-1 min-w-0 grid gap-y-1 gap-x-3 text-body-sm content-center"
                                          style="grid-template-columns: auto 1fr;">
+                                        <template x-if="editingImage.original_filename">
+                                            <span class="contents">
+                                                <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("Original filename") }}</span>
+                                                <span class="min-w-0 truncate font-mono" style="color: var(--color-body-text);" :title="editingImage.original_filename" x-text="editingImage.original_filename"></span>
+                                            </span>
+                                        </template>
+
                                         <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("Dimensions") }}</span>
                                         <span class="min-w-0" style="color: var(--color-body-text);">
                                             <span x-text="editingImage.width"></span>
@@ -667,31 +674,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                 class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
                                                 style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
                                                 aria-label="{{ _('Copy file name') }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-
-                            {# Original filename (read-only + copy) — hidden when not stored (older uploads) #}
-                                <div class="mb-3" x-show="editingImage.original_filename">
-                                    <label for="image-details-original-filename" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
-                                        {{ _("Original filename") }}
-                                    </label>
-                                    <div class="flex gap-2">
-                                        <input type="text"
-                                               id="image-details-original-filename"
-                                               readonly
-                                               :value="editingImage.original_filename || ''"
-                                               @click="$event.target.select()"
-                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
-                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
-                                        <button type="button"
-                                                @click="copyToClipboard(editingImage.original_filename, '{{ _('Original filename copied to clipboard') }}')"
-                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
-                                                aria-label="{{ _('Copy original filename') }}">
                                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                                             </svg>

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -674,6 +674,31 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     </div>
                                 </div>
 
+                            {# Original filename (read-only + copy) — hidden when not stored (older uploads) #}
+                                <div class="mb-3" x-show="editingImage.original_filename">
+                                    <label for="image-details-original-filename" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                                        {{ _("Original filename") }}
+                                    </label>
+                                    <div class="flex gap-2">
+                                        <input type="text"
+                                               id="image-details-original-filename"
+                                               readonly
+                                               :value="editingImage.original_filename || ''"
+                                               @click="$event.target.select()"
+                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        <button type="button"
+                                                @click="copyToClipboard(editingImage.original_filename, '{{ _('Original filename copied to clipboard') }}')"
+                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                                aria-label="{{ _('Copy original filename') }}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+
                             {# <img> snippet (read-only + copy) — hidden when there's no public URL yet #}
                                 <div class="mb-3" x-show="editingImage.img_snippet">
                                     <label for="image-details-snippet" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -637,6 +637,15 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             <span class="font-medium" style="color: var(--color-headings);">{{ _("URL") }}</span>
                                             <span class="col-span-2 flex items-center gap-1 min-w-0">
                                                 <span class="font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.public_url" x-text="editingImage.public_url"></span>
+                                                <button type="button"
+                                                        @click="copyImageUrl(editingImage)"
+                                                        class="shrink-0 p-1 rounded-md transition-colors hover:bg-gray-100"
+                                                        style="color: var(--color-secondary-text);"
+                                                        :aria-label="'{{ _('Copy URL to clipboard') }}'">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                    </svg>
+                                                </button>
                                                 <a :href="editingImage.public_url"
                                                    target="_blank"
                                                    rel="noopener noreferrer"
@@ -907,6 +916,16 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         }
                         navigator.clipboard.writeText(image.img_snippet)
                             .then(() => this.showToast('{{ _("Snippet copied to clipboard") }}', 'success'))
+                            .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
+                    },
+
+                    copyImageUrl(image) {
+                        if (!image || !image.public_url) {
+                            this.showToast('{{ _("No public URL available yet") }}', 'error');
+                            return;
+                        }
+                        navigator.clipboard.writeText(image.public_url)
+                            .then(() => this.showToast('{{ _("URL copied to clipboard") }}', 'success'))
                             .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
                     },
 

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -635,7 +635,19 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     <template x-if="editingImage.public_url">
                                         <span class="contents">
                                             <span class="font-medium" style="color: var(--color-headings);">{{ _("URL") }}</span>
-                                            <span class="col-span-2 font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.public_url" x-text="editingImage.public_url"></span>
+                                            <span class="col-span-2 flex items-center gap-1 min-w-0">
+                                                <span class="font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.public_url" x-text="editingImage.public_url"></span>
+                                                <a :href="editingImage.public_url"
+                                                   target="_blank"
+                                                   rel="noopener noreferrer"
+                                                   class="shrink-0 p-1 rounded-md transition-colors hover:bg-gray-100"
+                                                   style="color: var(--color-secondary-text);"
+                                                   :aria-label="'{{ _('Open image in new tab') }}'">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                                    </svg>
+                                                </a>
+                                            </span>
                                         </span>
                                     </template>
 

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -285,6 +285,16 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                        style="color: var(--color-body-text);"
                                        x-text="image.display_name"></a>
                                     <div class="flex items-center gap-1 flex-shrink-0">
+                                    {# Image details / edit alt text #}
+                                        <button type="button"
+                                                @click="openImageDetailsModal(image)"
+                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                style="color: var(--color-secondary-text);"
+                                                :aria-label="'{{ _('Details for') }} ' + image.display_name">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                            </svg>
+                                        </button>
                                     {# Copy <img> snippet to clipboard #}
                                         <button type="button"
                                                 @click="copyImageSnippet(image)"
@@ -543,12 +553,14 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     <div>
                                         <label for="image-upload-alt" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
                                             {{ _("Alt text") }}
-                                            <span class="font-normal" style="color: var(--color-secondary-text);">({{ _("optional") }})</span>
+                                            <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
                                         </label>
                                         <input type="text"
                                                id="image-upload-alt"
                                                x-model="imageAlt"
                                                :disabled="imageUploading"
+                                               required
+                                               aria-required="true"
                                                class="w-full px-3 py-2 rounded-md text-body-sm"
                                                style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
                                         <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
@@ -565,8 +577,95 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         {# Footer #}
                             <div class="px-6 py-3 flex gap-2 justify-end"
                                  style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
-                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageUploadModalIfAllowed()" :disabled="imageUploading"') }}
-                                {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitImageUpload()" :disabled="!imageFile || imageUploading"') }}
+                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageUploadModalIfAllowed()"', alpine_disabled="imageUploading") }}
+                                {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitImageUpload()"', alpine_disabled="!imageFile || !imageAlt.trim() || imageUploading") }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
+        {# Image Details / Edit Alt Modal #}
+            <template x-if="imageDetailsModalOpen && editingImage">
+                <div x-cloak>
+                {# Backdrop overlay #}
+                    <div class="fixed inset-0 z-40"
+                         style="background-color: rgba(0, 0, 0, 0.5)"
+                         @click="closeImageDetailsModalIfAllowed()"
+                         @keydown.escape.window="closeImageDetailsModalIfAllowed()"></div>
+                {# Modal panel #}
+                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                         role="dialog"
+                         aria-modal="true"
+                         aria-labelledby="image-details-modal-title">
+                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
+                             @click.stop>
+                        {# Header #}
+                            <div class="px-6 py-4 flex items-center justify-between"
+                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                <h2 id="image-details-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                                    {{ _("Image details") }}
+                                </h2>
+                                <button type="button"
+                                        @click="closeImageDetailsModalIfAllowed()"
+                                        :disabled="imageEditing"
+                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
+                                        style="color: var(--color-secondary-text);"
+                                        aria-label="{{ _('Close') }}">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                    </svg>
+                                </button>
+                            </div>
+                        {# Content #}
+                            <div class="px-6 py-4">
+                                <div class="rounded-md p-3 mb-4 grid grid-cols-3 gap-y-1 gap-x-3 text-body-sm"
+                                     style="background-color: var(--color-subtle-background-panels);">
+                                    <span class="font-medium" style="color: var(--color-headings);">{{ _("File name") }}</span>
+                                    <span class="col-span-2 font-mono truncate" style="color: var(--color-body-text);" x-text="editingImage.file_name"></span>
+
+                                    <span class="font-medium" style="color: var(--color-headings);">{{ _("Dimensions") }}</span>
+                                    <span class="col-span-2" style="color: var(--color-body-text);">
+                                        <span x-text="editingImage.width"></span>
+                                        ×
+                                        <span x-text="editingImage.height"></span>
+                                        {{ _("px") }}
+                                    </span>
+
+                                    <span class="font-medium" style="color: var(--color-headings);">{{ _("File size") }}</span>
+                                    <span class="col-span-2" style="color: var(--color-body-text);" x-text="formatBytes(editingImage.byte_size)"></span>
+                                </div>
+
+                                <div>
+                                    <label for="image-edit-alt" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                                        {{ _("Alt text") }}
+                                        <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
+                                    </label>
+                                    <input type="text"
+                                           id="image-edit-alt"
+                                           x-model="editingImageAlt"
+                                           :disabled="imageEditing"
+                                           required
+                                           aria-required="true"
+                                           class="w-full px-3 py-2 rounded-md text-body-sm"
+                                           style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                    <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                        {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
+                                    </p>
+                                </div>
+
+                            {# Inline error #}
+                                <div x-show="imageEditError" x-cloak class="rounded-md p-3 mt-3"
+                                     style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
+                                    <p class="text-body-sm" style="color: var(--color-error-600);" x-text="imageEditError"></p>
+                                </div>
+                            </div>
+                        {# Footer #}
+                            <div class="px-6 py-3 flex gap-2 justify-end"
+                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageDetailsModalIfAllowed()"', alpine_disabled="imageEditing") }}
+                                {{ button(_("Save"), variant="primary", attrs='type="button" @click="submitImageEdit()"', alpine_disabled="!editingImageAlt.trim() || imageEditing") }}
                             </div>
                         </div>
                     </div>
@@ -611,6 +710,12 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     imageAlt: '',
                     imageUploadError: '',
                     imageBeingDeletedId: '',
+                    // Image details / edit-alt modal
+                    imageDetailsModalOpen: false,
+                    editingImage: null,
+                    editingImageAlt: '',
+                    imageEditing: false,
+                    imageEditError: '',
 
                     fetchSkeleton() {
                         this.skeletonLoading = true;
@@ -689,11 +794,16 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                     submitImageUpload() {
                         if (!this.imageFile || this.imageUploading) return;
+                        const alt = this.imageAlt.trim();
+                        if (!alt) {
+                            this.imageUploadError = '{{ _("Alt text is required for accessibility") }}';
+                            return;
+                        }
                         this.imageUploading = true;
                         this.imageUploadError = '';
                         const formData = new FormData();
                         formData.append('image', this.imageFile);
-                        formData.append('alt', this.imageAlt);
+                        formData.append('alt', alt);
                         fetch('{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}', {
                             method: 'POST',
                             headers: {
@@ -761,6 +871,68 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         navigator.clipboard.writeText(image.img_snippet)
                             .then(() => this.showToast('{{ _("Snippet copied to clipboard") }}', 'success'))
                             .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
+                    },
+
+                    openImageDetailsModal(image) {
+                        if (!image) return;
+                        this.editingImage = image;
+                        this.editingImageAlt = image.alt || '';
+                        this.imageEditError = '';
+                        this.imageDetailsModalOpen = true;
+                    },
+
+                    closeImageDetailsModalIfAllowed() {
+                        if (this.imageEditing) return;
+                        this.imageDetailsModalOpen = false;
+                        this.editingImage = null;
+                        this.editingImageAlt = '';
+                        this.imageEditError = '';
+                    },
+
+                    submitImageEdit() {
+                        if (!this.editingImage || this.imageEditing) return;
+                        const alt = this.editingImageAlt.trim();
+                        if (!alt) {
+                            this.imageEditError = '{{ _("Alt text is required for accessibility") }}';
+                            return;
+                        }
+                        this.imageEditing = true;
+                        this.imageEditError = '';
+                        const url = '{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}/' + encodeURIComponent(this.editingImage.id);
+                        fetch(url, {
+                            method: 'PATCH',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRFToken': '{{ csrf_token() }}'
+                            },
+                            body: JSON.stringify({ alt: alt })
+                        })
+                            .then(async (response) => {
+                                const data = await response.json().catch(() => ({}));
+                                if (!response.ok) {
+                                    this.imageEditError = data.error || '{{ _("Failed to update image") }}';
+                                    return;
+                                }
+                                const idx = this.images.findIndex(img => img.id === data.image.id);
+                                if (idx >= 0) this.images.splice(idx, 1, data.image);
+                                this.imageDetailsModalOpen = false;
+                                this.editingImage = null;
+                                this.editingImageAlt = '';
+                                this.showToast('{{ _("Image updated") }}', 'success');
+                            })
+                            .catch(() => {
+                                this.imageEditError = '{{ _("Network error while updating the image") }}';
+                            })
+                            .finally(() => {
+                                this.imageEditing = false;
+                            });
+                    },
+
+                    formatBytes(bytes) {
+                        if (!Number.isFinite(bytes)) return '';
+                        if (bytes < 1024) return bytes + ' B';
+                        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+                        return (bytes / 1024 / 1024).toFixed(2) + ' MB';
                     }
                 }));
             });

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -620,56 +620,83 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             </div>
                         {# Content #}
                             <div class="px-6 py-4">
-                                <div class="rounded-md p-3 mb-4 grid grid-cols-3 gap-y-1 gap-x-3 text-body-sm"
+                            {# Thumbnail + compact metadata #}
+                                <div class="rounded-md p-3 mb-4 flex gap-3"
                                      style="background-color: var(--color-subtle-background-panels);">
-                                    <span class="font-medium" style="color: var(--color-headings);">{{ _("File name") }}</span>
-                                    <span class="col-span-2 font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.file_name" x-text="editingImage.file_name"></span>
-
-                                    <template x-if="editingImage.original_filename">
-                                        <span class="contents">
-                                            <span class="font-medium" style="color: var(--color-headings);">{{ _("Original filename") }}</span>
-                                            <span class="col-span-2 font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.original_filename" x-text="editingImage.original_filename"></span>
+                                    <div class="flex-shrink-0 w-16 h-16 rounded-md overflow-hidden flex items-center justify-center"
+                                         style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers);">
+                                        <template x-if="editingImage.public_url">
+                                            <img :src="editingImage.public_url"
+                                                 :alt="editingImage.alt || ''"
+                                                 class="max-w-full max-h-full object-contain" />
+                                        </template>
+                                        <template x-if="!editingImage.public_url">
+                                            <span class="text-body-sm text-center px-1 leading-tight" style="color: var(--color-placeholder-text);">{{ _("No preview") }}</span>
+                                        </template>
+                                    </div>
+                                    <div class="flex-1 min-w-0 grid gap-y-1 gap-x-3 text-body-sm content-center"
+                                         style="grid-template-columns: auto 1fr;">
+                                        <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("Dimensions") }}</span>
+                                        <span class="min-w-0" style="color: var(--color-body-text);">
+                                            <span x-text="editingImage.width"></span>
+                                            ×
+                                            <span x-text="editingImage.height"></span>
+                                            {{ _("px") }}
                                         </span>
-                                    </template>
 
-                                    <template x-if="editingImage.public_url">
-                                        <span class="contents">
-                                            <span class="font-medium" style="color: var(--color-headings);">{{ _("URL") }}</span>
-                                            <span class="col-span-2 flex items-center gap-1 min-w-0">
-                                                <span class="font-mono truncate" style="color: var(--color-body-text);" :title="editingImage.public_url" x-text="editingImage.public_url"></span>
-                                                <button type="button"
-                                                        @click="copyImageUrl(editingImage)"
-                                                        class="shrink-0 p-1 rounded-md transition-colors hover:bg-gray-100"
-                                                        style="color: var(--color-secondary-text);"
-                                                        :aria-label="'{{ _('Copy URL to clipboard') }}'">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                    </svg>
-                                                </button>
-                                                <a :href="editingImage.public_url"
-                                                   target="_blank"
-                                                   rel="noopener noreferrer"
-                                                   class="shrink-0 p-1 rounded-md transition-colors hover:bg-gray-100"
-                                                   style="color: var(--color-secondary-text);"
-                                                   :aria-label="'{{ _('Open image in new tab') }}'">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                                                    </svg>
-                                                </a>
-                                            </span>
-                                        </span>
-                                    </template>
+                                        <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("File size") }}</span>
+                                        <span class="min-w-0" style="color: var(--color-body-text);" x-text="formatBytes(editingImage.byte_size)"></span>
+                                    </div>
+                                </div>
 
-                                    <span class="font-medium" style="color: var(--color-headings);">{{ _("Dimensions") }}</span>
-                                    <span class="col-span-2" style="color: var(--color-body-text);">
-                                        <span x-text="editingImage.width"></span>
-                                        ×
-                                        <span x-text="editingImage.height"></span>
-                                        {{ _("px") }}
-                                    </span>
+                            {# File name (read-only + copy) #}
+                                <div class="mb-3">
+                                    <label for="image-details-filename" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                                        {{ _("File name") }}
+                                    </label>
+                                    <div class="flex gap-2">
+                                        <input type="text"
+                                               id="image-details-filename"
+                                               readonly
+                                               :value="editingImage.file_name"
+                                               @click="$event.target.select()"
+                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        <button type="button"
+                                                @click="copyToClipboard(editingImage.file_name, '{{ _('File name copied to clipboard') }}')"
+                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                                aria-label="{{ _('Copy file name') }}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
 
-                                    <span class="font-medium" style="color: var(--color-headings);">{{ _("File size") }}</span>
-                                    <span class="col-span-2" style="color: var(--color-body-text);" x-text="formatBytes(editingImage.byte_size)"></span>
+                            {# <img> snippet (read-only + copy) — hidden when there's no public URL yet #}
+                                <div class="mb-3" x-show="editingImage.img_snippet">
+                                    <label for="image-details-snippet" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                                        {{ _("Image snippet") }}
+                                    </label>
+                                    <div class="flex gap-2">
+                                        <input type="text"
+                                               id="image-details-snippet"
+                                               readonly
+                                               :value="editingImage.img_snippet"
+                                               @click="$event.target.select()"
+                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        <button type="button"
+                                                @click="copyImageSnippet(editingImage)"
+                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                                aria-label="{{ _('Copy image snippet') }}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                            </svg>
+                                        </button>
+                                    </div>
                                 </div>
 
                                 <div>
@@ -697,10 +724,13 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 </div>
                             </div>
                         {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-end"
+                            <div class="px-6 py-3 flex gap-2 justify-between items-center"
                                  style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
-                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageDetailsModalIfAllowed()"', alpine_disabled="imageEditing") }}
-                                {{ button(_("Save"), variant="primary", attrs='type="button" @click="submitImageEdit()"', alpine_disabled="!editingImageAlt.trim() || imageEditing") }}
+                                {{ button(_("Delete image"), variant="danger", attrs='type="button" @click="deleteEditingImage()"', alpine_disabled="imageEditing || imageBeingDeletedId === editingImage.id") }}
+                                <div class="flex gap-2">
+                                    {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageDetailsModalIfAllowed()"', alpine_disabled="imageEditing") }}
+                                    {{ button(_("Save alt"), variant="primary", attrs='type="button" @click="submitImageEdit()"', alpine_disabled="!editingImageAlt.trim() || imageEditing") }}
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -919,13 +949,10 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
                     },
 
-                    copyImageUrl(image) {
-                        if (!image || !image.public_url) {
-                            this.showToast('{{ _("No public URL available yet") }}', 'error');
-                            return;
-                        }
-                        navigator.clipboard.writeText(image.public_url)
-                            .then(() => this.showToast('{{ _("URL copied to clipboard") }}', 'success'))
+                    copyToClipboard(text, successMessage) {
+                        if (!text) return;
+                        navigator.clipboard.writeText(text)
+                            .then(() => this.showToast(successMessage || '{{ _("Copied to clipboard") }}', 'success'))
                             .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
                     },
 
@@ -943,6 +970,36 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         this.editingImage = null;
                         this.editingImageAlt = '';
                         this.imageEditError = '';
+                    },
+
+                    deleteEditingImage() {
+                        if (!this.editingImage || this.imageEditing || this.imageBeingDeletedId) return;
+                        const image = this.editingImage;
+                        this.imageBeingDeletedId = image.id;
+                        fetch(this.imageItemUrl(image.id), {
+                            method: 'DELETE',
+                            headers: {
+                                'X-CSRFToken': '{{ csrf_token() }}'
+                            }
+                        })
+                            .then(async (response) => {
+                                if (!response.ok) {
+                                    const data = await response.json().catch(() => ({}));
+                                    this.showToast(data.error || '{{ _("Failed to delete image") }}', 'error');
+                                    return;
+                                }
+                                this.images = this.images.filter(img => img.id !== image.id);
+                                this.imageDetailsModalOpen = false;
+                                this.editingImage = null;
+                                this.editingImageAlt = '';
+                                this.showToast('{{ _("Image deleted") }}', 'success');
+                            })
+                            .catch(() => {
+                                this.showToast('{{ _("Network error while deleting the image") }}', 'error');
+                            })
+                            .finally(() => {
+                                this.imageBeingDeletedId = '';
+                            });
                     },
 
                     submitImageEdit() {

--- a/backend/templates/backoffice/components/button.html
+++ b/backend/templates/backoffice/components/button.html
@@ -19,6 +19,10 @@ ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and ful
                          renders the HTML `disabled` attribute AND the muted variant style.
                          Use this when the disabled state depends on Alpine state. Example:
                          alpine_disabled="!form.name || saving"
+                         The expression is rendered into double-quoted attributes; Jinja
+                         autoescape handles any `"` inside the expression, but prefer
+                         single quotes for string literals (e.g. `status === 'ready'`) to
+                         keep the rendered HTML readable.
         type: button type attribute (default: "button")
         href: if provided, renders as <a> instead of <button>
         id: optional id attribute

--- a/backend/templates/backoffice/components/button.html
+++ b/backend/templates/backoffice/components/button.html
@@ -3,7 +3,7 @@ ABOUTME: Button component macro for backoffice design system
 ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and full a11y support
 #}
 
-{% macro button(text="", variant="primary", disabled=false, type="button", href="", id="", classes="", attrs="", leading_icon="", trailing_icon="", icon="", full_width=false, aria_label="", aria_pressed="", aria_haspopup="", aria_expanded="", aria_describedby="") %}
+{% macro button(text="", variant="primary", disabled=false, alpine_disabled="", type="button", href="", id="", classes="", attrs="", leading_icon="", trailing_icon="", icon="", full_width=false, aria_label="", aria_pressed="", aria_haspopup="", aria_expanded="", aria_describedby="") %}
     {#
     Button component based on Figma OpenDLP UI specification.
     Renders as <a> when href is provided, otherwise <button>.
@@ -14,7 +14,11 @@ ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and ful
         variant: "primary" | "secondary" | "tertiary" | "danger" | "icon" | "outline" (default: "primary")
                  Note: "outline" is deprecated, use "secondary" instead
                  "danger" is a transparent-background red-text button for destructive actions
-        disabled: boolean to disable the button
+        disabled: boolean to disable the button (Jinja-time)
+        alpine_disabled: Alpine.js boolean expression — when truthy at runtime the button
+                         renders the HTML `disabled` attribute AND the muted variant style.
+                         Use this when the disabled state depends on Alpine state. Example:
+                         alpine_disabled="!form.name || saving"
         type: button type attribute (default: "button")
         href: if provided, renders as <a> instead of <button>
         id: optional id attribute
@@ -90,7 +94,9 @@ ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and ful
         {% set width_styles = "" %}
     {% endif %}
 
-    {# Variant-specific styles #}
+    {# Variant-specific styles. Jinja-time `disabled=true` swaps to the muted look
+       inline; the same muted look is applied at runtime via the `.btn-runtime-disabled`
+       class toggled by Alpine when `alpine_disabled` is set. #}
     {% if disabled %}
         {% set variant_styles = "background-color: var(--color-disabled-borders); color: var(--color-placeholder-text); cursor: not-allowed; border: none; opacity: 0.5;" %}
         {% set hover_class = "" %}
@@ -160,6 +166,11 @@ ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and ful
             type="{{ type }}"
             {% if id %}id="{{ id }}"{% endif %}
             {% if disabled %}disabled aria-disabled="true"{% endif %}
+            {% if alpine_disabled %}
+                :disabled="{{ alpine_disabled }}"
+                :aria-disabled="({{ alpine_disabled }}) ? 'true' : 'false'"
+                :class="{ 'btn-runtime-disabled': ({{ alpine_disabled }}) }"
+            {% endif %}
             {% if aria_label %}aria-label="{{ aria_label }}"{% endif %}
             {% if aria_pressed %}aria-pressed="{{ aria_pressed }}"{% endif %}
             {% if aria_haspopup %}aria-haspopup="{{ aria_haspopup }}"{% endif %}

--- a/backend/templates/backoffice/service_docs.html
+++ b/backend/templates/backoffice/service_docs.html
@@ -44,7 +44,8 @@ ABOUTME: Provides testing console with code references, sample data, and executi
         {"key": "respondents", "label": _("Respondents"), "href": url_for('dev.service_docs', tab='respondents'), "active": active_tab == 'respondents'},
         {"key": "targets", "label": _("Targets"), "href": url_for('dev.service_docs', tab='targets'), "active": active_tab == 'targets'},
         {"key": "config", "label": _("CSV Config"), "href": url_for('dev.service_docs', tab='config'), "active": active_tab == 'config'},
-        {"key": "selection", "label": _("Selection"), "href": url_for('dev.service_docs', tab='selection'), "active": active_tab == 'selection'}
+        {"key": "selection", "label": _("Selection"), "href": url_for('dev.service_docs', tab='selection'), "active": active_tab == 'selection'},
+        {"key": "images", "label": _("Images"), "href": url_for('dev.service_docs', tab='images'), "active": active_tab == 'images'}
         ],
         aria_label=_("Service categories"),
         preserve_scroll=true
@@ -77,6 +78,10 @@ ABOUTME: Provides testing console with code references, sample data, and executi
 
         {% if active_tab == 'selection' %}
             {% include "backoffice/service_docs/_selection.html" %}
+        {% endif %}
+
+        {% if active_tab == 'images' %}
+            {% include "backoffice/service_docs/_images.html" %}
         {% endif %}
 
         {# Toast Notification #}
@@ -134,6 +139,21 @@ ABOUTME: Provides testing console with code references, sample data, and executi
                 addFieldType: 'text',
                 addFieldOptions: '',
 
+                // Image form properties
+                addImageAssemblyId: '',
+                addImageBase64: '',
+                addImageFileName: '',
+                addImageAlt: '',
+                listImagesAssemblyId: '',
+                deleteImageAssemblyId: '',
+                deleteImageImageId: '',
+                setAltAssemblyId: '',
+                setAltImageId: '',
+                setAltText: '',
+                listSnippetsAssemblyId: '',
+                serveImageUrlSlug: '',
+                serveImageImageName: '',
+
                 // Registration form properties
                 createRegistrationAssemblyId: '',
                 getRegistrationAssemblyId: '',
@@ -172,7 +192,13 @@ ABOUTME: Provides testing console with code references, sample data, and executi
                     reopen_registration: false,
                     generate_starter_html: false,
                     submit_registration: false,
-                    add_field: false
+                    add_field: false,
+                    add_image: false,
+                    list_images: false,
+                    delete_image: false,
+                    set_image_alt: false,
+                    list_snippets: false,
+                    serve_image: false
                 },
 
                 // Response data for each service
@@ -196,7 +222,13 @@ ABOUTME: Provides testing console with code references, sample data, and executi
                     reopen_registration: null,
                     generate_starter_html: null,
                     submit_registration: null,
-                    add_field: null
+                    add_field: null,
+                    add_image: null,
+                    list_images: null,
+                    delete_image: null,
+                    set_image_alt: null,
+                    list_snippets: null,
+                    serve_image: null
                 },
 
                 // Sample data for each service
@@ -245,7 +277,13 @@ Age,51+,2,5,1,1`,
                         'reopen_registration_page': 'reopen_registration',
                         'generate_starter_form_html': 'generate_starter_html',
                         'submit_registration': 'submit_registration',
-                        'add_field': 'add_field'
+                        'add_field': 'add_field',
+                        'add_registration_image': 'add_image',
+                        'list_registration_images': 'list_images',
+                        'delete_registration_image': 'delete_image',
+                        'set_registration_image_alt': 'set_image_alt',
+                        'list_image_snippets': 'list_snippets',
+                        'get_registration_image_for_serving': 'serve_image'
                     };
                     const key = keyMap[serviceName];
 
@@ -439,6 +477,69 @@ Age,51+,2,5,1,1`,
                         group: this.addFieldGroup,
                         field_type: this.addFieldType,
                         options: options
+                    });
+                },
+
+                // ===== Image service execute methods =====
+                handleImageFileChange(event) {
+                    const file = event.target.files && event.target.files[0];
+                    if (!file) {
+                        this.addImageBase64 = '';
+                        this.addImageFileName = '';
+                        return;
+                    }
+                    this.addImageFileName = file.name;
+                    const reader = new FileReader();
+                    reader.onload = () => {
+                        // FileReader.readAsDataURL returns "data:<mime>;base64,<payload>"
+                        const result = String(reader.result || '');
+                        const idx = result.indexOf(',');
+                        this.addImageBase64 = idx >= 0 ? result.slice(idx + 1) : result;
+                    };
+                    reader.onerror = () => {
+                        this.addImageBase64 = '';
+                        this.showToast('Failed to read file', 'error');
+                    };
+                    reader.readAsDataURL(file);
+                },
+                executeAddRegistrationImage() {
+                    if (!this.addImageBase64) {
+                        this.responses.add_image = { status: 'error', error: 'Please choose an image file first', error_type: 'ValidationError' };
+                        return;
+                    }
+                    this.executeService('add_registration_image', {
+                        assembly_id: this.addImageAssemblyId,
+                        image_base64: this.addImageBase64,
+                        alt: this.addImageAlt
+                    });
+                },
+                executeListRegistrationImages() {
+                    this.executeService('list_registration_images', {
+                        assembly_id: this.listImagesAssemblyId
+                    });
+                },
+                executeDeleteRegistrationImage() {
+                    this.executeService('delete_registration_image', {
+                        assembly_id: this.deleteImageAssemblyId,
+                        image_id: this.deleteImageImageId
+                    });
+                },
+                executeSetRegistrationImageAlt() {
+                    this.executeService('set_registration_image_alt', {
+                        assembly_id: this.setAltAssemblyId,
+                        image_id: this.setAltImageId,
+                        alt: this.setAltText
+                    });
+                },
+                executeListImageSnippets() {
+                    this.executeService('list_image_snippets', {
+                        assembly_id: this.listSnippetsAssemblyId
+                    });
+                },
+                executeGetRegistrationImageForServing() {
+                    this.executeService('get_registration_image_for_serving', {
+                        url_slug: this.serveImageUrlSlug,
+                        image_name: this.serveImageImageName
                     });
                 },
 

--- a/backend/templates/backoffice/service_docs/_images.html
+++ b/backend/templates/backoffice/service_docs/_images.html
@@ -1,0 +1,456 @@
+<div class="space-y-6">
+    {# Overview #}
+    {% call card(title="Registration Image Services", composed=true) %}
+        {% call card_body() %}
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Upload, list, retag and delete images attached to an assembly's registration page. Uploaded files are validated, EXIF-stripped, downscaled to PNG and de-duplicated by SHA-256.") }}
+            </p>
+            <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                {{ _("Allowed input formats: PNG, JPEG, WebP. The page must already exist (use the Registration tab to create one).") }}
+            </p>
+        {% endcall %}
+    {% endcall %}
+
+    {# add_registration_image #}
+    {% call card(title="add_registration_image()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels);
+                             color: var(--color-info-600)">
+                    registration_image_service.py:52
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100);
+                                 color: var(--color-warning-600)">🔒 can_manage_assembly()</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Validate, process and store an image for the assembly's registration page. Identical bytes on the same page collapse to one row.") }}
+            </p>
+
+            {# Parameters #}
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-body-sm"
+                           style="border: 1px solid var(--color-borders-dividers)">
+                        <tbody>
+                            <tr>
+                                <td class="px-3 py-2 font-mono"
+                                    style="border-bottom: 1px solid var(--color-borders-dividers)">assembly_id</td>
+                                <td class="px-3 py-2"
+                                    style="border-bottom: 1px solid var(--color-borders-dividers)">UUID</td>
+                                <td class="px-3 py-2"
+                                    style="border-bottom: 1px solid var(--color-borders-dividers)">✅</td>
+                                <td class="px-3 py-2"
+                                    style="border-bottom: 1px solid var(--color-borders-dividers)">Target assembly ID</td>
+                            </tr>
+                            <tr>
+                                <td class="px-3 py-2 font-mono"
+                                    style="border-bottom: 1px solid var(--color-borders-dividers)">raw</td>
+                                <td class="px-3 py-2"
+                                    style="border-bottom: 1px solid var(--color-borders-dividers)">bytes</td>
+                                <td class="px-3 py-2"
+                                    style="border-bottom: 1px solid var(--color-borders-dividers)">✅</td>
+                                <td class="px-3 py-2"
+                                    style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                    Image bytes. Sent as <code>image_base64</code> over the wire and decoded server-side.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="px-3 py-2 font-mono">alt</td>
+                                <td class="px-3 py-2">str</td>
+                                <td class="px-3 py-2">❌</td>
+                                <td class="px-3 py-2">Alt text for accessibility (default: empty)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            {# Returns #}
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm px-2 py-1 rounded block"
+                      style="background-color: var(--color-subtle-background-panels)">
+                    RegistrationImage  →  Stored image metadata (existing row on dedup)
+                </code>
+            </div>
+
+            {# Error Cases #}
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Error Cases") }}</h4>
+                <ul class="list-disc list-inside text-body-sm space-y-1"
+                    style="color: var(--color-body-text)">
+                    <li>
+                        <code class="px-1 rounded"
+                              style="background-color: var(--color-error-100)">ImageValidationError</code> — too large, unsupported format, decompression bomb, or undecodable
+                    </li>
+                    <li>
+                        <code class="px-1 rounded"
+                              style="background-color: var(--color-error-100)">ImageQuotaExceeded</code> — page already at the per-page image limit
+                    </li>
+                    <li>
+                        <code class="px-1 rounded"
+                              style="background-color: var(--color-error-100)">RegistrationPageNotFoundError</code> — assembly has no registration page
+                    </li>
+                </ul>
+            </div>
+
+            {# Interactive Form #}
+            <div class="p-4 rounded-lg mb-4"
+                 style="background-color: var(--color-subtle-background-panels);
+                        border: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("Try it") }}</h4>
+                <div class="space-y-3">
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Assembly</label>
+                        <select x-model="addImageAssemblyId"
+                                class="w-full px-3 py-2 rounded text-body-sm"
+                                style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);">
+                            <option value="">Select an assembly...</option>
+                            {% for assembly in assemblies %}
+                                <option value="{{ assembly.id }}">{{ assembly.title }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Image file (PNG/JPEG/WebP)</label>
+                        <input type="file"
+                               accept="image/png,image/jpeg,image/webp"
+                               @change="handleImageFileChange($event)"
+                               class="w-full px-3 py-2 rounded text-body-sm"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                        <p class="text-body-sm mt-1" x-show="addImageFileName" x-cloak style="color: var(--color-secondary-text);">
+                            <span x-text="addImageFileName"></span>
+                            (<span x-text="addImageBase64.length"></span> base64 chars)
+                        </p>
+                    </div>
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Alt text (optional)</label>
+                        <input type="text"
+                               x-model="addImageAlt"
+                               placeholder="Assembly venue exterior"
+                               class="w-full px-3 py-2 rounded text-body-sm"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                    </div>
+                    <button @click="executeAddRegistrationImage()"
+                            class="px-4 py-2 rounded text-button-sm"
+                            style="background-color: var(--color-primary-action); color: white;"
+                            :disabled="loading.add_image">
+                        <span x-show="!loading.add_image">Execute</span>
+                        <span x-show="loading.add_image">Loading...</span>
+                    </button>
+                </div>
+            </div>
+            <div x-show="responses.add_image" x-cloak>
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Response") }}</h4>
+                <pre class="p-3 rounded text-body-sm overflow-x-auto"
+                     style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                     x-text="formatResponse('add_image')"></pre>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# list_registration_images #}
+    {% call card(title="list_registration_images()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels);
+                             color: var(--color-info-600)">
+                    registration_image_service.py:83
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100);
+                                 color: var(--color-warning-600)">🔒 can_view_assembly()</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Return every image attached to the assembly's registration page. Empty list when no page exists yet.") }}
+            </p>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm px-2 py-1 rounded block"
+                      style="background-color: var(--color-subtle-background-panels)">
+                    list[RegistrationImage]
+                </code>
+            </div>
+
+            <div class="p-4 rounded-lg mb-4"
+                 style="background-color: var(--color-subtle-background-panels);
+                        border: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("Try it") }}</h4>
+                <div class="space-y-3">
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Assembly</label>
+                        <select x-model="listImagesAssemblyId"
+                                class="w-full px-3 py-2 rounded text-body-sm"
+                                style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);">
+                            <option value="">Select an assembly...</option>
+                            {% for assembly in assemblies %}
+                                <option value="{{ assembly.id }}">{{ assembly.title }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <button @click="executeListRegistrationImages()"
+                            class="px-4 py-2 rounded text-button-sm"
+                            style="background-color: var(--color-primary-action); color: white;"
+                            :disabled="loading.list_images">
+                        <span x-show="!loading.list_images">Execute</span>
+                        <span x-show="loading.list_images">Loading...</span>
+                    </button>
+                </div>
+            </div>
+            <div x-show="responses.list_images" x-cloak>
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Response") }}</h4>
+                <pre class="p-3 rounded text-body-sm overflow-x-auto"
+                     style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                     x-text="formatResponse('list_images')"></pre>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# delete_registration_image #}
+    {% call card(title="delete_registration_image()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels);
+                             color: var(--color-info-600)">
+                    registration_image_service.py:96
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100);
+                                 color: var(--color-warning-600)">🔒 can_manage_assembly()</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Permanently delete an image. The image_id must belong to the assembly's registration page.") }}
+            </p>
+
+            <div class="p-4 rounded-lg mb-4"
+                 style="background-color: var(--color-subtle-background-panels);
+                        border: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("Try it") }}</h4>
+                <div class="space-y-3">
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Assembly</label>
+                        <select x-model="deleteImageAssemblyId"
+                                class="w-full px-3 py-2 rounded text-body-sm"
+                                style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);">
+                            <option value="">Select an assembly...</option>
+                            {% for assembly in assemblies %}
+                                <option value="{{ assembly.id }}">{{ assembly.title }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Image ID (UUID)</label>
+                        <input type="text"
+                               x-model="deleteImageImageId"
+                               placeholder="copy from list_registration_images() response"
+                               class="w-full px-3 py-2 rounded text-body-sm font-mono"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                    </div>
+                    <button @click="executeDeleteRegistrationImage()"
+                            class="px-4 py-2 rounded text-button-sm"
+                            style="background-color: var(--color-error-500); color: white;"
+                            :disabled="loading.delete_image">
+                        <span x-show="!loading.delete_image">Delete</span>
+                        <span x-show="loading.delete_image">Loading...</span>
+                    </button>
+                </div>
+            </div>
+            <div x-show="responses.delete_image" x-cloak>
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Response") }}</h4>
+                <pre class="p-3 rounded text-body-sm overflow-x-auto"
+                     style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                     x-text="formatResponse('delete_image')"></pre>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# set_registration_image_alt #}
+    {% call card(title="set_registration_image_alt()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels);
+                             color: var(--color-info-600)">
+                    registration_image_service.py:112
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100);
+                                 color: var(--color-warning-600)">🔒 can_manage_assembly()</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Update an image's alt text in place. Records an edit on the parent registration page.") }}
+            </p>
+
+            <div class="p-4 rounded-lg mb-4"
+                 style="background-color: var(--color-subtle-background-panels);
+                        border: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("Try it") }}</h4>
+                <div class="space-y-3">
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Assembly</label>
+                        <select x-model="setAltAssemblyId"
+                                class="w-full px-3 py-2 rounded text-body-sm"
+                                style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);">
+                            <option value="">Select an assembly...</option>
+                            {% for assembly in assemblies %}
+                                <option value="{{ assembly.id }}">{{ assembly.title }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Image ID (UUID)</label>
+                        <input type="text"
+                               x-model="setAltImageId"
+                               placeholder="copy from list_registration_images() response"
+                               class="w-full px-3 py-2 rounded text-body-sm font-mono"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                    </div>
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">New alt text</label>
+                        <input type="text"
+                               x-model="setAltText"
+                               class="w-full px-3 py-2 rounded text-body-sm"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                    </div>
+                    <button @click="executeSetRegistrationImageAlt()"
+                            class="px-4 py-2 rounded text-button-sm"
+                            style="background-color: var(--color-primary-action); color: white;"
+                            :disabled="loading.set_image_alt">
+                        <span x-show="!loading.set_image_alt">Execute</span>
+                        <span x-show="loading.set_image_alt">Loading...</span>
+                    </button>
+                </div>
+            </div>
+            <div x-show="responses.set_image_alt" x-cloak>
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Response") }}</h4>
+                <pre class="p-3 rounded text-body-sm overflow-x-auto"
+                     style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                     x-text="formatResponse('set_image_alt')"></pre>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# list_image_snippets #}
+    {% call card(title="list_image_snippets()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels);
+                             color: var(--color-info-600)">
+                    registration_image_service.py:129
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100);
+                                 color: var(--color-warning-600)">🔒 can_view_assembly()</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("List images paired with ready-to-paste <img> snippets. URLs point at the public /register/<slug>/assets/<sha>.png route.") }}
+            </p>
+
+            <div class="p-4 rounded-lg mb-4"
+                 style="background-color: var(--color-subtle-background-panels);
+                        border: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("Try it") }}</h4>
+                <div class="space-y-3">
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Assembly</label>
+                        <select x-model="listSnippetsAssemblyId"
+                                class="w-full px-3 py-2 rounded text-body-sm"
+                                style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);">
+                            <option value="">Select an assembly...</option>
+                            {% for assembly in assemblies %}
+                                <option value="{{ assembly.id }}">{{ assembly.title }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <button @click="executeListImageSnippets()"
+                            class="px-4 py-2 rounded text-button-sm"
+                            style="background-color: var(--color-primary-action); color: white;"
+                            :disabled="loading.list_snippets">
+                        <span x-show="!loading.list_snippets">Execute</span>
+                        <span x-show="loading.list_snippets">Loading...</span>
+                    </button>
+                </div>
+            </div>
+            <div x-show="responses.list_snippets" x-cloak>
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Response") }}</h4>
+                <pre class="p-3 rounded text-body-sm overflow-x-auto"
+                     style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                     x-text="formatResponse('list_snippets')"></pre>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# get_registration_image_for_serving #}
+    {% call card(title="get_registration_image_for_serving()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels);
+                             color: var(--color-info-600)">
+                    registration_image_service.py:139
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-info-100);
+                                 color: var(--color-info-700)">🌐 public (no auth)</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Lookup helper used by the public /register/<slug>/assets/<image_name> route. Returns None unless the registration page is publicly loadable (TEST or PUBLISHED). The response here reports metadata; fetch the actual bytes from the public URL.") }}
+            </p>
+
+            <div class="p-4 rounded-lg mb-4"
+                 style="background-color: var(--color-subtle-background-panels);
+                        border: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("Try it") }}</h4>
+                <div class="space-y-3">
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">URL slug</label>
+                        <input type="text"
+                               x-model="serveImageUrlSlug"
+                               placeholder="my-assembly-2026"
+                               class="w-full px-3 py-2 rounded text-body-sm"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                    </div>
+                    <div>
+                        <label class="text-body-sm font-medium block mb-1">Image name (sha256.png)</label>
+                        <input type="text"
+                               x-model="serveImageImageName"
+                               placeholder="ab12...cd.png"
+                               class="w-full px-3 py-2 rounded text-body-sm font-mono"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                    </div>
+                    <button @click="executeGetRegistrationImageForServing()"
+                            class="px-4 py-2 rounded text-button-sm"
+                            style="background-color: var(--color-primary-action); color: white;"
+                            :disabled="loading.serve_image">
+                        <span x-show="!loading.serve_image">Execute</span>
+                        <span x-show="loading.serve_image">Loading...</span>
+                    </button>
+                </div>
+            </div>
+            <div x-show="responses.serve_image" x-cloak>
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Response") }}</h4>
+                <pre class="p-3 rounded text-body-sm overflow-x-auto"
+                     style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text);"
+                     x-text="formatResponse('serve_image')"></pre>
+            </div>
+        {% endcall %}
+    {% endcall %}
+</div>

--- a/backend/templates/backoffice/showcase/button_component.html
+++ b/backend/templates/backoffice/showcase/button_component.html
@@ -4,6 +4,7 @@ ABOUTME: Displays button variants and usage examples
 #}
 {% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_example, showcase_tokens %}
 {% from "backoffice/components/button.html" import button %}
+{% from "backoffice/components/input.html" import switch %}
 
 {# Sample SVG icons for demonstration #}
 {% set edit_icon %}
@@ -40,13 +41,22 @@ ABOUTME: Displays button variants and usage examples
 
         {# Variants Section #}
         {% call showcase_example('{% from "backoffice/components/button.html" import button %}
+            {% from "backoffice/components/input.html" import switch %}
 
 {# Basic variants #}
             {{ button("Primary", variant="primary") }}
             {{ button("Secondary", variant="secondary") }}
             {{ button("Tertiary", variant="tertiary") }}
             {{ button("Delete", variant="danger") }}
-            {{ button("Disabled", disabled=true) }}') %}
+            {{ button("Disabled", disabled=true) }}
+
+{# Reactive disabled — the HTML disabled attribute AND the muted look are
+   toggled at runtime from an Alpine expression. Pair with form state, e.g.
+   alpine_disabled="!form.name || saving". #}
+            <div x-data="{ enabled: false }">
+                {{ switch("demo-toggle", label="Enable", attrs=\'x-model="enabled"\') }}
+                {{ button("Save", variant="primary", alpine_disabled="!enabled") }}
+            </div>') %}
             <div class="flex flex-wrap gap-4 items-center">
                 <div class="flex flex-col items-center gap-2">
                     {{ button("Primary", variant="primary", id="btn-primary") }}
@@ -66,7 +76,15 @@ ABOUTME: Displays button variants and usage examples
                 </div>
                 <div class="flex flex-col items-center gap-2">
                     {{ button("Disabled", disabled=true, id="btn-disabled") }}
-                    <span class="text-caption" style="color: var(--color-secondary-text);">Disabled</span>
+                    <span class="text-caption" style="color: var(--color-secondary-text);">Disabled (Jinja)</span>
+                </div>
+                <div class="flex flex-col items-center gap-3" x-data="{ enabled: false }">
+                    {{ button("Save",
+                    variant="primary",
+                    id="btn-reactive",
+                    alpine_disabled="!enabled") }}
+                    {{ switch("btn-reactive-toggle", label="Enable", attrs='x-model="enabled"') }}
+                    <span class="text-caption" style="color: var(--color-secondary-text);">Disabled (Alpine)</span>
                 </div>
             </div>
         {% endcall %}

--- a/backend/tests/contract/test_registration_image_repo.py
+++ b/backend/tests/contract/test_registration_image_repo.py
@@ -37,6 +37,13 @@ class TestAddAndGet:
         assert retrieved is not None
         assert retrieved.alt == "A red square"
 
+    def test_add_and_get_preserves_original_filename(self, registration_image_backend: ContractBackend):
+        image = registration_image_backend.make_registration_image(original_filename="holiday photo.png")
+
+        retrieved = registration_image_backend.repo.get(image.id)
+        assert retrieved is not None
+        assert retrieved.original_filename == "holiday photo.png"
+
     def test_get_nonexistent_returns_none(self, registration_image_backend: ContractBackend):
         assert registration_image_backend.repo.get(uuid.uuid4()) is None
 

--- a/backend/tests/unit/domain/test_registration_image.py
+++ b/backend/tests/unit/domain/test_registration_image.py
@@ -5,9 +5,11 @@ import uuid
 
 from opendlp.domain.registration_image import (
     IMAGE_CONTENT_TYPE,
+    MAX_ORIGINAL_FILENAME_LENGTH,
     ProcessedImage,
     RegistrationImage,
     generate_image_html,
+    sanitise_original_filename,
 )
 
 
@@ -55,6 +57,18 @@ class TestRegistrationImage:
         img = RegistrationImage.from_processed(uuid.uuid4(), _processed(), alt="A red square")
         assert img.create_detached_copy().alt == "A red square"
 
+    def test_original_filename_defaults_to_empty_string(self):
+        img = RegistrationImage.from_processed(uuid.uuid4(), _processed())
+        assert img.original_filename == ""
+
+    def test_from_processed_keeps_original_filename(self):
+        img = RegistrationImage.from_processed(uuid.uuid4(), _processed(), original_filename="holiday photo.jpg")
+        assert img.original_filename == "holiday photo.jpg"
+
+    def test_detached_copy_preserves_original_filename(self):
+        img = RegistrationImage.from_processed(uuid.uuid4(), _processed(), original_filename="holiday photo.jpg")
+        assert img.create_detached_copy().original_filename == "holiday photo.jpg"
+
     def test_detached_copy_equal_by_id(self):
         img = RegistrationImage.from_processed(uuid.uuid4(), _processed())
         copy = img.create_detached_copy()
@@ -65,6 +79,28 @@ class TestRegistrationImage:
     def test_not_equal_to_other_type(self):
         img = RegistrationImage.from_processed(uuid.uuid4(), _processed())
         assert img != "not an image"
+
+
+class TestSanitiseOriginalFilename:
+    def test_keeps_a_plain_readable_name(self):
+        assert sanitise_original_filename("holiday photo.JPG") == "holiday photo.JPG"
+
+    def test_strips_unix_path_components(self):
+        assert sanitise_original_filename("/home/user/photos/cat.png") == "cat.png"
+
+    def test_strips_windows_path_components(self):
+        assert sanitise_original_filename(r"C:\\Users\\me\\cat.png") == "cat.png"
+
+    def test_strips_control_characters(self):
+        assert sanitise_original_filename("ca\x00t\x1f.png") == "cat.png"
+
+    def test_truncates_to_max_length(self):
+        long_name = "a" * (MAX_ORIGINAL_FILENAME_LENGTH + 50)
+        result = sanitise_original_filename(long_name)
+        assert len(result) == MAX_ORIGINAL_FILENAME_LENGTH
+
+    def test_empty_stays_empty(self):
+        assert sanitise_original_filename("") == ""
 
 
 class TestGenerateImageHtml:

--- a/backend/tests/unit/test_backoffice_registration_images.py
+++ b/backend/tests/unit/test_backoffice_registration_images.py
@@ -1,5 +1,5 @@
 """ABOUTME: Unit tests for the backoffice registration image helpers and JSON routes
-ABOUTME: Covers _image_to_dict, _add_image_honouring_alt and the POST/PATCH/DELETE endpoints"""
+ABOUTME: Covers _image_to_dict and the POST/PATCH/DELETE endpoints"""
 
 import io
 import uuid
@@ -10,7 +10,6 @@ import pytest
 
 from opendlp.domain.registration_image import RegistrationImage
 from opendlp.entrypoints.blueprints.backoffice_registration import (
-    _add_image_honouring_alt,
     _image_to_dict,
 )
 from opendlp.entrypoints.flask_app import create_app
@@ -90,54 +89,6 @@ class TestImageToDict:
         assert result["img_snippet"] == ""
 
 
-class TestAddImageHonouringAlt:
-    def test_no_dedup_returns_image_directly(self, app, assembly_id):
-        stored = _image(alt="Hello")
-        with (
-            app.test_request_context(),
-            patch("opendlp.entrypoints.blueprints.backoffice_registration.current_user") as cu,
-            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
-            patch(
-                "opendlp.entrypoints.blueprints.backoffice_registration.add_registration_image",
-                return_value=stored,
-            ) as add,
-            patch(
-                "opendlp.entrypoints.blueprints.backoffice_registration.set_registration_image_alt",
-            ) as set_alt,
-        ):
-            cu.id = uuid.uuid4()
-            result = _add_image_honouring_alt(assembly_id, b"raw-bytes", alt="Hello")
-
-        add.assert_called_once()
-        set_alt.assert_not_called()
-        assert result is stored
-
-    def test_dedup_returning_different_alt_triggers_followup_update(self, app, assembly_id):
-        stored = _image(alt="")  # existing row with empty alt (legacy upload)
-        updated = _image(alt="New alt")
-        with (
-            app.test_request_context(),
-            patch("opendlp.entrypoints.blueprints.backoffice_registration.current_user") as cu,
-            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
-            patch(
-                "opendlp.entrypoints.blueprints.backoffice_registration.add_registration_image",
-                return_value=stored,
-            ),
-            patch(
-                "opendlp.entrypoints.blueprints.backoffice_registration.set_registration_image_alt",
-                return_value=updated,
-            ) as set_alt,
-        ):
-            cu.id = uuid.uuid4()
-            result = _add_image_honouring_alt(assembly_id, b"raw-bytes", alt="New alt")
-
-        set_alt.assert_called_once()
-        _, kwargs = set_alt.call_args
-        # alt argument is passed by keyword in the helper
-        assert kwargs.get("alt") == "New alt"
-        assert result is updated
-
-
 class TestImageRoutesRequireLogin:
     def test_upload_redirects_anonymous_to_login(self, client, assembly_id):
         response = client.post(f"/backoffice/assembly/{assembly_id}/registration/images")
@@ -173,10 +124,11 @@ class TestUploadRouteHappyPath:
         stored = _image(alt="Hello world")
         with (
             patch("opendlp.entrypoints.blueprints.backoffice_registration.current_user") as cu,
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
             patch(
-                "opendlp.entrypoints.blueprints.backoffice_registration._add_image_honouring_alt",
+                "opendlp.entrypoints.blueprints.backoffice_registration.add_registration_image",
                 return_value=stored,
-            ) as helper,
+            ) as add,
             patch(
                 "opendlp.entrypoints.blueprints.backoffice_registration._resolve_page_url_slug",
                 return_value="my-slug",
@@ -196,9 +148,9 @@ class TestUploadRouteHappyPath:
         body = response.get_json()
         assert body["image"]["alt"] == "Hello world"
         assert body["image"]["id"] == str(stored.id)
-        helper.assert_called_once()
+        add.assert_called_once()
         # The uploaded filename is threaded through to the service layer.
-        _, kwargs = helper.call_args
+        _, kwargs = add.call_args
         assert kwargs.get("original_filename") == "logo.png"
 
     def test_upload_rejects_missing_alt(self, authed_client, assembly_id):

--- a/backend/tests/unit/test_backoffice_registration_images.py
+++ b/backend/tests/unit/test_backoffice_registration_images.py
@@ -3,6 +3,7 @@ ABOUTME: Covers _image_to_dict, _add_image_honouring_alt and the POST/PATCH/DELE
 
 import io
 import uuid
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -285,3 +286,74 @@ class TestDeleteRouteHappyPath:
         assert response.status_code == 204
         assert response.data == b""
         delete.assert_called_once()
+
+
+class TestImageDetailsModalTemplate:
+    """Structural assertions on the Image Details modal in assembly_registration.html.
+
+    The modal HTML lives inline in the registration template, gated by
+    ``<template x-if="imageDetailsModalOpen && editingImage">`` so Alpine controls
+    visibility client-side. Rendering the page through the route requires a real
+    authenticated user (the base layout reads ``current_user.global_role`` in a
+    context processor), which is heavyweight for verifying static modal markup.
+
+    We instead scan the template file and confirm the enhanced modal carries the
+    expected structural markers — thumbnail binding, read-only inputs with copy
+    handlers, danger-styled Delete button, and the renamed "Save alt" button.
+    """
+
+    @pytest.fixture
+    def modal_block(self) -> str:
+        """Return only the Image Details modal subsection of the template."""
+        path = Path(__file__).resolve().parents[2] / "templates/backoffice/assembly_registration.html"
+        text = path.read_text(encoding="utf-8")
+        start_marker = "{# Image Details / Edit Alt Modal #}"
+        end_marker = "{# Toast notification #}"
+        start = text.find(start_marker)
+        end = text.find(end_marker, start)
+        assert start != -1 and end != -1, "Image Details modal section not found in template"
+        return text[start:end]
+
+    @pytest.fixture
+    def alpine_data_block(self) -> str:
+        """Return the Alpine data block (where the JS handlers live)."""
+        path = Path(__file__).resolve().parents[2] / "templates/backoffice/assembly_registration.html"
+        return path.read_text(encoding="utf-8")
+
+    def test_thumbnail_binds_to_public_url_with_no_preview_fallback(self, modal_block):
+        assert ':src="editingImage.public_url"' in modal_block
+        assert ':alt="editingImage.alt' in modal_block
+        # Fallback hint when the page has no slug yet (public_url is blank)
+        assert "No preview" in modal_block
+
+    def test_read_only_filename_input_has_copy_handler(self, modal_block):
+        assert 'id="image-details-filename"' in modal_block
+        assert "readonly" in modal_block
+        assert ':value="editingImage.file_name"' in modal_block
+        # Click-to-select the value
+        assert "$event.target.select()" in modal_block
+        # Copy uses the new generic clipboard helper
+        assert "copyToClipboard(editingImage.file_name" in modal_block
+
+    def test_read_only_snippet_input_has_copy_handler(self, modal_block):
+        assert 'id="image-details-snippet"' in modal_block
+        assert ':value="editingImage.img_snippet"' in modal_block
+        # Snippet copy reuses the existing helper (which guards on missing public URL)
+        assert "copyImageSnippet(editingImage)" in modal_block
+
+    def test_footer_has_delete_on_left_and_renamed_save_button(self, modal_block):
+        # Danger-styled Delete handler exists and is wired through a non-confirming method
+        assert 'variant="danger"' in modal_block
+        assert "deleteEditingImage()" in modal_block
+        assert "Delete image" in modal_block
+        # The primary save button is renamed to clarify what's persisted
+        assert "Save alt" in modal_block
+        # Old generic "Save" label is no longer the button text
+        assert 'button(_("Save"),' not in modal_block
+
+    def test_alpine_data_block_exposes_copy_helper_and_delete_method(self, alpine_data_block):
+        # Generic clipboard helper used by the filename copy button
+        assert "copyToClipboard(text, successMessage)" in alpine_data_block
+        # Modal-scoped delete that closes the modal on success and skips the panel's confirm()
+        assert "deleteEditingImage()" in alpine_data_block
+        assert "this.imageDetailsModalOpen = false" in alpine_data_block

--- a/backend/tests/unit/test_backoffice_registration_images.py
+++ b/backend/tests/unit/test_backoffice_registration_images.py
@@ -1,0 +1,271 @@
+"""ABOUTME: Unit tests for the backoffice registration image helpers and JSON routes
+ABOUTME: Covers _image_to_dict, _add_image_honouring_alt and the POST/PATCH/DELETE endpoints"""
+
+import io
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from opendlp.domain.registration_image import RegistrationImage
+from opendlp.entrypoints.blueprints.backoffice_registration import (
+    _add_image_honouring_alt,
+    _image_to_dict,
+)
+from opendlp.entrypoints.flask_app import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app("testing")
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def assembly_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+def _image(*, alt: str = "Logo", sha256: str = "a" * 64) -> RegistrationImage:
+    return RegistrationImage(
+        registration_page_id=uuid.uuid4(),
+        byte_size=123,
+        width=100,
+        height=80,
+        sha256=sha256,
+        data=b"\x89PNG...",
+        alt=alt,
+        created_by=uuid.uuid4(),
+    )
+
+
+class TestImageToDict:
+    def test_builds_public_url_and_snippet_when_slug_present(self, app):
+        image = _image(alt="A nice logo", sha256="b" * 64)
+        with app.test_request_context():
+            result = _image_to_dict(image, url_slug="my-slug")
+
+        assert result["id"] == str(image.id)
+        assert result["alt"] == "A nice logo"
+        assert result["file_name"] == f"{'b' * 64}.png"
+        assert result["display_name"] == "A nice logo"
+        assert "/register/my-slug/assets/" in result["public_url"]
+        assert result["public_url"].endswith(f"{'b' * 64}.png")
+        # Domain helper html-escapes both src and alt
+        assert result["img_snippet"].startswith('<img src="')
+        assert 'alt="A nice logo"' in result["img_snippet"]
+        assert result["width"] == 100
+        assert result["height"] == 80
+        assert result["byte_size"] == 123
+
+    def test_falls_back_to_short_sha_when_alt_blank(self, app):
+        image = _image(alt="   ", sha256="c" * 64)
+        with app.test_request_context():
+            result = _image_to_dict(image, url_slug="my-slug")
+        assert result["display_name"] == f"{'c' * 8}.png"
+
+    def test_omits_public_url_and_snippet_when_no_slug(self, app):
+        image = _image(sha256="d" * 64)
+        with app.test_request_context():
+            result = _image_to_dict(image, url_slug="")
+        assert result["public_url"] == ""
+        assert result["img_snippet"] == ""
+
+
+class TestAddImageHonouringAlt:
+    def test_no_dedup_returns_image_directly(self, app, assembly_id):
+        stored = _image(alt="Hello")
+        with (
+            app.test_request_context(),
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.current_user") as cu,
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.add_registration_image",
+                return_value=stored,
+            ) as add,
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.set_registration_image_alt",
+            ) as set_alt,
+        ):
+            cu.id = uuid.uuid4()
+            result = _add_image_honouring_alt(assembly_id, b"raw-bytes", alt="Hello")
+
+        add.assert_called_once()
+        set_alt.assert_not_called()
+        assert result is stored
+
+    def test_dedup_returning_different_alt_triggers_followup_update(self, app, assembly_id):
+        stored = _image(alt="")  # existing row with empty alt (legacy upload)
+        updated = _image(alt="New alt")
+        with (
+            app.test_request_context(),
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.current_user") as cu,
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.add_registration_image",
+                return_value=stored,
+            ),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.set_registration_image_alt",
+                return_value=updated,
+            ) as set_alt,
+        ):
+            cu.id = uuid.uuid4()
+            result = _add_image_honouring_alt(assembly_id, b"raw-bytes", alt="New alt")
+
+        set_alt.assert_called_once()
+        _, kwargs = set_alt.call_args
+        # alt argument is passed by keyword in the helper
+        assert kwargs.get("alt") == "New alt"
+        assert result is updated
+
+
+class TestImageRoutesRequireLogin:
+    def test_upload_redirects_anonymous_to_login(self, client, assembly_id):
+        response = client.post(f"/backoffice/assembly/{assembly_id}/registration/images")
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+    def test_patch_redirects_anonymous_to_login(self, client, assembly_id):
+        image_id = uuid.uuid4()
+        response = client.patch(
+            f"/backoffice/assembly/{assembly_id}/registration/images/{image_id}",
+            json={"alt": "x"},
+        )
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+    def test_delete_redirects_anonymous_to_login(self, client, assembly_id):
+        image_id = uuid.uuid4()
+        response = client.delete(f"/backoffice/assembly/{assembly_id}/registration/images/{image_id}")
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+
+class TestUploadRouteHappyPath:
+    """The route is shielded by login_required + current_user, so we bypass auth
+    via LOGIN_DISABLED and patch the service-layer functions."""
+
+    @pytest.fixture
+    def authed_client(self, app):
+        app.config["LOGIN_DISABLED"] = True
+        return app.test_client()
+
+    def test_upload_with_file_and_alt_returns_201_and_image_dict(self, app, authed_client, assembly_id):
+        stored = _image(alt="Hello world")
+        with (
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.current_user") as cu,
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration._add_image_honouring_alt",
+                return_value=stored,
+            ) as helper,
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration._resolve_page_url_slug",
+                return_value="my-slug",
+            ),
+        ):
+            cu.id = uuid.uuid4()
+            response = authed_client.post(
+                f"/backoffice/assembly/{assembly_id}/registration/images",
+                data={
+                    "image": (io.BytesIO(b"\x89PNG-fake-bytes"), "logo.png"),
+                    "alt": "Hello world",
+                },
+                content_type="multipart/form-data",
+            )
+
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["image"]["alt"] == "Hello world"
+        assert body["image"]["id"] == str(stored.id)
+        helper.assert_called_once()
+
+    def test_upload_rejects_missing_alt(self, authed_client, assembly_id):
+        response = authed_client.post(
+            f"/backoffice/assembly/{assembly_id}/registration/images",
+            data={"image": (io.BytesIO(b"bytes"), "logo.png"), "alt": "   "},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+        assert "alt" in response.get_json()["error"].lower()
+
+    def test_upload_rejects_missing_file(self, authed_client, assembly_id):
+        response = authed_client.post(
+            f"/backoffice/assembly/{assembly_id}/registration/images",
+            data={"alt": "Logo"},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+
+
+class TestPatchRouteHappyPath:
+    @pytest.fixture
+    def authed_client(self, app):
+        app.config["LOGIN_DISABLED"] = True
+        return app.test_client()
+
+    def test_patch_updates_alt_and_returns_image(self, authed_client, assembly_id):
+        updated = _image(alt="Renamed")
+        image_id = uuid.uuid4()
+        with (
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.current_user") as cu,
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.set_registration_image_alt",
+                return_value=updated,
+            ) as set_alt,
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration._resolve_page_url_slug",
+                return_value="my-slug",
+            ),
+        ):
+            cu.id = uuid.uuid4()
+            response = authed_client.patch(
+                f"/backoffice/assembly/{assembly_id}/registration/images/{image_id}",
+                json={"alt": "Renamed"},
+            )
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["image"]["alt"] == "Renamed"
+        set_alt.assert_called_once()
+        _, kwargs = set_alt.call_args
+        assert kwargs.get("alt") == "Renamed"
+
+    def test_patch_rejects_missing_alt(self, authed_client, assembly_id):
+        image_id = uuid.uuid4()
+        response = authed_client.patch(
+            f"/backoffice/assembly/{assembly_id}/registration/images/{image_id}",
+            json={"alt": "  "},
+        )
+        assert response.status_code == 400
+
+
+class TestDeleteRouteHappyPath:
+    @pytest.fixture
+    def authed_client(self, app):
+        app.config["LOGIN_DISABLED"] = True
+        return app.test_client()
+
+    def test_delete_returns_204(self, authed_client, assembly_id):
+        image_id = uuid.uuid4()
+        with (
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.current_user") as cu,
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.delete_registration_image",
+                return_value=None,
+            ) as delete,
+        ):
+            cu.id = uuid.uuid4()
+            response = authed_client.delete(
+                f"/backoffice/assembly/{assembly_id}/registration/images/{image_id}",
+            )
+
+        assert response.status_code == 204
+        assert response.data == b""
+        delete.assert_called_once()

--- a/backend/tests/unit/test_backoffice_registration_images.py
+++ b/backend/tests/unit/test_backoffice_registration_images.py
@@ -335,13 +335,16 @@ class TestImageDetailsModalTemplate:
         # Copy uses the new generic clipboard helper
         assert "copyToClipboard(editingImage.file_name" in modal_block
 
-    def test_original_filename_row_is_hidden_unless_present(self, modal_block):
-        """The Original filename row uses x-show so it disappears for older
-        uploads that have no original_filename stored."""
-        assert 'id="image-details-original-filename"' in modal_block
-        assert 'x-show="editingImage.original_filename"' in modal_block
-        assert ":value=\"editingImage.original_filename || ''\"" in modal_block
-        assert "copyToClipboard(editingImage.original_filename" in modal_block
+    def test_original_filename_shown_in_metadata_block_only_when_present(self, modal_block):
+        """Original filename sits inside the top metadata block alongside Dimensions
+        and File size, gated by an x-if so the row collapses out of the grid for
+        older uploads that have no original_filename stored. It's display-only —
+        no input, no copy button."""
+        assert 'x-text="editingImage.original_filename"' in modal_block
+        assert 'x-if="editingImage.original_filename"' in modal_block
+        # No standalone copy input/button for the original filename
+        assert 'id="image-details-original-filename"' not in modal_block
+        assert "copyToClipboard(editingImage.original_filename" not in modal_block
 
     def test_read_only_snippet_input_has_copy_handler(self, modal_block):
         assert 'id="image-details-snippet"' in modal_block

--- a/backend/tests/unit/test_backoffice_registration_images.py
+++ b/backend/tests/unit/test_backoffice_registration_images.py
@@ -335,6 +335,14 @@ class TestImageDetailsModalTemplate:
         # Copy uses the new generic clipboard helper
         assert "copyToClipboard(editingImage.file_name" in modal_block
 
+    def test_original_filename_row_is_hidden_unless_present(self, modal_block):
+        """The Original filename row uses x-show so it disappears for older
+        uploads that have no original_filename stored."""
+        assert 'id="image-details-original-filename"' in modal_block
+        assert 'x-show="editingImage.original_filename"' in modal_block
+        assert ":value=\"editingImage.original_filename || ''\"" in modal_block
+        assert "copyToClipboard(editingImage.original_filename" in modal_block
+
     def test_read_only_snippet_input_has_copy_handler(self, modal_block):
         assert 'id="image-details-snippet"' in modal_block
         assert ':value="editingImage.img_snippet"' in modal_block

--- a/backend/tests/unit/test_backoffice_registration_images.py
+++ b/backend/tests/unit/test_backoffice_registration_images.py
@@ -30,7 +30,7 @@ def assembly_id() -> uuid.UUID:
     return uuid.uuid4()
 
 
-def _image(*, alt: str = "Logo", sha256: str = "a" * 64) -> RegistrationImage:
+def _image(*, alt: str = "Logo", sha256: str = "a" * 64, original_filename: str = "") -> RegistrationImage:
     return RegistrationImage(
         registration_page_id=uuid.uuid4(),
         byte_size=123,
@@ -39,6 +39,7 @@ def _image(*, alt: str = "Logo", sha256: str = "a" * 64) -> RegistrationImage:
         sha256=sha256,
         data=b"\x89PNG...",
         alt=alt,
+        original_filename=original_filename,
         created_by=uuid.uuid4(),
     )
 
@@ -62,7 +63,19 @@ class TestImageToDict:
         assert result["height"] == 80
         assert result["byte_size"] == 123
 
-    def test_falls_back_to_short_sha_when_alt_blank(self, app):
+    def test_includes_original_filename(self, app):
+        image = _image(alt="A nice logo", original_filename="logo.png")
+        with app.test_request_context():
+            result = _image_to_dict(image, url_slug="my-slug")
+        assert result["original_filename"] == "logo.png"
+
+    def test_falls_back_to_original_filename_when_alt_blank(self, app):
+        image = _image(alt="   ", sha256="c" * 64, original_filename="holiday photo.png")
+        with app.test_request_context():
+            result = _image_to_dict(image, url_slug="my-slug")
+        assert result["display_name"] == "holiday photo.png"
+
+    def test_falls_back_to_short_sha_when_alt_and_filename_blank(self, app):
         image = _image(alt="   ", sha256="c" * 64)
         with app.test_request_context():
             result = _image_to_dict(image, url_slug="my-slug")
@@ -183,6 +196,9 @@ class TestUploadRouteHappyPath:
         assert body["image"]["alt"] == "Hello world"
         assert body["image"]["id"] == str(stored.id)
         helper.assert_called_once()
+        # The uploaded filename is threaded through to the service layer.
+        _, kwargs = helper.call_args
+        assert kwargs.get("original_filename") == "logo.png"
 
     def test_upload_rejects_missing_alt(self, authed_client, assembly_id):
         response = authed_client.post(

--- a/backend/tests/unit/test_button_macro_alpine_disabled.py
+++ b/backend/tests/unit/test_button_macro_alpine_disabled.py
@@ -1,0 +1,54 @@
+"""ABOUTME: Jinja render tests for the button macro's alpine_disabled param.
+ABOUTME: Verifies the rendered HTML carries reactive Alpine bindings and the muted-class toggle."""
+
+from flask import Flask, render_template_string
+
+from opendlp import config
+from opendlp.translations import gettext
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__, template_folder=str(config.get_templates_path()))
+    app.config["TESTING"] = True
+    app.jinja_env.globals["_"] = gettext
+    app.jinja_env.globals["gettext"] = gettext
+    return app
+
+
+def _render(macro_call: str) -> str:
+    app = _make_app()
+    with app.test_request_context("/"):
+        return render_template_string(
+            '{% from "backoffice/components/button.html" import button %}' + macro_call,
+        )
+
+
+class TestButtonMacroAlpineDisabled:
+    def test_emits_alpine_bindings_when_alpine_disabled_provided(self):
+        html = _render('{{ button("Save", variant="primary", alpine_disabled="!form.name") }}')
+        assert ':disabled="!form.name"' in html
+        assert ":aria-disabled=" in html
+        assert "btn-runtime-disabled" in html
+        # The Alpine expression must appear inside the :class object literal
+        assert "!form.name" in html
+
+    def test_does_not_emit_alpine_bindings_when_alpine_disabled_absent(self):
+        html = _render('{{ button("Save", variant="primary") }}')
+        assert ":disabled=" not in html
+        assert ":aria-disabled=" not in html
+        assert "btn-runtime-disabled" not in html
+
+    def test_static_disabled_still_renders_muted_style_and_html_attr(self):
+        html = _render('{{ button("Save", variant="primary", disabled=true) }}')
+        assert " disabled " in html or "disabled>" in html or 'disabled aria-disabled="true"' in html
+        # The Jinja-time muted style uses the placeholder text colour token
+        assert "color: var(--color-placeholder-text)" in html
+
+    def test_alpine_disabled_keeps_static_active_variant_style(self):
+        """Static `style` keeps the active look so padding/base styles survive when
+        Alpine merges the reactive :class on top."""
+        html = _render('{{ button("Save", variant="primary", alpine_disabled="locked") }}')
+        # Active primary background colour is still in the inline style attribute
+        assert "color: var(--color-button-primary-text)" in html
+        # Padding / base styles should remain in the rendered inline style
+        assert "padding:" in html

--- a/backend/tests/unit/test_dev_image_handlers.py
+++ b/backend/tests/unit/test_dev_image_handlers.py
@@ -30,7 +30,7 @@ def assembly_id() -> uuid.UUID:
     return uuid.uuid4()
 
 
-def _image(*, alt: str = "Logo", sha256: str = "a" * 64) -> RegistrationImage:
+def _image(*, alt: str = "Logo", sha256: str = "a" * 64, original_filename: str = "") -> RegistrationImage:
     return RegistrationImage(
         registration_page_id=uuid.uuid4(),
         byte_size=321,
@@ -39,18 +39,20 @@ def _image(*, alt: str = "Logo", sha256: str = "a" * 64) -> RegistrationImage:
         sha256=sha256,
         data=b"\x89PNG-bytes",
         alt=alt,
+        original_filename=original_filename,
         created_by=uuid.uuid4(),
     )
 
 
 class TestSerialiseImage:
     def test_emits_expected_fields(self):
-        image = _image(alt="Hello", sha256="e" * 64)
+        image = _image(alt="Hello", sha256="e" * 64, original_filename="logo.png")
         result = _serialise_image(image)
         assert result["id"] == str(image.id)
         assert result["alt"] == "Hello"
         assert result["sha256"] == "e" * 64
         assert result["file_name"] == f"{'e' * 64}.png"
+        assert result["original_filename"] == "logo.png"
         assert result["width"] == 200
         assert result["height"] == 150
         assert result["byte_size"] == 321
@@ -72,7 +74,12 @@ class TestHandleAddRegistrationImage:
             cu.id = uuid.uuid4()
             result = _handle_add_registration_image(
                 uow=MagicMock(),
-                params={"assembly_id": str(assembly_id), "image_base64": b64, "alt": "Decoded"},
+                params={
+                    "assembly_id": str(assembly_id),
+                    "image_base64": b64,
+                    "alt": "Decoded",
+                    "original_filename": "logo.png",
+                },
             )
 
         assert result["status"] == "success"
@@ -80,6 +87,7 @@ class TestHandleAddRegistrationImage:
         _, kwargs = add.call_args
         assert kwargs["raw"] == raw_bytes
         assert kwargs["alt"] == "Decoded"
+        assert kwargs["original_filename"] == "logo.png"
 
     def test_strips_data_url_prefix(self, app, assembly_id):
         stored = _image()

--- a/backend/tests/unit/test_dev_image_handlers.py
+++ b/backend/tests/unit/test_dev_image_handlers.py
@@ -1,0 +1,242 @@
+"""ABOUTME: Unit tests for the dev /service-docs image-service handlers
+ABOUTME: Covers _serialise_image and the six _handle_* functions for the Images tab"""
+
+import base64
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opendlp.domain.registration_image import RegistrationImage
+from opendlp.entrypoints.blueprints.dev import (
+    _handle_add_registration_image,
+    _handle_delete_registration_image,
+    _handle_get_registration_image_for_serving,
+    _handle_list_image_snippets,
+    _handle_list_registration_images,
+    _handle_set_registration_image_alt,
+    _serialise_image,
+)
+from opendlp.entrypoints.flask_app import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app("testing")
+
+
+@pytest.fixture
+def assembly_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+def _image(*, alt: str = "Logo", sha256: str = "a" * 64) -> RegistrationImage:
+    return RegistrationImage(
+        registration_page_id=uuid.uuid4(),
+        byte_size=321,
+        width=200,
+        height=150,
+        sha256=sha256,
+        data=b"\x89PNG-bytes",
+        alt=alt,
+        created_by=uuid.uuid4(),
+    )
+
+
+class TestSerialiseImage:
+    def test_emits_expected_fields(self):
+        image = _image(alt="Hello", sha256="e" * 64)
+        result = _serialise_image(image)
+        assert result["id"] == str(image.id)
+        assert result["alt"] == "Hello"
+        assert result["sha256"] == "e" * 64
+        assert result["file_name"] == f"{'e' * 64}.png"
+        assert result["width"] == 200
+        assert result["height"] == 150
+        assert result["byte_size"] == 321
+
+
+class TestHandleAddRegistrationImage:
+    def test_decodes_base64_and_returns_serialised_image(self, app, assembly_id):
+        stored = _image(alt="Decoded")
+        raw_bytes = b"\x89PNG\r\n\x1a\nfake"
+        b64 = base64.b64encode(raw_bytes).decode()
+        with (
+            app.test_request_context(),
+            patch("opendlp.entrypoints.blueprints.dev.current_user") as cu,
+            patch(
+                "opendlp.entrypoints.blueprints.dev.add_registration_image",
+                return_value=stored,
+            ) as add,
+        ):
+            cu.id = uuid.uuid4()
+            result = _handle_add_registration_image(
+                uow=MagicMock(),
+                params={"assembly_id": str(assembly_id), "image_base64": b64, "alt": "Decoded"},
+            )
+
+        assert result["status"] == "success"
+        assert result["image"]["alt"] == "Decoded"
+        _, kwargs = add.call_args
+        assert kwargs["raw"] == raw_bytes
+        assert kwargs["alt"] == "Decoded"
+
+    def test_strips_data_url_prefix(self, app, assembly_id):
+        stored = _image()
+        raw_bytes = b"\x89PNG-data-url"
+        b64 = base64.b64encode(raw_bytes).decode()
+        with (
+            app.test_request_context(),
+            patch("opendlp.entrypoints.blueprints.dev.current_user") as cu,
+            patch(
+                "opendlp.entrypoints.blueprints.dev.add_registration_image",
+                return_value=stored,
+            ) as add,
+        ):
+            cu.id = uuid.uuid4()
+            _handle_add_registration_image(
+                uow=MagicMock(),
+                params={
+                    "assembly_id": str(assembly_id),
+                    "image_base64": f"data:image/png;base64,{b64}",
+                    "alt": "Alt",
+                },
+            )
+
+        _, kwargs = add.call_args
+        assert kwargs["raw"] == raw_bytes
+
+
+class TestHandleListRegistrationImages:
+    def test_returns_serialised_list(self, app, assembly_id):
+        images = [_image(alt="A", sha256="1" * 64), _image(alt="B", sha256="2" * 64)]
+        with (
+            app.test_request_context(),
+            patch("opendlp.entrypoints.blueprints.dev.current_user") as cu,
+            patch(
+                "opendlp.entrypoints.blueprints.dev.list_registration_images",
+                return_value=images,
+            ) as list_fn,
+        ):
+            cu.id = uuid.uuid4()
+            result = _handle_list_registration_images(
+                uow=MagicMock(),
+                params={"assembly_id": str(assembly_id)},
+            )
+
+        assert result["status"] == "success"
+        assert result["total_count"] == 2
+        assert {img["alt"] for img in result["images"]} == {"A", "B"}
+        list_fn.assert_called_once()
+
+
+class TestHandleDeleteRegistrationImage:
+    def test_deletes_and_returns_id(self, app, assembly_id):
+        image_id = uuid.uuid4()
+        with (
+            app.test_request_context(),
+            patch("opendlp.entrypoints.blueprints.dev.current_user") as cu,
+            patch("opendlp.entrypoints.blueprints.dev.delete_registration_image") as delete,
+        ):
+            cu.id = uuid.uuid4()
+            result = _handle_delete_registration_image(
+                uow=MagicMock(),
+                params={"assembly_id": str(assembly_id), "image_id": str(image_id)},
+            )
+
+        assert result == {"status": "success", "deleted_image_id": str(image_id)}
+        delete.assert_called_once()
+
+
+class TestHandleSetRegistrationImageAlt:
+    def test_updates_alt_and_returns_serialised_image(self, app, assembly_id):
+        image_id = uuid.uuid4()
+        updated = _image(alt="Renamed")
+        with (
+            app.test_request_context(),
+            patch("opendlp.entrypoints.blueprints.dev.current_user") as cu,
+            patch(
+                "opendlp.entrypoints.blueprints.dev.set_registration_image_alt",
+                return_value=updated,
+            ) as set_alt,
+        ):
+            cu.id = uuid.uuid4()
+            result = _handle_set_registration_image_alt(
+                uow=MagicMock(),
+                params={
+                    "assembly_id": str(assembly_id),
+                    "image_id": str(image_id),
+                    "alt": "Renamed",
+                },
+            )
+
+        assert result["status"] == "success"
+        assert result["image"]["alt"] == "Renamed"
+        _, kwargs = set_alt.call_args
+        assert kwargs["alt"] == "Renamed"
+
+
+class TestHandleListImageSnippets:
+    def test_pairs_image_with_html_snippet(self, app, assembly_id):
+        image_a = _image(alt="Alpha", sha256="3" * 64)
+        image_b = _image(alt="Beta", sha256="4" * 64)
+        page = MagicMock()
+        page.url_slug = "my-slug"
+        # Mock the page repo lookup the handler does to derive the URL slug
+        repo_uow = MagicMock()
+        repo_uow.__enter__ = MagicMock(return_value=repo_uow)
+        repo_uow.__exit__ = MagicMock(return_value=False)
+        repo_uow.registration_pages.get_by_assembly_id = MagicMock(return_value=page)
+        with (
+            app.test_request_context(),
+            patch("opendlp.entrypoints.blueprints.dev.current_user") as cu,
+            patch("opendlp.entrypoints.blueprints.dev.bootstrap.bootstrap", return_value=repo_uow),
+            patch(
+                "opendlp.entrypoints.blueprints.dev.list_image_snippets",
+                return_value=[(image_a, '<img src="..." alt="Alpha">'), (image_b, '<img src="..." alt="Beta">')],
+            ),
+        ):
+            cu.id = uuid.uuid4()
+            result = _handle_list_image_snippets(
+                uow=MagicMock(),
+                params={"assembly_id": str(assembly_id)},
+            )
+
+        assert result["status"] == "success"
+        assert result["total_count"] == 2
+        assert result["snippets"][0]["image"]["alt"] == "Alpha"
+        assert "Alpha" in result["snippets"][0]["html"]
+
+
+class TestHandleGetRegistrationImageForServing:
+    def test_found_returns_serialised_image(self, app):
+        image = _image(alt="Public", sha256="5" * 64)
+        with (
+            app.test_request_context(),
+            patch(
+                "opendlp.entrypoints.blueprints.dev.get_registration_image_for_serving",
+                return_value=image,
+            ) as lookup,
+        ):
+            result = _handle_get_registration_image_for_serving(
+                uow=MagicMock(),
+                params={"url_slug": "my-slug", "image_name": f"{'5' * 64}.png"},
+            )
+
+        assert result == {"status": "success", "found": True, "image": _serialise_image(image)}
+        lookup.assert_called_once()
+
+    def test_not_found_returns_none(self, app):
+        with (
+            app.test_request_context(),
+            patch(
+                "opendlp.entrypoints.blueprints.dev.get_registration_image_for_serving",
+                return_value=None,
+            ),
+        ):
+            result = _handle_get_registration_image_for_serving(
+                uow=MagicMock(),
+                params={"url_slug": "bad-slug", "image_name": "x.png"},
+            )
+
+        assert result == {"status": "success", "found": False, "image": None}

--- a/backend/tests/unit/test_registration_image_service.py
+++ b/backend/tests/unit/test_registration_image_service.py
@@ -135,7 +135,7 @@ class TestAddRegistrationImage:
 
         assert image.alt == "A red square"
 
-    def test_dedup_keeps_first_alt(self):
+    def test_dedup_updates_alt(self):
         uow = FakeUnitOfWork()
         admin, assembly = _admin(uow), _assembly(uow)
         _page(uow, assembly)
@@ -143,7 +143,7 @@ class TestAddRegistrationImage:
         service.add_registration_image(uow, admin.id, assembly.id, _png(), alt="First caption")
         second = service.add_registration_image(uow, admin.id, assembly.id, _png(), alt="Second caption")
 
-        assert second.alt == "First caption"
+        assert second.alt == "Second caption"
 
     def test_stores_original_filename(self):
         uow = FakeUnitOfWork()

--- a/backend/tests/unit/test_registration_image_service.py
+++ b/backend/tests/unit/test_registration_image_service.py
@@ -145,6 +145,40 @@ class TestAddRegistrationImage:
 
         assert second.alt == "First caption"
 
+    def test_stores_original_filename(self):
+        uow = FakeUnitOfWork()
+        admin, assembly = _admin(uow), _assembly(uow)
+        _page(uow, assembly)
+
+        image = service.add_registration_image(
+            uow, admin.id, assembly.id, _png(), alt="A red square", original_filename="red square.png"
+        )
+
+        assert image.original_filename == "red square.png"
+
+    def test_sanitises_original_filename(self):
+        uow = FakeUnitOfWork()
+        admin, assembly = _admin(uow), _assembly(uow)
+        _page(uow, assembly)
+
+        image = service.add_registration_image(
+            uow, admin.id, assembly.id, _png(), alt="A red square", original_filename="/home/user/red square.png"
+        )
+
+        assert image.original_filename == "red square.png"
+
+    def test_dedup_keeps_first_original_filename(self):
+        uow = FakeUnitOfWork()
+        admin, assembly = _admin(uow), _assembly(uow)
+        _page(uow, assembly)
+
+        service.add_registration_image(uow, admin.id, assembly.id, _png(), alt="x", original_filename="first.png")
+        second = service.add_registration_image(
+            uow, admin.id, assembly.id, _png(), alt="x", original_filename="second.png"
+        )
+
+        assert second.original_filename == "first.png"
+
     def test_dedup_returns_existing_without_new_row_or_activity(self):
         uow = FakeUnitOfWork()
         admin, assembly = _admin(uow), _assembly(uow)

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-17 16:50+0100\n"
+"POT-Creation-Date: 2026-06-17 16:52+0100\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1356,8 +1356,8 @@ msgstr ""
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:407
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:436
-#: templates/backoffice/assembly_registration.html:825
-#: templates/backoffice/assembly_registration.html:921
+#: templates/backoffice/assembly_registration.html:837
+#: templates/backoffice/assembly_registration.html:933
 msgid "Alt text is required for accessibility"
 msgstr ""
 
@@ -3180,7 +3180,7 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
 #: templates/backoffice/assembly_registration.html:580
-#: templates/backoffice/assembly_registration.html:681
+#: templates/backoffice/assembly_registration.html:693
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:37
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -4669,7 +4669,7 @@ msgid "Preview and Test Responses"
 msgstr ""
 
 #: templates/backoffice/assembly_registration.html:202
-#: templates/backoffice/assembly_registration.html:682
+#: templates/backoffice/assembly_registration.html:694
 #: templates/backoffice/components/edit_number_to_select_modal.html:38
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4775,13 +4775,13 @@ msgid "Image file"
 msgstr ""
 
 #: templates/backoffice/assembly_registration.html:555
-#: templates/backoffice/assembly_registration.html:656
+#: templates/backoffice/assembly_registration.html:668
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
 #: templates/backoffice/assembly_registration.html:567
-#: templates/backoffice/assembly_registration.html:668
+#: templates/backoffice/assembly_registration.html:680
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
@@ -4805,87 +4805,91 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:642
+#: templates/backoffice/assembly_registration.html:645
+msgid "Open image in new tab"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:654
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:647
+#: templates/backoffice/assembly_registration.html:659
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:650
+#: templates/backoffice/assembly_registration.html:662
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:766
+#: templates/backoffice/assembly_registration.html:778
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:785
+#: templates/backoffice/assembly_registration.html:797
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:788
-#: templates/backoffice/assembly_registration.html:898
+#: templates/backoffice/assembly_registration.html:800
+#: templates/backoffice/assembly_registration.html:910
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:843
+#: templates/backoffice/assembly_registration.html:855
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:854
+#: templates/backoffice/assembly_registration.html:866
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:857
+#: templates/backoffice/assembly_registration.html:869
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:866
+#: templates/backoffice/assembly_registration.html:878
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:877
+#: templates/backoffice/assembly_registration.html:889
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:881
+#: templates/backoffice/assembly_registration.html:893
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:884
+#: templates/backoffice/assembly_registration.html:896
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:893
+#: templates/backoffice/assembly_registration.html:905
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:897
+#: templates/backoffice/assembly_registration.html:909
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:937
+#: templates/backoffice/assembly_registration.html:949
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:945
+#: templates/backoffice/assembly_registration.html:957
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:948
+#: templates/backoffice/assembly_registration.html:960
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-17 16:52+0100\n"
+"POT-Creation-Date: 2026-06-17 16:54+0100\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1356,8 +1356,8 @@ msgstr ""
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:407
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:436
-#: templates/backoffice/assembly_registration.html:837
-#: templates/backoffice/assembly_registration.html:933
+#: templates/backoffice/assembly_registration.html:846
+#: templates/backoffice/assembly_registration.html:952
 msgid "Alt text is required for accessibility"
 msgstr ""
 
@@ -3180,7 +3180,7 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
 #: templates/backoffice/assembly_registration.html:580
-#: templates/backoffice/assembly_registration.html:693
+#: templates/backoffice/assembly_registration.html:702
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:37
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -4669,7 +4669,7 @@ msgid "Preview and Test Responses"
 msgstr ""
 
 #: templates/backoffice/assembly_registration.html:202
-#: templates/backoffice/assembly_registration.html:694
+#: templates/backoffice/assembly_registration.html:703
 #: templates/backoffice/components/edit_number_to_select_modal.html:38
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4775,13 +4775,13 @@ msgid "Image file"
 msgstr ""
 
 #: templates/backoffice/assembly_registration.html:555
-#: templates/backoffice/assembly_registration.html:668
+#: templates/backoffice/assembly_registration.html:677
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
 #: templates/backoffice/assembly_registration.html:567
-#: templates/backoffice/assembly_registration.html:680
+#: templates/backoffice/assembly_registration.html:689
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
@@ -4805,91 +4805,103 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:645
-msgid "Open image in new tab"
+#: templates/backoffice/assembly_registration.html:644
+#: templates/backoffice/components/url_display.html:36
+#: templates/backoffice/components/url_display.html:38
+msgid "Copy URL to clipboard"
 msgstr ""
 
 #: templates/backoffice/assembly_registration.html:654
+msgid "Open image in new tab"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:663
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:659
+#: templates/backoffice/assembly_registration.html:668
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:662
+#: templates/backoffice/assembly_registration.html:671
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:778
+#: templates/backoffice/assembly_registration.html:787
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:797
+#: templates/backoffice/assembly_registration.html:806
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:800
-#: templates/backoffice/assembly_registration.html:910
+#: templates/backoffice/assembly_registration.html:809
+#: templates/backoffice/assembly_registration.html:919
+#: templates/backoffice/assembly_registration.html:929
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:855
+#: templates/backoffice/assembly_registration.html:864
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:866
+#: templates/backoffice/assembly_registration.html:875
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:869
+#: templates/backoffice/assembly_registration.html:878
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:878
+#: templates/backoffice/assembly_registration.html:887
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:889
+#: templates/backoffice/assembly_registration.html:898
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:893
+#: templates/backoffice/assembly_registration.html:902
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:896
+#: templates/backoffice/assembly_registration.html:905
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:905
+#: templates/backoffice/assembly_registration.html:914
+#: templates/backoffice/assembly_registration.html:924
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:909
+#: templates/backoffice/assembly_registration.html:918
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:949
+#: templates/backoffice/assembly_registration.html:928
+msgid "URL copied to clipboard"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:968
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:957
+#: templates/backoffice/assembly_registration.html:976
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:960
+#: templates/backoffice/assembly_registration.html:979
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -6078,11 +6090,6 @@ msgstr "Az oldal nem elérhető"
 #, fuzzy
 msgid "More actions"
 msgstr "Kiválasztás"
-
-#: templates/backoffice/components/url_display.html:36
-#: templates/backoffice/components/url_display.html:38
-msgid "Copy URL to clipboard"
-msgstr ""
 
 #: templates/backoffice/patterns/_ajax.html:9
 msgid "Documentation for AJAX patterns coming soon..."

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-12 13:14+0100\n"
+"POT-Creation-Date: 2026-06-17 16:50+0100\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1053,7 +1053,7 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:160
 #: src/opendlp/entrypoints/blueprints/backoffice.py:397
 #: src/opendlp/entrypoints/blueprints/backoffice.py:444
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:100
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:157
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:80
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:91
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:126
@@ -1092,11 +1092,14 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:299
 #: src/opendlp/entrypoints/blueprints/backoffice.py:393
 #: src/opendlp/entrypoints/blueprints/backoffice.py:440
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:104
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:186
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:221
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:246
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:291
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:161
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:243
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:278
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:303
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:348
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:420
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:448
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:472
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:77
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:383
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:410
@@ -1252,91 +1255,138 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:110
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:167
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:122
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:179
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:123
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:180
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:127
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:184
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:131
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:188
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:135
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:192
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:139
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:196
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:140
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:197
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:178
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:235
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:416
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:182
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:218
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:239
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:275
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:418
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:446
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:470
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:199
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:256
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:213
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:270
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:226
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:283
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:231
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:288
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:244
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:287
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:301
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:344
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:249
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:306
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:295
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:352
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:397
+#, fuzzy
+msgid "No file was selected"
+msgstr "Táblázat lapfülei"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:403
+msgid "Failed to read the uploaded file"
+msgstr ""
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:407
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:436
+#: templates/backoffice/assembly_registration.html:825
+#: templates/backoffice/assembly_registration.html:921
+msgid "Alt text is required for accessibility"
+msgstr ""
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:424
+#, fuzzy
+msgid "An error occurred while uploading the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:442
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:466
+#, fuzzy
+msgid "Image not found"
+msgstr "Az oldal nem elérhető"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:444
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:468
+#, fuzzy
+msgid "Registration page not found"
+msgstr "Vissza a regisztrációhoz"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:451
+#, fuzzy
+msgid "An error occurred while updating the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:475
+#, fuzzy
+msgid "An error occurred while deleting the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
 
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:54
 msgid "Please review and save the selection settings before checking data."
@@ -1524,28 +1574,28 @@ msgstr "További beállítások"
 msgid "An unexpected error occurred"
 msgstr "Hiba történt a betöltés indítása közben"
 
-#: src/opendlp/entrypoints/blueprints/dev.py:86
-#: src/opendlp/entrypoints/blueprints/dev.py:106
-#: src/opendlp/entrypoints/blueprints/dev.py:902
-#: src/opendlp/entrypoints/blueprints/dev.py:927
+#: src/opendlp/entrypoints/blueprints/dev.py:103
+#: src/opendlp/entrypoints/blueprints/dev.py:123
+#: src/opendlp/entrypoints/blueprints/dev.py:1093
+#: src/opendlp/entrypoints/blueprints/dev.py:1118
 #, fuzzy
 msgid "You don't have permission to access developer tools"
 msgstr "Jelenleg egy közösségi gyűlés eléréséhez sincs jogosultságod"
 
-#: src/opendlp/entrypoints/blueprints/dev.py:935
+#: src/opendlp/entrypoints/blueprints/dev.py:1126
 msgid "Success! Your changes have been saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/dev.py:936
+#: src/opendlp/entrypoints/blueprints/dev.py:1127
 msgid "Warning: Please review the data before continuing."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/dev.py:937
+#: src/opendlp/entrypoints/blueprints/dev.py:1128
 #, fuzzy
 msgid "Error: Something went wrong. Please try again."
 msgstr "Hiba történt a bejelentkezés során. Kérjük, próbáld újra."
 
-#: src/opendlp/entrypoints/blueprints/dev.py:938
+#: src/opendlp/entrypoints/blueprints/dev.py:1129
 msgid "Info: A new feature is available."
 msgstr ""
 
@@ -3129,6 +3179,8 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_data.html:508
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
+#: templates/backoffice/assembly_registration.html:580
+#: templates/backoffice/assembly_registration.html:681
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:37
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -3169,7 +3221,7 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:341
+#: templates/backoffice/assembly_registration.html:438
 #: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Registration URL"
@@ -4024,6 +4076,7 @@ msgstr ""
 "beállításokat? Ez a művelet nem vonható vissza."
 
 #: templates/backoffice/assembly_data.html:82
+#: templates/backoffice/assembly_registration.html:314
 #: templates/backoffice/targets/category_block.html:32
 #: templates/backoffice/targets/category_block.html:157
 #: templates/targets/components/category_block.html:21
@@ -4249,6 +4302,8 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
+#: templates/backoffice/assembly_registration.html:250
+#: templates/backoffice/assembly_registration.html:581
 msgid "Upload"
 msgstr ""
 
@@ -4361,46 +4416,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:342
+#: templates/backoffice/assembly_registration.html:439
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:349
+#: templates/backoffice/assembly_registration.html:446
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:350
+#: templates/backoffice/assembly_registration.html:447
 #: templates/backoffice/edit_assembly.html:112
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:358
+#: templates/backoffice/assembly_registration.html:455
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:360
+#: templates/backoffice/assembly_registration.html:457
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:366
+#: templates/backoffice/assembly_registration.html:463
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:378
+#: templates/backoffice/assembly_registration.html:475
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:381
+#: templates/backoffice/assembly_registration.html:478
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4546,74 +4601,75 @@ msgstr ""
 msgid "Go to Details tab"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_registration.html:79
+#: templates/backoffice/assembly_registration.html:83
 #, fuzzy
 msgid "Registration Form HTML"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:89
-#: templates/backoffice/assembly_registration.html:113
-#: templates/backoffice/assembly_registration.html:137
+#: templates/backoffice/assembly_registration.html:93
+#: templates/backoffice/assembly_registration.html:117
+#: templates/backoffice/assembly_registration.html:141
 msgid "Published"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:95
+#: templates/backoffice/assembly_registration.html:99
 #, fuzzy
 msgid "Closed"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:102
-#: templates/backoffice/assembly_registration.html:128
+#: templates/backoffice/assembly_registration.html:106
+#: templates/backoffice/assembly_registration.html:132
 #, fuzzy
 msgid "Test"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:114
+#: templates/backoffice/assembly_registration.html:118
 msgid "Form goes live; submissions enter the selection pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:122
+#: templates/backoffice/assembly_registration.html:126
 msgid "Closed for Submissions"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:123
+#: templates/backoffice/assembly_registration.html:127
 msgid ""
 "Visitors are redirected to a registration-closed page; no new submissions"
 " are accepted."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:129
+#: templates/backoffice/assembly_registration.html:133
 msgid ""
 "Form stays public, but new submissions are flagged as test entries and "
 "skipped from the pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:138
+#: templates/backoffice/assembly_registration.html:142
 msgid "Form goes live again; new submissions enter the selection pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:145
+#: templates/backoffice/assembly_registration.html:149
 #, fuzzy
 msgid "Change status"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:159
+#: templates/backoffice/assembly_registration.html:163
 msgid "Show Form Skeleton"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:169
+#: templates/backoffice/assembly_registration.html:173
 msgid ""
 "Paste your HTML form code below. The only required placeholders are {{ "
 "form_action }} for the form's action attribute and {{ csrf_form_element "
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:193
-#: templates/backoffice/assembly_registration.html:294
+#: templates/backoffice/assembly_registration.html:197
+#: templates/backoffice/assembly_registration.html:391
 msgid "Preview and Test Responses"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:198
+#: templates/backoffice/assembly_registration.html:202
+#: templates/backoffice/assembly_registration.html:682
 #: templates/backoffice/components/edit_number_to_select_modal.html:38
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4626,30 +4682,56 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:207
-#: templates/backoffice/assembly_registration.html:216
-#: templates/backoffice/assembly_registration.html:294
+#: templates/backoffice/assembly_registration.html:211
+#: templates/backoffice/assembly_registration.html:220
+#: templates/backoffice/assembly_registration.html:391
 msgid "Share Form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:212
+#: templates/backoffice/assembly_registration.html:216
 #, fuzzy
 msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:220
-#: templates/backoffice/assembly_registration.html:221
+#: templates/backoffice/assembly_registration.html:224
+#: templates/backoffice/assembly_registration.html:225
 msgid "Registration is closed — the form URL redirects to the closed page"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:252
+#: templates/backoffice/assembly_registration.html:243
+#, fuzzy
+msgid "Assets"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/assembly_registration.html:264
+#, python-format
+msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:271
+#, fuzzy
+msgid "No images uploaded yet."
+msgstr "Feladat állapota"
+
+#: templates/backoffice/assembly_registration.html:293
+#, fuzzy
+msgid "Details for"
+msgstr "Hiba részletei"
+
+#: templates/backoffice/assembly_registration.html:303
+msgid "Copy <img> snippet for"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:349
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:258
-#: templates/backoffice/assembly_registration.html:320
-#: templates/backoffice/assembly_registration.html:392
+#: templates/backoffice/assembly_registration.html:355
+#: templates/backoffice/assembly_registration.html:417
+#: templates/backoffice/assembly_registration.html:489
+#: templates/backoffice/assembly_registration.html:524
+#: templates/backoffice/assembly_registration.html:615
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:54
@@ -4660,35 +4742,153 @@ msgstr "Rétegzett kiválasztás"
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:267
+#: templates/backoffice/assembly_registration.html:364
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:285
+#: templates/backoffice/assembly_registration.html:382
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:333
+#: templates/backoffice/assembly_registration.html:430
 msgid ""
 "The form is in test mode. Submissions made via these URLs are recorded as"
 " test submissions and will not enter the selection pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:448
+#: templates/backoffice/assembly_registration.html:517
+#, fuzzy
+msgid "Upload image"
+msgstr "Kész"
+
+#: templates/backoffice/assembly_registration.html:533
+#, python-format
+msgid ""
+"Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
+"Files are downscaled and re-encoded to PNG on upload."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:539
+msgid "Image file"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:555
+#: templates/backoffice/assembly_registration.html:656
+#, fuzzy
+msgid "Alt text"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/assembly_registration.html:567
+#: templates/backoffice/assembly_registration.html:668
+msgid ""
+"Describes the image for screen-reader users and is used as the file's "
+"display name in the asset list."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:608
+#, fuzzy
+msgid "Image details"
+msgstr "Meghívó kód"
+
+#: templates/backoffice/assembly_registration.html:625
+#, fuzzy
+msgid "File name"
+msgstr "Keresztnév"
+
+#: templates/backoffice/assembly_registration.html:630
+msgid "Original filename"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:637
+msgid "URL"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:642
+#, fuzzy
+msgid "Dimensions"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/assembly_registration.html:647
+msgid "px"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:650
+msgid "File size"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:766
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:467
+#: templates/backoffice/assembly_registration.html:785
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:470
+#: templates/backoffice/assembly_registration.html:788
+#: templates/backoffice/assembly_registration.html:898
 msgid "Failed to copy to clipboard"
 msgstr ""
+
+#: templates/backoffice/assembly_registration.html:843
+#, fuzzy
+msgid "Upload failed"
+msgstr "Kész"
+
+#: templates/backoffice/assembly_registration.html:854
+#, fuzzy
+msgid "Image uploaded"
+msgstr "Új jelszó"
+
+#: templates/backoffice/assembly_registration.html:857
+#, fuzzy
+msgid "Network error while uploading the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: templates/backoffice/assembly_registration.html:866
+#, fuzzy
+msgid "Delete this image?"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/assembly_registration.html:877
+msgid "Failed to delete image"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:881
+#, fuzzy
+msgid "Image deleted"
+msgstr "Kiválasztás"
+
+#: templates/backoffice/assembly_registration.html:884
+#, fuzzy
+msgid "Network error while deleting the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: templates/backoffice/assembly_registration.html:893
+msgid "No public URL available yet"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:897
+msgid "Snippet copied to clipboard"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:937
+#, fuzzy
+msgid "Failed to update image"
+msgstr "Utoljára módosítva"
+
+#: templates/backoffice/assembly_registration.html:945
+#, fuzzy
+msgid "Image updated"
+msgstr "Utoljára módosítva"
+
+#: templates/backoffice/assembly_registration.html:948
+#, fuzzy
+msgid "Network error while updating the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
 
 #: templates/backoffice/assembly_respondents.html:30
 #, fuzzy
@@ -5553,7 +5753,12 @@ msgstr ""
 msgid "CSV Config"
 msgstr "Beállítások mentése"
 
-#: templates/backoffice/service_docs.html:49
+#: templates/backoffice/service_docs.html:48
+#, fuzzy
+msgid "Images"
+msgstr "Jelentések a folyamatról"
+
+#: templates/backoffice/service_docs.html:50
 #, fuzzy
 msgid "Service categories"
 msgstr "Feladat állapota"
@@ -5970,6 +6175,7 @@ msgstr ""
 #: templates/backoffice/service_docs/_fields.html:427
 #: templates/backoffice/service_docs/_fields.html:455
 #: templates/backoffice/service_docs/_fields.html:483
+#: templates/backoffice/service_docs/_images.html:35
 #: templates/backoffice/service_docs/_registration.html:366
 #: templates/backoffice/service_docs/_registration.html:481
 #: templates/backoffice/service_docs/_registration.html:571
@@ -7340,6 +7546,8 @@ msgstr ""
 #: templates/backoffice/service_docs/_fields.html:433
 #: templates/backoffice/service_docs/_fields.html:461
 #: templates/backoffice/service_docs/_fields.html:492
+#: templates/backoffice/service_docs/_images.html:75
+#: templates/backoffice/service_docs/_images.html:176
 #: templates/backoffice/service_docs/_registration.html:401
 #: templates/backoffice/service_docs/_registration.html:502
 #: templates/backoffice/service_docs/_registration.html:620
@@ -7366,6 +7574,12 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:128
 #: templates/backoffice/service_docs/_assembly.html:235
 #: templates/backoffice/service_docs/_assembly.html:343
+#: templates/backoffice/service_docs/_images.html:106
+#: templates/backoffice/service_docs/_images.html:186
+#: templates/backoffice/service_docs/_images.html:239
+#: templates/backoffice/service_docs/_images.html:300
+#: templates/backoffice/service_docs/_images.html:368
+#: templates/backoffice/service_docs/_images.html:421
 #: templates/backoffice/service_docs/_registration.html:422
 #: templates/backoffice/service_docs/_registration.html:512
 #: templates/backoffice/service_docs/_registration.html:641
@@ -7382,6 +7596,12 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:166
 #: templates/backoffice/service_docs/_assembly.html:260
 #: templates/backoffice/service_docs/_assembly.html:384
+#: templates/backoffice/service_docs/_images.html:149
+#: templates/backoffice/service_docs/_images.html:209
+#: templates/backoffice/service_docs/_images.html:270
+#: templates/backoffice/service_docs/_images.html:338
+#: templates/backoffice/service_docs/_images.html:391
+#: templates/backoffice/service_docs/_images.html:449
 #: templates/backoffice/service_docs/_registration.html:447
 #: templates/backoffice/service_docs/_registration.html:537
 #: templates/backoffice/service_docs/_registration.html:682
@@ -7588,6 +7808,73 @@ msgid ""
 "Called automatically during CSV import."
 msgstr ""
 
+#: templates/backoffice/service_docs/_images.html:6
+msgid ""
+"Upload, list, retag and delete images attached to an assembly's "
+"registration page. Uploaded files are validated, EXIF-stripped, "
+"downscaled to PNG and de-duplicated by SHA-256."
+msgstr ""
+
+#: templates/backoffice/service_docs/_images.html:9
+msgid ""
+"Allowed input formats: PNG, JPEG, WebP. The page must already exist (use "
+"the Registration tab to create one)."
+msgstr ""
+
+#: templates/backoffice/service_docs/_images.html:30
+msgid ""
+"Validate, process and store an image for the assembly's registration "
+"page. Identical bytes on the same page collapse to one row."
+msgstr ""
+
+#: templates/backoffice/service_docs/_images.html:84
+#: templates/backoffice/service_docs/_registration.html:409
+#: templates/backoffice/service_docs/_registration.html:628
+#: templates/backoffice/service_docs/_registration.html:756
+#: templates/backoffice/service_docs/_registration.html:970
+#: templates/backoffice/service_docs/_registration.html:1086
+#: templates/backoffice/service_docs/_registration.html:1198
+#: templates/backoffice/service_docs/_registration.html:1310
+#: templates/backoffice/service_docs/_respondents.html:118
+#: templates/backoffice/service_docs/_respondents.html:304
+#: templates/backoffice/service_docs/_selection.html:245
+#: templates/backoffice/service_docs/_selection.html:320
+#, fuzzy
+msgid "Error Cases"
+msgstr "Hiba részletei"
+
+#: templates/backoffice/service_docs/_images.html:173
+msgid ""
+"Return every image attached to the assembly's registration page. Empty "
+"list when no page exists yet."
+msgstr ""
+
+#: templates/backoffice/service_docs/_images.html:233
+msgid ""
+"Permanently delete an image. The image_id must belong to the assembly's "
+"registration page."
+msgstr ""
+
+#: templates/backoffice/service_docs/_images.html:294
+msgid ""
+"Update an image's alt text in place. Records an edit on the parent "
+"registration page."
+msgstr ""
+
+#: templates/backoffice/service_docs/_images.html:362
+msgid ""
+"List images paired with ready-to-paste <img> snippets. URLs point at the "
+"public /register/<slug>/assets/<sha>.png route."
+msgstr ""
+
+#: templates/backoffice/service_docs/_images.html:415
+msgid ""
+"Lookup helper used by the public /register/<slug>/assets/<image_name> "
+"route. Returns None unless the registration page is publicly loadable "
+"(TEST or PUBLISHED). The response here reports metadata; fetch the actual"
+" bytes from the public URL."
+msgstr ""
+
 #: templates/backoffice/service_docs/_registration.html:6
 msgid ""
 "A registration page has three statuses. New pages start in TEST mode. The"
@@ -7643,21 +7930,6 @@ msgid ""
 "Create a new registration page and its HTML source for an assembly. Each "
 "assembly can have only one registration page."
 msgstr ""
-
-#: templates/backoffice/service_docs/_registration.html:409
-#: templates/backoffice/service_docs/_registration.html:628
-#: templates/backoffice/service_docs/_registration.html:756
-#: templates/backoffice/service_docs/_registration.html:970
-#: templates/backoffice/service_docs/_registration.html:1086
-#: templates/backoffice/service_docs/_registration.html:1198
-#: templates/backoffice/service_docs/_registration.html:1310
-#: templates/backoffice/service_docs/_respondents.html:118
-#: templates/backoffice/service_docs/_respondents.html:304
-#: templates/backoffice/service_docs/_selection.html:245
-#: templates/backoffice/service_docs/_selection.html:320
-#, fuzzy
-msgid "Error Cases"
-msgstr "Hiba részletei"
 
 #: templates/backoffice/service_docs/_registration.html:477
 msgid ""


### PR DESCRIPTION
## Summary

Closes the frontend half of the registration-image work — Hamish's service layer ([#171](https://github.com/sortitionfoundation/opendlp/pull/171)) now has a UI in the backoffice plus a dev-tools tab and a small reusable button-macro extension.

- **Assets panel on the registration tab** — fixed-width column to the right of the HTML editor. Upload modal (multipart + `X-CSRFToken`), copy-`<img>`-snippet, delete, and an info-icon Details modal showing filename / dimensions / size and letting the user rename the alt. All AJAX, so the editor's unsaved state survives.
- **Alt text is now required** on upload and on edit, surfaced both client-side (button stays muted/disabled, inline error) and server-side (`400`). Honours the dedup quirk: when `add_registration_image` returns an existing row with a stale alt, the endpoint follows up with `set_registration_image_alt` so the snippet reflects what the user typed.
- **Images tab in `/backoffice/dev/service-docs`** — interactive cards for all six functions in `registration_image_service.py` (add / list / delete / set_alt / list_snippets / serve), upload via base64 in the existing JSON `/execute` endpoint.
- **`button` macro gains `alpine_disabled`** — Alpine boolean expression that toggles the HTML `disabled` attribute, `aria-disabled`, and a new `.btn-runtime-disabled` class (CSS-class merge, not `:style` replace) so padding and base styles survive. Demoed in the Button showcase.

## Endpoints added

- `POST /backoffice/assembly/<id>/registration/images` — multipart upload, JSON response
- `PATCH /backoffice/assembly/<id>/registration/images/<image_id>` — `{ "alt": "..." }`
- `DELETE /backoffice/assembly/<id>/registration/images/<image_id>` — `204`

## Test plan

- [x] `uv run pytest tests/unit/test_backoffice_registration_images.py tests/unit/test_dev_image_handlers.py tests/unit/test_button_macro_alpine_disabled.py` — 27 happy-path tests across the new helpers, routes, dev handlers, and macro
- [ ] Manual: upload a PNG/JPEG/WebP on the registration tab, copy snippet, edit alt via info modal, delete
- [ ] Manual: enter unsaved HTML edits, upload an image → confirm the textarea is untouched
- [ ] Manual: `/backoffice/dev/service-docs?tab=images` works end-to-end
- [ ] Manual: `/backoffice/showcase` — the Variants section's "Disabled (Alpine)" column reacts to the switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)