### PR TITLE
Read-only HTML editor with Edit/Cancel CTAs

### DIFF
--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -132,6 +132,10 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             stored_images = list_registration_images(uow, current_user.id, assembly_id)
             images = [_image_to_dict(image, registration_page.url_slug) for image in stored_images]
 
+        # The HTML editor is read-only by default; ?edit=1 unlocks it. CLOSED pages
+        # have no save path so we always keep them read-only regardless of the param.
+        edit_mode = request.args.get("edit") == "1" and registration_status != "CLOSED"
+
         return render_template(
             "backoffice/assembly_registration.html",
             assembly=nav.assembly,
@@ -151,6 +155,7 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             images=images,
             max_image_upload_mb=get_max_image_upload_mb(),
             allowed_image_formats=sorted(ALLOWED_INPUT_FORMATS),
+            edit_mode=edit_mode,
         ), 200
     except InsufficientPermissions as e:
         current_app.logger.warning(f"Insufficient permissions for assembly {assembly_id} user {current_user.id}: {e}")
@@ -201,6 +206,15 @@ def _handle_registration_action(action: str, user_id: uuid.UUID, assembly_id: uu
 @login_required
 def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
     """Save and publish registration form HTML content."""
+    action = request.form.get("action", "save")
+    # If the user was editing (action="save") and the request fails, keep them in
+    # edit mode so they can fix and retry; status transitions only fire from
+    # read-only mode (the dropdown is disabled while editing), so they land back
+    # in read-only on error.
+    view_kwargs: dict[str, Any] = {"assembly_id": assembly_id}
+    if action == "save":
+        view_kwargs["edit"] = "1"
+    error_redirect_url = url_for("backoffice_registration.view_assembly_registration", **view_kwargs)
     try:
         # Verify user has permission to access this assembly (side effect: raises if unauthorized)
         get_assembly_nav_context(
@@ -211,7 +225,6 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
         )
 
         html_content = request.form.get("html_content", "")
-        action = request.form.get("action", "save")
 
         # Update HTML content (will raise RegistrationPageNotFoundError if page doesn't exist)
         uow = bootstrap.bootstrap()
@@ -219,6 +232,7 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
 
         flash_message = _handle_registration_action(action, current_user.id, assembly_id)
         flash(flash_message, "success")
+        # Success drops ?edit=1 — the user lands back in read-only.
         return redirect_preserving_scroll(
             url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id)
         )
@@ -227,9 +241,7 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
         error_message = "; ".join(e.problems)
         current_app.logger.warning(f"Registration page not ready for assembly {assembly_id}: {error_message}")
         flash(error_message, "error")
-        return redirect_preserving_scroll(
-            url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id)
-        )
+        return redirect_preserving_scroll(error_redirect_url)
     except RegistrationPageNotFoundError:
         # Registration page doesn't exist yet - redirect to Details tab to create it
         flash(_("Please create a registration page first from the Details tab."), "warning")
@@ -245,18 +257,14 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
     except ValueError as e:
         current_app.logger.warning(f"Validation error for assembly {assembly_id}: {e}")
         flash(str(e), "error")
-        return redirect_preserving_scroll(
-            url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id)
-        )
+        return redirect_preserving_scroll(error_redirect_url)
     except Exception as e:
         current_app.logger.error(
             f"Save assembly registration error for assembly {assembly_id} user {current_user.id}: {e}"
         )
         current_app.logger.exception("Full traceback:")
         flash(_("An error occurred while saving registration settings"), "error")
-        return redirect_preserving_scroll(
-            url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id)
-        )
+        return redirect_preserving_scroll(error_redirect_url)
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/create", methods=["POST"])

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -150,6 +150,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     items=status_items,
                                     variant="secondary",
                                     id="status-control",
+                                    disabled=edit_mode,
                                     ) }}
                                 </div>
                      {# Header right: editorial helper only (status controls live on the left next to the badge) #}
@@ -173,18 +174,25 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     {{ _("Paste your HTML form code below. The only required placeholders are {{ form_action }} for the form's action attribute and {{ csrf_form_element }} for CSRF protection.") }}
                                 </p>
 
-                    {# HTML Textarea with monospace font #}
+                    {# HTML Textarea with monospace font. `readonly` is the default;
+                       ?edit=1 unlocks it via the Edit CTA below. #}
+                                {% set textarea_attrs %}
+                                    {% if not edit_mode %}readonly aria-readonly="true" {% endif %}style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;{% if not edit_mode %} background-color: var(--color-subtle-background-panels); cursor: default;{% endif %}"
+                                {% endset %}
                                 {{ textarea(
                                 name="html_content",
                                 label="",
                                 value=html_content,
                                 placeholder="<form action=\"{{ form_action }}\" method=\"POST\">\n  {{ csrf_form_element }}\n  <div>\n    <label for=\"first_name\">First Name</label>\n    <input type=\"text\" id=\"first_name\" name=\"first_name\" required />\n  </div>\n  <!-- Add more fields here -->\n  <button type=\"submit\">Register</button>\n</form>",
                                 rows=25,
-                                attrs="style=\"font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;\""
+                                attrs=textarea_attrs|trim
                                 ) }}
 
-                    {# Footer: review the form + save edits. Status transitions live in the header dropdown. #}
+                    {# Footer: review the form + save edits. Status transitions live in the header dropdown.
+                       The primary action slot toggles between Edit (read-only, default) and Save/Cancel (edit_mode). #}
                                 <div class="flex justify-end gap-3">
+                                    {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, edit="1") %}
+                                    {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id) %}
                         {# Preview / Share lives next to Save — "view what you just edited" pairs with "save it" #}
                                     {% if registration_status == "TEST" %}
                                         {% set eye_icon %}
@@ -199,7 +207,12 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                         leading_icon=eye_icon,
                                         attrs='@click="openPreviewModal()"'
                                         ) }}
-                                        {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                        {% if edit_mode %}
+                                            {{ button(_("Cancel"), variant="secondary", href=view_url) }}
+                                            {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                        {% else %}
+                                            {{ button(_("Edit"), variant="primary", href=edit_url) }}
+                                        {% endif %}
                                     {% else %}
                                         {% set link_icon %}
                                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -213,9 +226,14 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             leading_icon=link_icon,
                                             attrs='@click="openPreviewModal()"'
                                             ) }}
-                                            {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                            {% if edit_mode %}
+                                                {{ button(_("Cancel"), variant="secondary", href=view_url) }}
+                                                {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                            {% else %}
+                                                {{ button(_("Edit"), variant="primary", href=edit_url) }}
+                                            {% endif %}
                                         {% else %}
-                                {# CLOSED: no save (form is redirecting), but keep Share Form visible-but-disabled so the user can see why #}
+                                {# CLOSED: no save (form is redirecting) and no Edit — admins must reopen first. #}
                                             {{ button(
                                             _("Share Form"),
                                             variant="tertiary",

--- a/backend/templates/backoffice/components/dropdown_button.html
+++ b/backend/templates/backoffice/components/dropdown_button.html
@@ -3,7 +3,7 @@ ABOUTME: Dropdown button component - single trigger that opens a menu of actions
 ABOUTME: Sibling of split_button; use when no primary action should be elevated outside the menu
 #}
 
-{% macro dropdown_button(label="", items=None, variant="secondary", id="", aria_label="") %}
+{% macro dropdown_button(label="", items=None, variant="secondary", id="", aria_label="", disabled=false) %}
     {#
     Dropdown button: a single button that opens a menu of related actions. Unlike
     split_button, no action is elevated outside the menu — every option lives in
@@ -17,6 +17,9 @@ ABOUTME: Sibling of split_button; use when no primary action should be elevated 
         variant: Style variant: "primary" | "secondary" | "danger" (default: "secondary").
         id: Optional id prefix used for the toggle and menu (defaults to "dropdown-btn").
         aria_label: aria-label for the trigger (defaults to the label).
+        disabled: When true, renders the trigger with the muted look and the HTML
+            `disabled` attribute — clicks and keyboard activation are blocked. The
+            menu cannot open in this state.
 
     Accessibility:
         - Trigger uses aria-haspopup="menu" and aria-expanded bound to open state.
@@ -38,22 +41,33 @@ ABOUTME: Sibling of split_button; use when no primary action should be elevated 
     {% set menu_id = prefix ~ "-menu" %}
     {% set toggle_id = prefix ~ "-toggle" %}
 
-    {# Variant styling - mirrors split_button so visually they look identical #}
-    {% if variant == "primary" %}
+    {# Variant styling - mirrors split_button so visually they look identical.
+       The disabled look mirrors button.html's disabled state so the two
+       components feel consistent when both are rendered side by side. #}
+    {% if disabled %}
+        {% set var_bg = "var(--color-disabled-borders)" %}
+        {% set var_fg = "var(--color-placeholder-text)" %}
+        {% set var_border = "transparent" %}
+        {% set hover_class = "" %}
+        {% set disabled_extra = "cursor: not-allowed; opacity: 0.5;" %}
+    {% elif variant == "primary" %}
         {% set var_bg = "var(--color-button-primary-bg)" %}
         {% set var_fg = "var(--color-button-primary-text)" %}
         {% set var_border = "transparent" %}
         {% set hover_class = "btn-primary-hover" %}
+        {% set disabled_extra = "" %}
     {% elif variant == "danger" %}
         {% set var_bg = "var(--color-button-danger-bg)" %}
         {% set var_fg = "var(--color-button-danger-text)" %}
         {% set var_border = "transparent" %}
         {% set hover_class = "btn-danger-hover" %}
+        {% set disabled_extra = "" %}
     {% else %}
         {% set var_bg = "var(--color-button-secondary-bg)" %}
         {% set var_fg = "var(--color-button-secondary-text)" %}
         {% set var_border = "var(--color-button-secondary-border)" %}
         {% set hover_class = "btn-secondary-hover" %}
+        {% set disabled_extra = "" %}
     {% endif %}
 
     {% set base_styles %}
@@ -75,6 +89,7 @@ ABOUTME: Sibling of split_button; use when no primary action should be elevated 
         border: 1px solid {{ var_border }};
         padding: 8px 12px;
         border-radius: 4px;
+        {{ disabled_extra }}
     {% endset %}
 
     <div class="relative inline-flex" x-data="{ open: false }" @keydown.escape.window="open = false">
@@ -82,8 +97,7 @@ ABOUTME: Sibling of split_button; use when no primary action should be elevated 
         <button
             type="button"
             id="{{ toggle_id }}"
-            @click="open = !open"
-            @click.outside="open = false"
+            {% if disabled %}disabled aria-disabled="true"{% else %}@click="open = !open" @click.outside="open = false"{% endif %}
             aria-haspopup="menu"
             x-bind:aria-expanded="open ? 'true' : 'false'"
             aria-controls="{{ menu_id }}"

--- a/backend/tests/unit/test_backoffice_registration_view.py
+++ b/backend/tests/unit/test_backoffice_registration_view.py
@@ -1,0 +1,346 @@
+"""ABOUTME: Unit tests for the registration view's read-only / edit-mode toggle
+ABOUTME: Covers the ?edit=1 query param and how save errors preserve edit mode"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask_login import AnonymousUserMixin
+
+from opendlp.domain.assembly import Assembly
+from opendlp.domain.registration_page import (
+    RegistrationPage,
+    RegistrationPageHtml,
+    RegistrationPageNotReady,
+    RegistrationPageStatus,
+)
+from opendlp.entrypoints.flask_app import create_app
+
+
+class _FakeAnonymous(AnonymousUserMixin):
+    """Anonymous user stand-in so backoffice templates can resolve
+    ``current_user.global_role.value`` while LOGIN_DISABLED bypasses login_required."""
+
+    id = uuid.uuid4()
+
+    @property
+    def global_role(self):  # type: ignore[no-untyped-def]
+        role = MagicMock()
+        role.value = "user"
+        return role
+
+
+@pytest.fixture
+def app():
+    a = create_app("testing")
+    a.config["LOGIN_DISABLED"] = True
+    a.login_manager.anonymous_user = _FakeAnonymous  # type: ignore[attr-defined]
+    return a
+
+
+@pytest.fixture
+def authed_client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def assembly_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+def _nav_context(assembly_id: uuid.UUID) -> MagicMock:
+    """Stand-in for AssemblyNavContext — only the bits the view passes through."""
+    nav = MagicMock()
+    nav.assembly = Assembly(title="Test Assembly", assembly_id=assembly_id)
+    nav.gsheet = None
+    nav.data_source = ""
+    nav.targets_enabled = False
+    nav.respondents_enabled = False
+    nav.selection_enabled = False
+    return nav
+
+
+def _page_and_html(
+    assembly_id: uuid.UUID,
+    status: RegistrationPageStatus,
+) -> tuple[RegistrationPage, RegistrationPageHtml]:
+    page = RegistrationPage(assembly_id=assembly_id, url_slug="my-slug", status=status)
+    return page, RegistrationPageHtml(registration_page_id=page.id, form_html="<p>hi</p>")
+
+
+class TestViewEditModeFlag:
+    """The route computes edit_mode from ?edit=1 and the current status."""
+
+    def _patches(self, status: RegistrationPageStatus, assembly_id: uuid.UUID):
+        return (
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.current_user",
+                new=MagicMock(id=uuid.uuid4()),
+            ),
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.get_assembly_nav_context",
+                return_value=_nav_context(assembly_id),
+            ),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.get_registration_page_with_source",
+                return_value=_page_and_html(assembly_id, status),
+            ),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.list_registration_images",
+                return_value=[],
+            ),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.render_template",
+                return_value="ok",
+            ),
+        )
+
+    def _edit_mode_kwarg(self, render_mock: MagicMock) -> bool:
+        assert render_mock.called, "render_template was not called"
+        _, kwargs = render_mock.call_args
+        return bool(kwargs.get("edit_mode"))
+
+    def test_default_test_status_is_read_only(self, authed_client, assembly_id):
+        p = self._patches(RegistrationPageStatus.TEST, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4], p[5] as render_template:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration")
+
+        assert response.status_code == 200
+        assert self._edit_mode_kwarg(render_template) is False
+
+    def test_edit_param_enables_edit_in_test_status(self, authed_client, assembly_id):
+        p = self._patches(RegistrationPageStatus.TEST, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4], p[5] as render_template:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1")
+
+        assert response.status_code == 200
+        assert self._edit_mode_kwarg(render_template) is True
+
+    def test_edit_param_enables_edit_in_published_status(self, authed_client, assembly_id):
+        p = self._patches(RegistrationPageStatus.PUBLISHED, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4], p[5] as render_template:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1")
+
+        assert response.status_code == 200
+        assert self._edit_mode_kwarg(render_template) is True
+
+    def test_edit_param_is_ignored_in_closed_status(self, authed_client, assembly_id):
+        # CLOSED has no save path so ?edit=1 should NOT unlock the editor.
+        p = self._patches(RegistrationPageStatus.CLOSED, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4], p[5] as render_template:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1")
+
+        assert response.status_code == 200
+        assert self._edit_mode_kwarg(render_template) is False
+
+    def test_edit_param_other_values_do_not_enable_edit(self, authed_client, assembly_id):
+        # Only the canonical ?edit=1 unlocks the editor — defensive against random truthy values.
+        p = self._patches(RegistrationPageStatus.TEST, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4], p[5] as render_template:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration?edit=true")
+
+        assert response.status_code == 200
+        assert self._edit_mode_kwarg(render_template) is False
+
+
+def _patches_with_full_render(status: RegistrationPageStatus, assembly_id: uuid.UUID):
+    """Same patches as TestViewEditModeFlag but WITHOUT mocking render_template, so
+    the test exercises the real Jinja output. Used to assert on textarea readonly,
+    Edit/Cancel buttons, and the disabled status dropdown."""
+    page = RegistrationPage(assembly_id=assembly_id, url_slug="my-slug", status=status)
+    html = RegistrationPageHtml(registration_page_id=page.id, form_html="<p>hi</p>")
+    return (
+        patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.current_user",
+            new=MagicMock(id=uuid.uuid4()),
+        ),
+        patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
+        patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.get_assembly_nav_context",
+            return_value=_nav_context(assembly_id),
+        ),
+        patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.get_registration_page_with_source",
+            return_value=(page, html),
+        ),
+        patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.list_registration_images",
+            return_value=[],
+        ),
+    )
+
+
+def _extract_textarea(body: str) -> str:
+    """Pluck the html_content textarea's opening tag for targeted assertions."""
+    assert 'name="html_content"' in body, "html_content textarea missing from body"
+    after_name = body.split('name="html_content"', 1)[1]
+    tag_inner = after_name.split(">", 1)[0]
+    return tag_inner
+
+
+class TestEditModeRendersExpectedHtml:
+    """End-to-end: render the actual template and assert on the produced HTML."""
+
+    def test_test_status_read_only_has_readonly_textarea_and_edit_link(self, authed_client, assembly_id):
+        p = _patches_with_full_render(RegistrationPageStatus.TEST, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4]:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration")
+
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # Textarea is read-only
+        assert "readonly" in _extract_textarea(body)
+        # Edit CTA links to ?edit=1
+        assert f"/backoffice/assembly/{assembly_id}/registration?edit=1" in body
+        # No Cancel button while read-only
+        # The footer Cancel is rendered as an <a> (it has href); image-modal Cancels
+        # are <button>s. Asserting on </a> scopes us to the footer link.
+        assert "Cancel</a>" not in body
+        # Status dropdown is NOT disabled while read-only
+        assert 'id="status-control-toggle"' in body
+        toggle_attrs = body.split('id="status-control-toggle"', 1)[1].split(">", 1)[0]
+        assert "disabled" not in toggle_attrs
+
+    def test_test_status_edit_mode_unlocks_textarea_and_disables_dropdown(self, authed_client, assembly_id):
+        p = _patches_with_full_render(RegistrationPageStatus.TEST, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4]:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1")
+
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # Textarea is editable
+        assert "readonly" not in _extract_textarea(body)
+        # Cancel (anchor) + Save (submit button) are present
+        assert "Cancel</a>" in body
+        assert "Save</button>" in body
+        # Status dropdown is disabled
+        assert 'id="status-control-toggle"' in body
+        toggle_attrs = body.split('id="status-control-toggle"', 1)[1].split(">", 1)[0]
+        assert "disabled" in toggle_attrs
+        # Cancel links back to the read-only URL (no edit=1)
+        cancel_block = body.split("Cancel</a>", 1)[0]
+        anchor = cancel_block.rsplit("<a", 1)[1]
+        assert f"/backoffice/assembly/{assembly_id}/registration" in anchor
+        assert "edit=1" not in anchor
+
+    def test_published_status_edit_mode_uses_save_and_republish_label(self, authed_client, assembly_id):
+        p = _patches_with_full_render(RegistrationPageStatus.PUBLISHED, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4]:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1")
+
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert "readonly" not in _extract_textarea(body)
+        assert "Save and Republish" in body
+        assert "Cancel</a>" in body
+
+    def test_closed_status_ignores_edit_param(self, authed_client, assembly_id):
+        p = _patches_with_full_render(RegistrationPageStatus.CLOSED, assembly_id)
+        with p[0], p[1], p[2], p[3], p[4]:
+            response = authed_client.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1")
+
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # Stays read-only
+        assert "readonly" in _extract_textarea(body)
+        # No Edit and no footer Cancel — admins must reopen via the status dropdown first
+        assert "Edit</a>" not in body
+        # The footer Cancel is rendered as an <a> (it has href); image-modal Cancels
+        # are <button>s. Asserting on </a> scopes us to the footer link.
+        assert "Cancel</a>" not in body
+
+
+class TestSaveRedirectPreservesEditMode:
+    """Save success drops ?edit=1; errors during a save keep the user in edit mode."""
+
+    def _patch_save(self):
+        return (
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.current_user",
+                new=MagicMock(id=uuid.uuid4()),
+            ),
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.bootstrap.bootstrap"),
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.get_assembly_nav_context"),
+        )
+
+    def test_save_success_redirects_to_read_only(self, authed_client, assembly_id):
+        p = self._patch_save()
+        with (
+            p[0],
+            p[1],
+            p[2],
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.update_registration_page_html"),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration._handle_registration_action",
+                return_value="saved",
+            ),
+        ):
+            response = authed_client.post(
+                f"/backoffice/assembly/{assembly_id}/registration/save",
+                data={"action": "save", "html_content": "<p>x</p>"},
+            )
+
+        assert response.status_code == 302
+        assert f"/backoffice/assembly/{assembly_id}/registration" in response.location
+        assert "edit=1" not in response.location
+
+    def test_save_value_error_redirects_back_in_edit_mode(self, authed_client, assembly_id):
+        p = self._patch_save()
+        with (
+            p[0],
+            p[1],
+            p[2],
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.update_registration_page_html",
+                side_effect=ValueError("bad html"),
+            ),
+        ):
+            response = authed_client.post(
+                f"/backoffice/assembly/{assembly_id}/registration/save",
+                data={"action": "save", "html_content": "<p>x</p>"},
+            )
+
+        assert response.status_code == 302
+        assert "edit=1" in response.location
+
+    def test_save_unexpected_error_redirects_back_in_edit_mode(self, authed_client, assembly_id):
+        p = self._patch_save()
+        with (
+            p[0],
+            p[1],
+            p[2],
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.update_registration_page_html",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            response = authed_client.post(
+                f"/backoffice/assembly/{assembly_id}/registration/save",
+                data={"action": "save", "html_content": "<p>x</p>"},
+            )
+
+        assert response.status_code == 302
+        assert "edit=1" in response.location
+
+    def test_publish_action_error_does_not_force_edit_mode(self, authed_client, assembly_id):
+        # Status transitions only fire from read-only (the dropdown is disabled in edit mode),
+        # so an error landing back on the registration page keeps the user in read-only.
+        p = self._patch_save()
+        with (
+            p[0],
+            p[1],
+            p[2],
+            patch("opendlp.entrypoints.blueprints.backoffice_registration.update_registration_page_html"),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration._handle_registration_action",
+                side_effect=RegistrationPageNotReady(["missing field"]),
+            ),
+        ):
+            response = authed_client.post(
+                f"/backoffice/assembly/{assembly_id}/registration/save",
+                data={"action": "publish", "html_content": "<p>x</p>"},
+            )
+
+        assert response.status_code == 302
+        assert "edit=1" not in response.location


### PR DESCRIPTION
## Summary

Makes the Registration Form HTML textarea read-only by default. The editor unlocks only when the URL carries `?edit=1`, which an explicit **Edit** CTA in the footer toggles on. This prevents accidental edits while admins are simply reviewing the form's HTML.

## Behavior

- **Read-only (default)**: textarea has `readonly`, footer shows **Edit** (links to `?edit=1`). The Preview / Share / Show Form Skeleton helpers remain interactive. The status badge and **Change status** dropdown work as before.
- **Edit mode (`?edit=1`)**: textarea is editable, footer shows **Cancel** (link back to the no-param URL — discards changes) + **Save** (or **Save and Republish** when PUBLISHED). The **Change status** dropdown is **disabled** so a stray click can't submit the form with a different action and discard unsaved edits.
- **CLOSED status**: stays read-only regardless of `?edit=1`. No Edit button — admins must reopen via the status dropdown first, since CLOSED has no save path.
- **Save success**: redirect drops `?edit=1` (back to read-only).
- **Save errors** (`ValueError`, unexpected exceptions): redirect preserves `?edit=1` so the user can fix and retry without re-clicking Edit.
- **Status-transition errors** (publish / unpublish / close / reopen via the dropdown): redirect drops `?edit=1` — those actions only fire from read-only mode anyway.

## Implementation notes

- `view_assembly_registration` computes `edit_mode = request.args.get("edit") == "1" and status != "CLOSED"` and passes it to the template.
- `save_assembly_registration` precomputes the error-redirect URL once, including `edit=1` when `action == "save"`, so all error branches stay consistent.
- New `disabled` parameter on the shared `dropdown_button` macro — mirrors `button.html`'s disabled treatment so the two components look consistent side by side.
- The textarea uses the existing `attrs` slot to add `readonly` + a subtle background tint in read-only mode (no macro change needed).
- The Show Form Skeleton button stays clickable in both modes — it opens a read-only modal.
- No `beforeunload` warning on unsaved-edit navigation; the editor doesn't track dirty state and a false-positive warning would be confusing.

## Tests

New `tests/unit/test_backoffice_registration_view.py` (13 tests, 3 classes):

- `TestViewEditModeFlag` (5) — route-level: asserts the `edit_mode` kwarg passed to `render_template` for TEST/PUBLISHED/CLOSED, default and `?edit=1`, plus a defensive check that non-canonical truthy values (`?edit=true`) don't unlock.
- `TestEditModeRendersExpectedHtml` (4) — end-to-end: renders the actual template (via a `FakeAnonymous` user that satisfies `current_user.global_role.value`) and asserts on the real HTML — `readonly` attribute on the textarea, Edit/Cancel anchor presence, Cancel `href` shape, status-dropdown `disabled` attribute, and the "Save and Republish" label for PUBLISHED.
- `TestSaveRedirectPreservesEditMode` (4) — redirect URLs: save success drops `edit=1`; save `ValueError` and unexpected errors preserve `edit=1`; publish action errors do not force edit mode.

## Test plan

- [ ] On TEST: the page loads with a read-only textarea + Edit button; clicking Edit unlocks the textarea and shows Cancel + Save
- [ ] Cancel discards changes (browser shows the previously-saved value after the redirect)
- [ ] Save persists changes and returns to read-only
- [ ] Change Status dropdown is interactive in read-only and visually disabled while editing
- [ ] Same flow on PUBLISHED with "Save and Republish"
- [ ] On CLOSED, no Edit button; `?edit=1` is ignored
- [ ] A failed Save (e.g. publish blocked by missing fields, when transitioning via dropdown) keeps the user in edit mode for retry
- [ ] Show Form Skeleton modal still opens in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)