### PR TITLE
SPIKE: convert JSON endpoints to HTMX for registration images

### DIFF
--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -533,6 +533,48 @@ def image_details_modal(assembly_id: uuid.UUID, image_id: uuid.UUID) -> Response
     return _render_registration_page(assembly_id, open_modal="details", open_image_id=image_id)
 
 
+def _render_preview_modal(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Render the read-only Preview / Share modal fragment (URLs + QR code)."""
+    try:
+        nav = get_assembly_nav_context(bootstrap.get_flask_uow, current_user.id, assembly_id, "")
+        uow = bootstrap.get_flask_uow()
+        result = get_registration_page_with_source(uow, current_user.id, assembly_id)
+    except InsufficientPermissions:
+        flash(_("You don't have permission to view this assembly"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+    except NotFoundError:
+        flash(_("Assembly not found"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+
+    registration_page = result[0] if result else None
+    if registration_page is None:
+        flash(_("Please create a registration page first from the Details tab."), "warning")
+        return redirect(url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id))
+
+    page_url = registration_url(registration_page.url_slug)
+    short = short_url(registration_page.short_url_slug) if registration_page.short_url_slug else None
+    qr_code_data_url = generate_qr_code_base64(short) if short else None
+
+    return render_template(
+        "backoffice/registration/preview_modal.html",
+        assembly=nav.assembly,
+        registration_page=registration_page,
+        registration_status=registration_page.status.value,
+        registration_url=page_url,
+        short_url=short,
+        qr_code_data_url=qr_code_data_url,
+    )
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/preview-modal")
+@login_required
+def preview_modal(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Serve the Preview / Share modal (HTMX fragment / full-page fallback)."""
+    if _is_htmx():
+        return _render_preview_modal(assembly_id)
+    return _render_registration_page(assembly_id, open_modal="preview")
+
+
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images", methods=["POST"])
 @login_required
 def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -1,10 +1,23 @@
 """ABOUTME: Backoffice registration-page editor routes
 ABOUTME: View / save / create / skeleton / QR-download / image upload routes for the assembly registration tab"""
 
+import json
 import uuid
 from typing import Any, cast
 
-from flask import Blueprint, Response, abort, current_app, flash, jsonify, redirect, render_template, request, url_for
+from flask import (
+    Blueprint,
+    Response,
+    abort,
+    current_app,
+    flash,
+    jsonify,
+    make_response,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from flask.typing import ResponseReturnValue
 from flask_login import current_user, login_required
 from werkzeug.exceptions import HTTPException
@@ -55,6 +68,10 @@ from opendlp.translations import gettext as _
 backoffice_registration_bp = Blueprint("backoffice_registration", __name__)
 
 
+def _is_htmx() -> bool:
+    return request.headers.get("HX-Request") == "true"
+
+
 def _image_to_dict(image: RegistrationImage, url_slug: str) -> dict[str, Any]:
     """Serialise an image for the Assets panel.
 
@@ -90,6 +107,16 @@ def _image_to_dict(image: RegistrationImage, url_slug: str) -> dict[str, Any]:
 @login_required
 def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
     """Backoffice registration form configuration page."""
+    return _render_registration_page(assembly_id, open_modal=request.args.get("modal", ""))
+
+
+def _render_registration_page(assembly_id: uuid.UUID, open_modal: str = "") -> ResponseReturnValue:
+    """Render the registration configuration page.
+
+    ``open_modal`` names a modal to render already-open server-side (e.g. "upload"),
+    which is the no-JS fallback for the HTMX-loaded modals — the page degrades to a
+    full reload that shows the requested modal.
+    """
     try:
         nav = get_assembly_nav_context(
             bootstrap.get_flask_uow,
@@ -156,6 +183,7 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             max_image_upload_mb=get_max_image_upload_mb(),
             allowed_image_formats=sorted(ALLOWED_INPUT_FORMATS),
             edit_mode=edit_mode,
+            open_modal=open_modal,
         ), 200
     except InsufficientPermissions as e:
         current_app.logger.warning(f"Insufficient permissions for assembly {assembly_id} user {current_user.id}: {e}")
@@ -369,27 +397,81 @@ def _resolve_page_url_slug(assembly_id: uuid.UUID) -> str:
     return result[0].url_slug
 
 
+def _upload_error_message(error: Exception) -> str:
+    """Map a known image-upload failure to a user-facing message."""
+    if isinstance(error, ImageValidationError):
+        return error.message
+    if isinstance(error, ImageQuotaExceeded):
+        return str(error)
+    if isinstance(error, RegistrationPageNotFoundError):
+        return _("Please create a registration page first from the Details tab.")
+    if isinstance(error, InsufficientPermissions):
+        return _("You don't have permission to modify this assembly")
+    return _("Assembly not found")
+
+
+def _render_image_upload_modal(
+    assembly_id: uuid.UUID, *, error: str = "", alt_value: str = "", status: int = 200
+) -> ResponseReturnValue:
+    """Render the upload-modal fragment (swapped into ``#image-modal-container`` by HTMX)."""
+    return render_template(
+        "backoffice/registration/image_upload_modal.html",
+        assembly_id=assembly_id,
+        allowed_image_formats=sorted(ALLOWED_INPUT_FORMATS),
+        max_image_upload_mb=get_max_image_upload_mb(),
+        error=error,
+        alt_value=alt_value,
+    ), status
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images/upload-modal")
+@login_required
+def image_upload_modal(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Serve the image-upload modal.
+
+    HTMX requests get just the modal fragment to swap into the Assets panel; a
+    plain navigation gets the whole registration page with the modal already open,
+    so opening the modal still works (via a full page load) when JS is unavailable.
+    """
+    if _is_htmx():
+        return _render_image_upload_modal(assembly_id)
+    return _render_registration_page(assembly_id, open_modal="upload")
+
+
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images", methods=["POST"])
 @login_required
 def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
-    """Accept a multipart image upload and return the stored image metadata as JSON.
+    """Accept a multipart image upload from the Assets panel modal.
 
-    The Assets panel calls this from the registration tab so uploads don't disturb
-    the HTML editor's unsaved state — no full-page reload is required.
+    Content-negotiates on HTMX: an HX-Request returns an empty body plus an
+    ``HX-Trigger`` carrying the new image (the page appends it client-side and
+    closes the modal), while a failure re-renders the modal with the error (422,
+    swapped back by the htmx-422 handler). A plain form post redirects back to the
+    registration page with a flash — the no-JS full-reload path.
     """
     upload = request.files.get("image")
+    alt = (request.form.get("alt") or "").strip()
+
+    def _fail(message: str) -> ResponseReturnValue:
+        if _is_htmx():
+            # 422 so the htmx-422-swap handler re-renders the modal with the error inline
+            return _render_image_upload_modal(assembly_id, error=message, alt_value=alt, status=422)
+        flash(message, "error")
+        return redirect(
+            url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id, modal="upload")
+        )
+
     if upload is None or not upload.filename:
-        return jsonify({"error": _("No file was selected")}), 400
+        return _fail(_("No file was selected"))
 
     try:
         raw = upload.read()
     except Exception as e:
         current_app.logger.warning(f"Failed to read uploaded image for assembly {assembly_id}: {e}")
-        return jsonify({"error": _("Failed to read the uploaded file")}), 400
+        return _fail(_("Failed to read the uploaded file"))
 
-    alt = (request.form.get("alt") or "").strip()
     if not alt:
-        return jsonify({"error": _("Alt text is required for accessibility")}), 400
+        return _fail(_("Alt text is required for accessibility"))
 
     try:
         image = add_registration_image(
@@ -400,22 +482,29 @@ def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
             alt=alt,
             original_filename=upload.filename or "",
         )
-    except ImageValidationError as e:
-        return jsonify({"error": e.message, "reason": e.reason}), 400
-    except ImageQuotaExceeded as e:
-        return jsonify({"error": str(e)}), 400
-    except RegistrationPageNotFoundError:
-        return jsonify({"error": _("Please create a registration page first from the Details tab.")}), 400
-    except InsufficientPermissions:
-        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
-    except NotFoundError:
-        return jsonify({"error": _("Assembly not found")}), 404
+    except (
+        ImageValidationError,
+        ImageQuotaExceeded,
+        RegistrationPageNotFoundError,
+        InsufficientPermissions,
+        NotFoundError,
+    ) as e:
+        return _fail(_upload_error_message(e))
     except Exception as e:
         current_app.logger.error(f"Image upload error for assembly {assembly_id}: {e}")
         current_app.logger.exception("Full traceback:")
-        return jsonify({"error": _("An error occurred while uploading the image")}), 500
+        return _fail(_("An error occurred while uploading the image"))
 
-    return jsonify({"image": _image_to_dict(image, _resolve_page_url_slug(assembly_id))}), 201
+    image_dict = _image_to_dict(image, _resolve_page_url_slug(assembly_id))
+    if _is_htmx():
+        # Empty body clears the modal container (closing the modal); the trigger
+        # hands the new image to the page so it can update the Assets list in place.
+        response = make_response("")
+        response.headers["HX-Trigger"] = json.dumps({"registration-image-uploaded": image_dict})
+        return response
+
+    flash(_("Image uploaded"), "success")
+    return redirect(url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id))
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images/<uuid:image_id>", methods=["PATCH"])

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -110,12 +110,15 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
     return _render_registration_page(assembly_id, open_modal=request.args.get("modal", ""))
 
 
-def _render_registration_page(assembly_id: uuid.UUID, open_modal: str = "") -> ResponseReturnValue:
+def _render_registration_page(
+    assembly_id: uuid.UUID, open_modal: str = "", open_image_id: uuid.UUID | None = None
+) -> ResponseReturnValue:
     """Render the registration configuration page.
 
-    ``open_modal`` names a modal to render already-open server-side (e.g. "upload"),
-    which is the no-JS fallback for the HTMX-loaded modals — the page degrades to a
-    full reload that shows the requested modal.
+    ``open_modal`` names a modal to render already-open server-side ("upload" or
+    "details"), which is the no-JS fallback for the HTMX-loaded modals — the page
+    degrades to a full reload that shows the requested modal. For "details",
+    ``open_image_id`` selects which image's modal to open.
     """
     try:
         nav = get_assembly_nav_context(
@@ -159,6 +162,12 @@ def _render_registration_page(assembly_id: uuid.UUID, open_modal: str = "") -> R
             stored_images = list_registration_images(uow, current_user.id, assembly_id)
             images = [_image_to_dict(image, registration_page.url_slug) for image in stored_images]
 
+        # When falling back to a full page with the details modal open, pick out the
+        # image whose modal should be shown from the list we just built.
+        open_image = None
+        if open_modal == "details" and open_image_id is not None:
+            open_image = next((img for img in images if img["id"] == str(open_image_id)), None)
+
         # The HTML editor is read-only by default; ?edit=1 unlocks it. CLOSED pages
         # have no save path so we always keep them read-only regardless of the param.
         edit_mode = request.args.get("edit") == "1" and registration_status != "CLOSED"
@@ -184,6 +193,7 @@ def _render_registration_page(assembly_id: uuid.UUID, open_modal: str = "") -> R
             allowed_image_formats=sorted(ALLOWED_INPUT_FORMATS),
             edit_mode=edit_mode,
             open_modal=open_modal,
+            open_image=open_image,
         ), 200
     except InsufficientPermissions as e:
         current_app.logger.warning(f"Insufficient permissions for assembly {assembly_id} user {current_user.id}: {e}")
@@ -397,6 +407,65 @@ def _resolve_page_url_slug(assembly_id: uuid.UUID) -> str:
     return result[0].url_slug
 
 
+def _list_images_as_dicts(assembly_id: uuid.UUID) -> list[dict[str, Any]]:
+    """Serialise all of an assembly's registration images for the Assets panel."""
+    uow = bootstrap.get_flask_uow()
+    images = list_registration_images(uow, current_user.id, assembly_id)
+    url_slug = _resolve_page_url_slug(assembly_id)
+    return [_image_to_dict(image, url_slug) for image in images]
+
+
+def _find_image_dict(assembly_id: uuid.UUID, image_id: uuid.UUID) -> dict[str, Any] | None:
+    """Return the serialised image with ``image_id`` for this assembly, or None."""
+    return next((img for img in _list_images_as_dicts(assembly_id) if img["id"] == str(image_id)), None)
+
+
+def _image_list_response(
+    assembly_id: uuid.UUID, *, toast: str = "", toast_type: str = "success"
+) -> ResponseReturnValue:
+    """Render the Assets list as an out-of-band fragment after a mutation.
+
+    Swapping ``#image-asset-list`` out of band refreshes the panel; because the
+    rest of the response body is empty it also clears ``#image-modal-container``,
+    closing whichever modal triggered the mutation. An optional toast is fired via
+    ``HX-Trigger`` for the page to surface.
+    """
+    html = render_template(
+        "backoffice/registration/image_asset_list.html",
+        assembly_id=assembly_id,
+        images=_list_images_as_dicts(assembly_id),
+        oob=True,
+    )
+    response = make_response(html)
+    if toast:
+        response.headers["HX-Trigger"] = json.dumps({"show-toast": {"message": toast, "type": toast_type}})
+    return response
+
+
+def _render_image_details_modal(
+    assembly_id: uuid.UUID, image: dict[str, Any], *, error: str = "", alt_value: str = "", status: int = 200
+) -> ResponseReturnValue:
+    """Render the per-image details/edit modal fragment."""
+    return render_template(
+        "backoffice/registration/image_details_modal.html",
+        assembly_id=assembly_id,
+        image=image,
+        error=error,
+        alt_value=alt_value,
+    ), status
+
+
+def _image_action_error_message(error: Exception) -> str:
+    """Map a known edit/delete failure to a user-facing message."""
+    if isinstance(error, RegistrationImageNotFoundError):
+        return _("Image not found")
+    if isinstance(error, RegistrationPageNotFoundError):
+        return _("Registration page not found")
+    if isinstance(error, InsufficientPermissions):
+        return _("You don't have permission to modify this assembly")
+    return _("Assembly not found")
+
+
 def _upload_error_message(error: Exception) -> str:
     """Map a known image-upload failure to a user-facing message."""
     if isinstance(error, ImageValidationError):
@@ -438,6 +507,32 @@ def image_upload_modal(assembly_id: uuid.UUID) -> ResponseReturnValue:
     return _render_registration_page(assembly_id, open_modal="upload")
 
 
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images/<uuid:image_id>/details-modal")
+@login_required
+def image_details_modal(assembly_id: uuid.UUID, image_id: uuid.UUID) -> ResponseReturnValue:
+    """Serve the per-image details/edit modal.
+
+    HTMX requests get the modal fragment to swap into the Assets panel; a plain
+    navigation gets the whole registration page with the modal already open.
+    """
+    try:
+        image = _find_image_dict(assembly_id, image_id)
+    except InsufficientPermissions:
+        flash(_("You don't have permission to view this assembly"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+    except NotFoundError:
+        flash(_("Assembly not found"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+
+    if image is None:
+        flash(_("Image not found"), "error")
+        return redirect(url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id))
+
+    if _is_htmx():
+        return _render_image_details_modal(assembly_id, image)
+    return _render_registration_page(assembly_id, open_modal="details", open_image_id=image_id)
+
+
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images", methods=["POST"])
 @login_required
 def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
@@ -474,7 +569,7 @@ def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
         return _fail(_("Alt text is required for accessibility"))
 
     try:
-        image = add_registration_image(
+        add_registration_image(
             bootstrap.get_flask_uow(),
             current_user.id,
             assembly_id,
@@ -495,13 +590,10 @@ def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
         current_app.logger.exception("Full traceback:")
         return _fail(_("An error occurred while uploading the image"))
 
-    image_dict = _image_to_dict(image, _resolve_page_url_slug(assembly_id))
     if _is_htmx():
-        # Empty body clears the modal container (closing the modal); the trigger
-        # hands the new image to the page so it can update the Assets list in place.
-        response = make_response("")
-        response.headers["HX-Trigger"] = json.dumps({"registration-image-uploaded": image_dict})
-        return response
+        # Refresh the Assets list out of band (which also closes the modal); the
+        # toast trigger announces success.
+        return _image_list_response(assembly_id, toast=_("Image uploaded"))
 
     flash(_("Image uploaded"), "success")
     return redirect(url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id))
@@ -510,28 +602,31 @@ def upload_registration_image(assembly_id: uuid.UUID) -> ResponseReturnValue:
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/images/<uuid:image_id>", methods=["PATCH"])
 @login_required
 def update_assembly_registration_image(assembly_id: uuid.UUID, image_id: uuid.UUID) -> ResponseReturnValue:
-    """Update an image's alt text. Returns the updated image metadata as JSON."""
-    data = request.get_json(silent=True) or {}
-    alt = (data.get("alt") or "").strip()
+    """Update an image's alt text (PATCH from the details modal, HTMX only).
+
+    Success returns the refreshed Assets list (out of band, which also closes the
+    modal); an empty alt re-renders the modal with the error at 422.
+    """
+    alt = (request.form.get("alt") or "").strip()
     if not alt:
-        return jsonify({"error": _("Alt text is required for accessibility")}), 400
+        image = _find_image_dict(assembly_id, image_id)
+        if image is None:
+            return _image_list_response(assembly_id, toast=_("Image not found"), toast_type="error")
+        return _render_image_details_modal(
+            assembly_id, image, error=_("Alt text is required for accessibility"), alt_value=alt, status=422
+        )
 
     try:
-        uow = bootstrap.get_flask_uow()
-        image = set_registration_image_alt(uow, current_user.id, assembly_id, image_id, alt=alt)
-    except RegistrationImageNotFoundError:
-        return jsonify({"error": _("Image not found")}), 404
-    except RegistrationPageNotFoundError:
-        return jsonify({"error": _("Registration page not found")}), 404
-    except InsufficientPermissions:
-        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
-    except NotFoundError:
-        return jsonify({"error": _("Assembly not found")}), 404
+        set_registration_image_alt(bootstrap.get_flask_uow(), current_user.id, assembly_id, image_id, alt=alt)
+    except (RegistrationImageNotFoundError, RegistrationPageNotFoundError, InsufficientPermissions, NotFoundError) as e:
+        return _image_list_response(assembly_id, toast=_image_action_error_message(e), toast_type="error")
     except Exception as e:
         current_app.logger.error(f"Update image alt error for assembly {assembly_id} image {image_id}: {e}")
-        return jsonify({"error": _("An error occurred while updating the image")}), 500
+        return _image_list_response(
+            assembly_id, toast=_("An error occurred while updating the image"), toast_type="error"
+        )
 
-    return jsonify({"image": _image_to_dict(image, _resolve_page_url_slug(assembly_id))}), 200
+    return _image_list_response(assembly_id, toast=_("Image updated"))
 
 
 @backoffice_registration_bp.route(
@@ -539,20 +634,19 @@ def update_assembly_registration_image(assembly_id: uuid.UUID, image_id: uuid.UU
 )
 @login_required
 def delete_assembly_registration_image(assembly_id: uuid.UUID, image_id: uuid.UUID) -> ResponseReturnValue:
-    """Delete a registration image. Returns 204 on success."""
+    """Delete a registration image (DELETE, HTMX only).
+
+    Returns the refreshed Assets list (out of band, which also closes the modal
+    when the delete came from it).
+    """
     try:
-        uow = bootstrap.get_flask_uow()
-        delete_registration_image(uow, current_user.id, assembly_id, image_id)
-    except RegistrationImageNotFoundError:
-        return jsonify({"error": _("Image not found")}), 404
-    except RegistrationPageNotFoundError:
-        return jsonify({"error": _("Registration page not found")}), 404
-    except InsufficientPermissions:
-        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
-    except NotFoundError:
-        return jsonify({"error": _("Assembly not found")}), 404
+        delete_registration_image(bootstrap.get_flask_uow(), current_user.id, assembly_id, image_id)
+    except (RegistrationImageNotFoundError, RegistrationPageNotFoundError, InsufficientPermissions, NotFoundError) as e:
+        return _image_list_response(assembly_id, toast=_image_action_error_message(e), toast_type="error")
     except Exception as e:
         current_app.logger.error(f"Delete image error for assembly {assembly_id} image {image_id}: {e}")
-        return jsonify({"error": _("An error occurred while deleting the image")}), 500
+        return _image_list_response(
+            assembly_id, toast=_("An error occurred while deleting the image"), toast_type="error"
+        )
 
-    return "", 204
+    return _image_list_response(assembly_id, toast=_("Image deleted"))

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -11,7 +11,6 @@ from flask import (
     abort,
     current_app,
     flash,
-    jsonify,
     make_response,
     redirect,
     render_template,
@@ -168,6 +167,12 @@ def _render_registration_page(
         if open_modal == "details" and open_image_id is not None:
             open_image = next((img for img in images if img["id"] == str(open_image_id)), None)
 
+        # The skeleton modal's content is generated server-side; build it for the
+        # full-page fallback so the modal renders without JS.
+        skeleton_html = ""
+        if open_modal == "skeleton":
+            skeleton_html = generate_starter_form_html(uow, current_user.id, assembly_id)
+
         # The HTML editor is read-only by default; ?edit=1 unlocks it. CLOSED pages
         # have no save path so we always keep them read-only regardless of the param.
         edit_mode = request.args.get("edit") == "1" and registration_status != "CLOSED"
@@ -194,6 +199,7 @@ def _render_registration_page(
             edit_mode=edit_mode,
             open_modal=open_modal,
             open_image=open_image,
+            skeleton_html=skeleton_html,
         ), 200
     except InsufficientPermissions as e:
         current_app.logger.warning(f"Insufficient permissions for assembly {assembly_id} user {current_user.id}: {e}")
@@ -330,21 +336,32 @@ def create_assembly_registration_page(assembly_id: uuid.UUID) -> ResponseReturnV
         return redirect(url_for("backoffice.view_assembly", assembly_id=assembly_id))
 
 
-@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/skeleton")
-@login_required
-def get_registration_skeleton(assembly_id: uuid.UUID) -> ResponseReturnValue:
-    """Generate starter HTML form skeleton based on assembly's field definitions."""
+def _render_skeleton_modal(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Render the Form Skeleton modal fragment with server-generated starter HTML."""
     try:
         uow = bootstrap.get_flask_uow()
-        html = generate_starter_form_html(uow, current_user.id, assembly_id)
-        return jsonify({"html": html})
+        skeleton_html = generate_starter_form_html(uow, current_user.id, assembly_id)
     except InsufficientPermissions:
-        return jsonify({"error": _("You don't have permission to access this assembly")}), 403
+        flash(_("You don't have permission to view this assembly"), "error")
+        return redirect(url_for("backoffice.dashboard"))
     except NotFoundError:
-        return jsonify({"error": _("Assembly not found")}), 404
-    except Exception as e:
-        current_app.logger.error(f"Generate skeleton error for assembly {assembly_id}: {e}")
-        return jsonify({"error": _("An error occurred while generating the form skeleton")}), 500
+        flash(_("Assembly not found"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+
+    return render_template(
+        "backoffice/registration/skeleton_modal.html",
+        assembly_id=assembly_id,
+        skeleton_html=skeleton_html,
+    )
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/skeleton-modal")
+@login_required
+def skeleton_modal(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Serve the Form Skeleton modal (HTMX fragment / full-page fallback)."""
+    if _is_htmx():
+        return _render_skeleton_modal(assembly_id)
+    return _render_registration_page(assembly_id, open_modal="skeleton")
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/qr-code.png")

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -194,6 +194,10 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 <div class="flex justify-end gap-3">
                                     {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, edit="1") %}
                                     {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id) %}
+                        {# Preview / Share opens over HTMX (swapped into #image-modal-container); a plain
+                           click navigates to the same URL and gets the full page with the modal open. #}
+                                    {% set preview_modal_url = url_for("backoffice_registration.preview_modal", assembly_id=assembly.id) %}
+                                    {% set preview_attrs = 'hx-get="' ~ preview_modal_url ~ '" hx-target="#image-modal-container" hx-swap="innerHTML"' %}
                         {# Preview / Share lives next to Save — "view what you just edited" pairs with "save it" #}
                                     {% if registration_status == "TEST" %}
                                         {% set eye_icon %}
@@ -206,7 +210,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                         _("Preview and Test Responses"),
                                         variant="tertiary",
                                         leading_icon=eye_icon,
-                                        attrs='@click="openPreviewModal()"'
+                                        href=preview_modal_url,
+                                        attrs=preview_attrs
                                         ) }}
                                         {% if edit_mode %}
                                             {{ button(_("Cancel"), variant="secondary", href=view_url) }}
@@ -225,7 +230,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             _("Share Form"),
                                             variant="tertiary",
                                             leading_icon=link_icon,
-                                            attrs='@click="openPreviewModal()"'
+                                            href=preview_modal_url,
+                                            attrs=preview_attrs
                                             ) }}
                                             {% if edit_mode %}
                                                 {{ button(_("Cancel"), variant="secondary", href=view_url) }}
@@ -359,117 +365,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </div>
             </template>
 
-        {# Preview / Share Modal - rendered for TEST and PUBLISHED (CLOSED button is disabled) #}
-            {% if registration_status in ("TEST", "PUBLISHED") and registration_page %}
-                {% set preview_modal_title = _("Preview and Test Responses") if registration_status == "TEST" else _("Share Form") %}
-                <template x-if="previewModalOpen">
-                    <div x-cloak>
-                    {# Backdrop overlay #}
-                        <div class="fixed inset-0 z-40"
-                             style="background-color: rgba(0, 0, 0, 0.5)"
-                             @click="closePreviewModal()"
-                             @keydown.escape.window="closePreviewModal()"></div>
-                    {# Modal panel #}
-                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                             role="dialog"
-                             aria-modal="true"
-                             aria-labelledby="preview-modal-title">
-                            <div class="pointer-events-auto w-full max-w-2xl mx-4 rounded-lg shadow-xl overflow-hidden"
-                                 style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
-                                 @click.stop>
-                            {# Header #}
-                                <div class="px-6 py-4 flex items-center justify-between"
-                                     style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                    <h2 id="preview-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
-                                        {{ preview_modal_title }}
-                                    </h2>
-                                    <button type="button"
-                                            @click="closePreviewModal()"
-                                            class="p-2 rounded-lg transition-colors hover:bg-gray-100"
-                                            style="color: var(--color-secondary-text);"
-                                            aria-label="{{ _('Close') }}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                        </svg>
-                                    </button>
-                                </div>
-                            {# Content #}
-                                <div class="px-6 py-4 max-h-[70vh] overflow-y-auto">
-                                {# Test submission notice - TEST state only #}
-                                    {% if registration_status == "TEST" %}
-                                        <div class="rounded-lg p-4 mb-6"
-                                             style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
-                                            <p class="text-body-sm" style="color: var(--color-warning-600);">
-                                                {{ _("The form is in test mode. Submissions made via these URLs are recorded as test submissions and will not enter the selection pool.") }}
-                                            </p>
-                                        </div>
-                                    {% endif %}
-
-                                    <div class="space-y-6">
-                                    {# Registration URL #}
-                                        {{ readonly_url_display(
-                                        label=_("Registration URL"),
-                                        hint=_("The URL for your registration form"),
-                                        url=registration_url
-                                        ) }}
-
-                                    {# Short URL - only if configured #}
-                                        {% if registration_page.short_url_slug %}
-                                            {{ readonly_url_display(
-                                            label=_("Short URL"),
-                                            hint=_("A shorter URL for QR codes and paper invitations"),
-                                            url=short_url
-                                            ) }}
-                                        {% endif %}
-
-                                    {# QR Code - only when short URL is configured #}
-                                        {% if qr_code_data_url %}
-                                            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers);">
-                                                <h3 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("QR Code") }}</h3>
-                                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                                    {{ _("Use this QR code on paper invitations") }}
-                                                </p>
-
-                                                <div class="flex items-start gap-6">
-                                                    <div class="flex-shrink-0 p-4 rounded-lg" style="background-color: white; border: 1px solid var(--color-borders-dividers);">
-                                                        <img src="{{ qr_code_data_url }}"
-                                                             alt="{{ _('QR code for registration page') }}"
-                                                             class="w-40 h-40" />
-                                                    </div>
-
-                                                    <div class="flex flex-col gap-2">
-                                                        <a href="{{ url_for('backoffice_registration.download_registration_qr_code', assembly_id=assembly.id) }}"
-                                                           class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-button-md transition-colors"
-                                                           style="background-color: var(--color-button-secondary-bg); color: var(--color-button-secondary-text); border: 1px solid var(--color-borders-dividers);"
-                                                           download>
-                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                                                            </svg>
-                                                            {{ _("Download QR Code") }}
-                                                        </a>
-                                                        <p class="text-body-sm" style="color: var(--color-secondary-text);">
-                                                            {{ _("PNG format, 400x400 pixels") }}
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        {% endif %}
-                                    </div>
-                                </div>
-                            {# Footer #}
-                                <div class="px-6 py-3 flex gap-2 justify-end"
-                                     style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
-                                    {{ button(_("Close"), variant="secondary", attrs='@click="closePreviewModal()"') }}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </template>
-            {% endif %}
-
-        {# Image modals (upload + per-image details) are loaded from the server via
-           HTMX into this container. The no-JS fallback renders the requested modal
-           here server-side via ?modal=upload / ?modal=details. #}
+        {# Page modals (upload + per-image details + preview/share) are loaded from
+           the server via HTMX into this container. The no-JS fallback renders the
+           requested modal here server-side via ?modal=upload / details / preview. #}
             <div id="image-modal-container">
                 {% if open_modal == "upload" %}
                     {% with assembly_id = assembly.id %}
@@ -479,6 +377,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     {% with assembly_id = assembly.id, image = open_image %}
                         {% include "backoffice/registration/image_details_modal.html" %}
                     {% endwith %}
+                {% elif open_modal == "preview" and registration_page %}
+                    {% include "backoffice/registration/preview_modal.html" %}
                 {% endif %}
             </div>
 
@@ -505,7 +405,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     skeletonLoading: false,
                     skeletonModalOpen: false,
                     skeletonHtml: '',
-                    previewModalOpen: false,
                     toastVisible: false,
                     toastMessage: '',
                     toastType: 'success',
@@ -536,14 +435,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                     closeSkeletonModal() {
                         this.skeletonModalOpen = false;
-                    },
-
-                    openPreviewModal() {
-                        this.previewModalOpen = true;
-                    },
-
-                    closePreviewModal() {
-                        this.previewModalOpen = false;
                     },
 
                     copySkeletonToClipboard() {

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -25,7 +25,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
 {% block page_content %}
     <div x-data="registrationPageController()"
-         x-on:registration-image-uploaded.window="onImageUploaded($event)">
+         x-on:show-toast.window="onToast($event)">
         {# Page Heading #}
         <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
         <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
@@ -289,61 +289,10 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             </p>
                         </div>
 
-                    {# Empty state #}
-                        <template x-if="!images.length">
-                            <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
-                                {{ _("No images uploaded yet.") }}
-                            </p>
-                        </template>
-
-                    {# Image list #}
-                        <ul class="space-y-2" x-show="images.length" x-cloak>
-                            <template x-for="image in images" :key="image.id">
-                                <li class="rounded-md px-3 py-2 flex items-center justify-between"
-                                    style="background-color: var(--color-subtle-background-panels);">
-                                    <a :href="image.public_url"
-                                       :title="image.alt || image.file_name"
-                                       target="_blank"
-                                       rel="noopener"
-                                       class="text-body-sm truncate flex-1 mr-2"
-                                       style="color: var(--color-body-text);"
-                                       x-text="image.display_name"></a>
-                                    <div class="flex items-center gap-1 flex-shrink-0">
-                                    {# Image details / edit alt text #}
-                                        <button type="button"
-                                                @click="openImageDetailsModal(image)"
-                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                style="color: var(--color-secondary-text);"
-                                                :aria-label="'{{ _('Details for') }} ' + image.display_name">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                            </svg>
-                                        </button>
-                                    {# Copy <img> snippet to clipboard #}
-                                        <button type="button"
-                                                @click="copyImageSnippet(image)"
-                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                style="color: var(--color-secondary-text);"
-                                                :aria-label="'{{ _('Copy <img> snippet for') }} ' + image.display_name">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
-                                    {# Delete #}
-                                        <button type="button"
-                                                @click="deleteImage(image)"
-                                                :disabled="imageBeingDeletedId === image.id"
-                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                style="color: var(--color-secondary-text);"
-                                                :aria-label="'{{ _('Delete') }} ' + image.display_name">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </li>
-                            </template>
-                        </ul>
+                    {# Image list — server-rendered; mutations re-render this fragment over HTMX #}
+                        {% with assembly_id = assembly.id %}
+                            {% include "backoffice/registration/image_asset_list.html" %}
+                        {% endwith %}
                     </section>
                 </aside>
             </div>
@@ -518,174 +467,20 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </template>
             {% endif %}
 
-        {# Image Upload Modal — loaded from the server via HTMX into this container.
-           The no-JS fallback renders the modal here server-side when ?modal=upload. #}
+        {# Image modals (upload + per-image details) are loaded from the server via
+           HTMX into this container. The no-JS fallback renders the requested modal
+           here server-side via ?modal=upload / ?modal=details. #}
             <div id="image-modal-container">
                 {% if open_modal == "upload" %}
                     {% with assembly_id = assembly.id %}
                         {% include "backoffice/registration/image_upload_modal.html" %}
                     {% endwith %}
+                {% elif open_modal == "details" and open_image %}
+                    {% with assembly_id = assembly.id, image = open_image %}
+                        {% include "backoffice/registration/image_details_modal.html" %}
+                    {% endwith %}
                 {% endif %}
             </div>
-
-        {# Image Details / Edit Alt Modal #}
-            <template x-if="imageDetailsModalOpen && editingImage">
-                <div x-cloak>
-                {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeImageDetailsModalIfAllowed()"
-                         @keydown.escape.window="closeImageDetailsModalIfAllowed()"></div>
-                {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="image-details-modal-title">
-                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
-                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
-                        {# Header #}
-                            <div class="px-6 py-4 flex items-center justify-between"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="image-details-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
-                                    {{ _("Image details") }}
-                                </h2>
-                                <button type="button"
-                                        @click="closeImageDetailsModalIfAllowed()"
-                                        :disabled="imageEditing"
-                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
-                                        style="color: var(--color-secondary-text);"
-                                        aria-label="{{ _('Close') }}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
-                        {# Content #}
-                            <div class="px-6 py-4">
-                            {# Thumbnail + compact metadata #}
-                                <div class="rounded-md p-3 mb-4 flex gap-3"
-                                     style="background-color: var(--color-subtle-background-panels);">
-                                    <div class="flex-shrink-0 w-16 h-16 rounded-md overflow-hidden flex items-center justify-center"
-                                         style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers);">
-                                        <template x-if="editingImage.public_url">
-                                            <img :src="editingImage.public_url"
-                                                 :alt="editingImage.alt || ''"
-                                                 class="max-w-full max-h-full object-contain" />
-                                        </template>
-                                        <template x-if="!editingImage.public_url">
-                                            <span class="text-body-sm text-center px-1 leading-tight" style="color: var(--color-placeholder-text);">{{ _("No preview") }}</span>
-                                        </template>
-                                    </div>
-                                    <div class="flex-1 min-w-0 grid gap-y-1 gap-x-3 text-body-sm content-center"
-                                         style="grid-template-columns: auto 1fr;">
-                                        <template x-if="editingImage.original_filename">
-                                            <span class="contents">
-                                                <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("Original filename") }}</span>
-                                                <span class="min-w-0 truncate font-mono" style="color: var(--color-body-text);" :title="editingImage.original_filename" x-text="editingImage.original_filename"></span>
-                                            </span>
-                                        </template>
-
-                                        <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("Dimensions") }}</span>
-                                        <span class="min-w-0" style="color: var(--color-body-text);">
-                                            <span x-text="editingImage.width"></span>
-                                            ×
-                                            <span x-text="editingImage.height"></span>
-                                            {{ _("px") }}
-                                        </span>
-
-                                        <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("File size") }}</span>
-                                        <span class="min-w-0" style="color: var(--color-body-text);" x-text="formatBytes(editingImage.byte_size)"></span>
-                                    </div>
-                                </div>
-
-                            {# File name (read-only + copy) #}
-                                <div class="mb-3">
-                                    <label for="image-details-filename" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
-                                        {{ _("File name") }}
-                                    </label>
-                                    <div class="flex gap-2">
-                                        <input type="text"
-                                               id="image-details-filename"
-                                               readonly
-                                               :value="editingImage.file_name"
-                                               @click="$event.target.select()"
-                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
-                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
-                                        <button type="button"
-                                                @click="copyToClipboard(editingImage.file_name, '{{ _('File name copied to clipboard') }}')"
-                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
-                                                aria-label="{{ _('Copy file name') }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-
-                            {# <img> snippet (read-only + copy) — hidden when there's no public URL yet #}
-                                <div class="mb-3" x-show="editingImage.img_snippet">
-                                    <label for="image-details-snippet" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
-                                        {{ _("Image snippet") }}
-                                    </label>
-                                    <div class="flex gap-2">
-                                        <input type="text"
-                                               id="image-details-snippet"
-                                               readonly
-                                               :value="editingImage.img_snippet"
-                                               @click="$event.target.select()"
-                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
-                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
-                                        <button type="button"
-                                                @click="copyImageSnippet(editingImage)"
-                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
-                                                aria-label="{{ _('Copy image snippet') }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-
-                                <div>
-                                    <label for="image-edit-alt" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
-                                        {{ _("Alt text") }}
-                                        <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
-                                    </label>
-                                    <input type="text"
-                                           id="image-edit-alt"
-                                           x-model="editingImageAlt"
-                                           :disabled="imageEditing"
-                                           required
-                                           aria-required="true"
-                                           class="w-full px-3 py-2 rounded-md text-body-sm"
-                                           style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
-                                    <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
-                                        {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
-                                    </p>
-                                </div>
-
-                            {# Inline error #}
-                                <div x-show="imageEditError" x-cloak class="rounded-md p-3 mt-3"
-                                     style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
-                                    <p class="text-body-sm" style="color: var(--color-error-600);" x-text="imageEditError"></p>
-                                </div>
-                            </div>
-                        {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-between items-center"
-                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
-                                {{ button(_("Delete image"), variant="danger", attrs='type="button" @click="deleteEditingImage()"', alpine_disabled="imageEditing || imageBeingDeletedId === editingImage.id") }}
-                                <div class="flex gap-2">
-                                    {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageDetailsModalIfAllowed()"', alpine_disabled="imageEditing") }}
-                                    {{ button(_("Save alt"), variant="primary", attrs='type="button" @click="submitImageEdit()"', alpine_disabled="!editingImageAlt.trim() || imageEditing") }}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
 
         {# Toast notification #}
             <div x-cloak
@@ -714,28 +509,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     toastVisible: false,
                     toastMessage: '',
                     toastType: 'success',
-
-                    // Assets panel state. `images` is seeded from server-side render and mutated in place
-                    // so the page never reloads — uncommitted edits in the HTML editor survive.
-                    images: {{ images|tojson }},
-                    // URL contract: the per-image PATCH/DELETE URL is rendered once via
-                    // url_for with a sentinel UUID, and imageItemUrl() swaps in the real id
-                    // at call time. This keeps the route-name dependency explicit instead of
-                    // implying the URL hierarchy. (Upload is handled by the HTMX modal.)
-                    imageItemUrlTemplate: '{{ url_for("backoffice_registration.update_assembly_registration_image", assembly_id=assembly.id, image_id="00000000-0000-0000-0000-000000000000") }}',
-                    imageItemUrl(id) {
-                        return this.imageItemUrlTemplate.replace(
-                            '00000000-0000-0000-0000-000000000000',
-                            encodeURIComponent(id),
-                        );
-                    },
-                    imageBeingDeletedId: '',
-                    // Image details / edit-alt modal
-                    imageDetailsModalOpen: false,
-                    editingImage: null,
-                    editingImageAlt: '',
-                    imageEditing: false,
-                    imageEditError: '',
 
                     fetchSkeleton() {
                         this.skeletonLoading = true;
@@ -792,155 +565,11 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         }, 3000);
                     },
 
-                    // The upload modal posts via HTMX; on success the server fires a
-                    // `registration-image-uploaded` event carrying the new image, which we
-                    // merge into the reactive list here (dedup against an existing row when
-                    // the same bytes were re-uploaded).
-                    onImageUploaded(event) {
-                        const image = event.detail;
-                        if (!image || !image.id) return;
-                        const existing = this.images.findIndex(img => img.id === image.id);
-                        if (existing >= 0) {
-                            this.images.splice(existing, 1, image);
-                        } else {
-                            this.images.push(image);
-                        }
-                        this.showToast('{{ _("Image uploaded") }}', 'success');
-                    },
-
-                    deleteImage(image) {
-                        if (!image || this.imageBeingDeletedId) return;
-                        if (!confirm('{{ _("Delete this image?") }} ' + (image.display_name || ''))) return;
-                        this.imageBeingDeletedId = image.id;
-                        fetch(this.imageItemUrl(image.id), {
-                            method: 'DELETE',
-                            headers: {
-                                'X-CSRFToken': '{{ csrf_token() }}'
-                            }
-                        })
-                            .then(async (response) => {
-                                if (!response.ok) {
-                                    const data = await response.json().catch(() => ({}));
-                                    this.showToast(data.error || '{{ _("Failed to delete image") }}', 'error');
-                                    return;
-                                }
-                                this.images = this.images.filter(img => img.id !== image.id);
-                                this.showToast('{{ _("Image deleted") }}', 'success');
-                            })
-                            .catch(() => {
-                                this.showToast('{{ _("Network error while deleting the image") }}', 'error');
-                            })
-                            .finally(() => {
-                                this.imageBeingDeletedId = '';
-                            });
-                    },
-
-                    copyImageSnippet(image) {
-                        if (!image || !image.img_snippet) {
-                            this.showToast('{{ _("No public URL available yet") }}', 'error');
-                            return;
-                        }
-                        navigator.clipboard.writeText(image.img_snippet)
-                            .then(() => this.showToast('{{ _("Snippet copied to clipboard") }}', 'success'))
-                            .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
-                    },
-
-                    copyToClipboard(text, successMessage) {
-                        if (!text) return;
-                        navigator.clipboard.writeText(text)
-                            .then(() => this.showToast(successMessage || '{{ _("Copied to clipboard") }}', 'success'))
-                            .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
-                    },
-
-                    openImageDetailsModal(image) {
-                        if (!image) return;
-                        this.editingImage = image;
-                        this.editingImageAlt = image.alt || '';
-                        this.imageEditError = '';
-                        this.imageDetailsModalOpen = true;
-                    },
-
-                    closeImageDetailsModalIfAllowed() {
-                        if (this.imageEditing) return;
-                        this.imageDetailsModalOpen = false;
-                        this.editingImage = null;
-                        this.editingImageAlt = '';
-                        this.imageEditError = '';
-                    },
-
-                    deleteEditingImage() {
-                        if (!this.editingImage || this.imageEditing || this.imageBeingDeletedId) return;
-                        const image = this.editingImage;
-                        this.imageBeingDeletedId = image.id;
-                        fetch(this.imageItemUrl(image.id), {
-                            method: 'DELETE',
-                            headers: {
-                                'X-CSRFToken': '{{ csrf_token() }}'
-                            }
-                        })
-                            .then(async (response) => {
-                                if (!response.ok) {
-                                    const data = await response.json().catch(() => ({}));
-                                    this.showToast(data.error || '{{ _("Failed to delete image") }}', 'error');
-                                    return;
-                                }
-                                this.images = this.images.filter(img => img.id !== image.id);
-                                this.imageDetailsModalOpen = false;
-                                this.editingImage = null;
-                                this.editingImageAlt = '';
-                                this.showToast('{{ _("Image deleted") }}', 'success');
-                            })
-                            .catch(() => {
-                                this.showToast('{{ _("Network error while deleting the image") }}', 'error');
-                            })
-                            .finally(() => {
-                                this.imageBeingDeletedId = '';
-                            });
-                    },
-
-                    submitImageEdit() {
-                        if (!this.editingImage || this.imageEditing) return;
-                        const alt = this.editingImageAlt.trim();
-                        if (!alt) {
-                            this.imageEditError = '{{ _("Alt text is required for accessibility") }}';
-                            return;
-                        }
-                        this.imageEditing = true;
-                        this.imageEditError = '';
-                        fetch(this.imageItemUrl(this.editingImage.id), {
-                            method: 'PATCH',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRFToken': '{{ csrf_token() }}'
-                            },
-                            body: JSON.stringify({ alt: alt })
-                        })
-                            .then(async (response) => {
-                                const data = await response.json().catch(() => ({}));
-                                if (!response.ok) {
-                                    this.imageEditError = data.error || '{{ _("Failed to update image") }}';
-                                    return;
-                                }
-                                const idx = this.images.findIndex(img => img.id === data.image.id);
-                                if (idx >= 0) this.images.splice(idx, 1, data.image);
-                                this.imageDetailsModalOpen = false;
-                                this.editingImage = null;
-                                this.editingImageAlt = '';
-                                this.showToast('{{ _("Image updated") }}', 'success');
-                            })
-                            .catch(() => {
-                                this.imageEditError = '{{ _("Network error while updating the image") }}';
-                            })
-                            .finally(() => {
-                                this.imageEditing = false;
-                            });
-                    },
-
-                    formatBytes(bytes) {
-                        if (!Number.isFinite(bytes)) return '';
-                        if (bytes < 1024) return bytes + ' B';
-                        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-                        return (bytes / 1024 / 1024).toFixed(2) + ' MB';
+                    // The image modals post via HTMX; on success the server fires a
+                    // `show-toast` event (HX-Trigger) carrying the message + type.
+                    onToast(event) {
+                        const detail = event.detail || {};
+                        this.showToast(detail.message || '', detail.type || 'success');
                     }
                 }));
             });

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -161,11 +161,15 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
                                         </svg>
                                     {% endset %}
+                        {# Opens the skeleton modal over HTMX (swapped into #image-modal-container);
+                           a plain click navigates to the same URL for the full-page fallback. #}
+                                    {% set skeleton_modal_url = url_for("backoffice_registration.skeleton_modal", assembly_id=assembly.id) %}
                                     {{ button(
                                     _("Show Form Skeleton"),
                                     variant="tertiary",
                                     leading_icon=code_icon,
-                                    attrs='@click="fetchSkeleton()" :disabled="skeletonLoading"'
+                                    href=skeleton_modal_url,
+                                    attrs='hx-get="' ~ skeleton_modal_url ~ '" hx-target="#image-modal-container" hx-swap="innerHTML"'
                                     ) }}
                                 </div>
                             </div>
@@ -304,70 +308,13 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
             </div>
         {% endif %}
 
-        {# Form Skeleton Modal - only shown when registration page exists #}
+        {# Modals are only relevant when a registration page exists #}
         {% if has_registration_page %}
-            <template x-if="skeletonModalOpen">
-                <div x-cloak>
-                {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeSkeletonModal()"
-                         @keydown.escape.window="closeSkeletonModal()"></div>
-                {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="skeleton-modal-title">
-                        <div class="pointer-events-auto w-full max-w-4xl mx-4 rounded-lg shadow-xl overflow-hidden"
-                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
-                        {# Header #}
-                            <div class="px-6 py-4 flex items-center justify-between"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="skeleton-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
-                                    {{ _("Form Skeleton") }}
-                                </h2>
-                                <button type="button"
-                                        @click="closeSkeletonModal()"
-                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100"
-                                        style="color: var(--color-secondary-text);"
-                                        aria-label="{{ _('Close') }}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
-                        {# Content #}
-                            <div class="px-6 py-4">
-                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                    {{ _("This skeleton is generated from your assembly's field definitions. Copy all or select specific parts to paste into your form.") }}
-                                </p>
-                                <textarea readonly
-                                          x-ref="skeletonTextarea"
-                                          x-text="skeletonHtml"
-                                          class="w-full rounded-lg p-4"
-                                          rows="18"
-                                          style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
-                                                 font-size: 0.875rem;
-                                                 line-height: 1.5;
-                                                 background-color: var(--color-subtle-background-panels);
-                                                 border: 1px solid var(--color-borders-dividers);
-                                                 color: var(--color-body-text);
-                                                 resize: none;"></textarea>
-                            </div>
-                        {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-end"
-                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
-                                {{ button(_("Copy All"), variant="secondary", attrs='@click="copySkeletonToClipboard()"') }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
 
-        {# Page modals (upload + per-image details + preview/share) are loaded from
-           the server via HTMX into this container. The no-JS fallback renders the
-           requested modal here server-side via ?modal=upload / details / preview. #}
+        {# Page modals (upload, per-image details, preview/share, form skeleton) are
+           loaded from the server via HTMX into this container. The no-JS fallback
+           renders the requested modal here server-side via ?modal=upload / details /
+           preview / skeleton. #}
             <div id="image-modal-container">
                 {% if open_modal == "upload" %}
                     {% with assembly_id = assembly.id %}
@@ -379,6 +326,10 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     {% endwith %}
                 {% elif open_modal == "preview" and registration_page %}
                     {% include "backoffice/registration/preview_modal.html" %}
+                {% elif open_modal == "skeleton" %}
+                    {% with assembly_id = assembly.id %}
+                        {% include "backoffice/registration/skeleton_modal.html" %}
+                    {% endwith %}
                 {% endif %}
             </div>
 
@@ -402,50 +353,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
         <script nonce="{{ csp_nonce }}">
             document.addEventListener('alpine:init', () => {
                 Alpine.data('registrationPageController', () => ({
-                    skeletonLoading: false,
-                    skeletonModalOpen: false,
-                    skeletonHtml: '',
                     toastVisible: false,
                     toastMessage: '',
                     toastType: 'success',
-
-                    fetchSkeleton() {
-                        this.skeletonLoading = true;
-                        fetch('{{ url_for("backoffice_registration.get_registration_skeleton", assembly_id=assembly.id) }}', {
-                            method: 'GET',
-                            headers: {
-                                'X-CSRFToken': '{{ csrf_token() }}'
-                            }
-                        })
-                            .then(response => response.json())
-                            .then(data => {
-                                this.skeletonLoading = false;
-                                if (data.error) {
-                                    this.showToast(data.error, 'error');
-                                } else {
-                                    this.skeletonHtml = data.html;
-                                    this.skeletonModalOpen = true;
-                                }
-                            })
-                            .catch(error => {
-                                this.skeletonLoading = false;
-                                this.showToast('{{ _("An error occurred while fetching the form skeleton") }}', 'error');
-                            });
-                    },
-
-                    closeSkeletonModal() {
-                        this.skeletonModalOpen = false;
-                    },
-
-                    copySkeletonToClipboard() {
-                        navigator.clipboard.writeText(this.skeletonHtml)
-                            .then(() => {
-                                this.showToast('{{ _("Copied to clipboard") }}', 'success');
-                            })
-                            .catch(() => {
-                                this.showToast('{{ _("Failed to copy to clipboard") }}', 'error');
-                            });
-                    },
 
                     showToast(message, type) {
                         this.toastMessage = message;

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -169,7 +169,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     variant="tertiary",
                                     leading_icon=code_icon,
                                     href=skeleton_modal_url,
-                                    attrs='hx-get="' ~ skeleton_modal_url ~ '" hx-target="#image-modal-container" hx-swap="innerHTML"'
+                                    hx_get=skeleton_modal_url,
+                                    hx_target="#image-modal-container",
+                                    hx_swap="innerHTML"
                                     ) }}
                                 </div>
                             </div>
@@ -201,7 +203,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         {# Preview / Share opens over HTMX (swapped into #image-modal-container); a plain
                            click navigates to the same URL and gets the full page with the modal open. #}
                                     {% set preview_modal_url = url_for("backoffice_registration.preview_modal", assembly_id=assembly.id) %}
-                                    {% set preview_attrs = 'hx-get="' ~ preview_modal_url ~ '" hx-target="#image-modal-container" hx-swap="innerHTML"' %}
                         {# Preview / Share lives next to Save — "view what you just edited" pairs with "save it" #}
                                     {% if registration_status == "TEST" %}
                                         {% set eye_icon %}
@@ -215,7 +216,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                         variant="tertiary",
                                         leading_icon=eye_icon,
                                         href=preview_modal_url,
-                                        attrs=preview_attrs
+                                        hx_get=preview_modal_url,
+                                        hx_target="#image-modal-container",
+                                        hx_swap="innerHTML"
                                         ) }}
                                         {% if edit_mode %}
                                             {{ button(_("Cancel"), variant="secondary", href=view_url) }}
@@ -235,7 +238,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             variant="tertiary",
                                             leading_icon=link_icon,
                                             href=preview_modal_url,
-                                            attrs=preview_attrs
+                                            hx_get=preview_modal_url,
+                                            hx_target="#image-modal-container",
+                                            hx_swap="innerHTML"
                                             ) }}
                                             {% if edit_mode %}
                                                 {{ button(_("Cancel"), variant="secondary", href=view_url) }}
@@ -284,7 +289,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             variant="tertiary",
                             leading_icon=upload_icon,
                             href=upload_modal_url,
-                            attrs='hx-get="' ~ upload_modal_url ~ '" hx-target="#image-modal-container" hx-swap="innerHTML"'
+                            hx_get=upload_modal_url,
+                            hx_target="#image-modal-container",
+                            hx_swap="innerHTML"
                             ) }}
                         </div>
 

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -24,7 +24,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 {% endblock %}
 
 {% block page_content %}
-    <div x-data="registrationPageController()">
+    <div x-data="registrationPageController()"
+         x-on:registration-image-uploaded.window="onImageUploaded($event)">
         {# Page Heading #}
         <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
         <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
@@ -264,11 +265,16 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
                                 </svg>
                             {% endset %}
+                        {# Opens the upload modal via HTMX (swapped into #image-modal-container);
+                           a plain click navigates to the same URL and gets the full page with the
+                           modal already open, so it still works when JS is unavailable. #}
+                            {% set upload_modal_url = url_for('backoffice_registration.image_upload_modal', assembly_id=assembly.id) %}
                             {{ button(
                             _("Upload"),
                             variant="tertiary",
                             leading_icon=upload_icon,
-                            attrs='type="button" @click="openImageUploadModal()"'
+                            href=upload_modal_url,
+                            attrs='hx-get="' ~ upload_modal_url ~ '" hx-target="#image-modal-container" hx-swap="innerHTML"'
                             ) }}
                         </div>
 
@@ -512,96 +518,15 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </template>
             {% endif %}
 
-        {# Image Upload Modal #}
-            <template x-if="imageUploadModalOpen">
-                <div x-cloak>
-                {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeImageUploadModalIfAllowed()"
-                         @keydown.escape.window="closeImageUploadModalIfAllowed()"></div>
-                {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="image-upload-modal-title">
-                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
-                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
-                        {# Header #}
-                            <div class="px-6 py-4 flex items-center justify-between"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="image-upload-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
-                                    {{ _("Upload image") }}
-                                </h2>
-                                <button type="button"
-                                        @click="closeImageUploadModalIfAllowed()"
-                                        :disabled="imageUploading"
-                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
-                                        style="color: var(--color-secondary-text);"
-                                        aria-label="{{ _('Close') }}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
-                        {# Content #}
-                            <div class="px-6 py-4">
-                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                    {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. Files are downscaled and re-encoded to PNG on upload.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
-                                </p>
-
-                                <div class="space-y-4">
-                                    <div>
-                                        <label for="image-upload-file" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
-                                            {{ _("Image file") }}
-                                        </label>
-                                        <input type="file"
-                                               id="image-upload-file"
-                                               x-ref="imageFileInput"
-                                               accept="image/png,image/jpeg,image/webp"
-                                               @change="onImageFileSelected($event)"
-                                               :disabled="imageUploading"
-                                               class="w-full px-3 py-2 rounded-md text-body-sm"
-                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
-                                        <p x-show="imageFileName" x-cloak class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
-                                            <span x-text="imageFileName"></span>
-                                        </p>
-                                    </div>
-                                    <div>
-                                        <label for="image-upload-alt" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
-                                            {{ _("Alt text") }}
-                                            <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
-                                        </label>
-                                        <input type="text"
-                                               id="image-upload-alt"
-                                               x-model="imageAlt"
-                                               :disabled="imageUploading"
-                                               required
-                                               aria-required="true"
-                                               class="w-full px-3 py-2 rounded-md text-body-sm"
-                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
-                                        <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
-                                            {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
-                                        </p>
-                                    </div>
-                                {# Inline error #}
-                                    <div x-show="imageUploadError" x-cloak class="rounded-md p-3"
-                                         style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
-                                        <p class="text-body-sm" style="color: var(--color-error-600);" x-text="imageUploadError"></p>
-                                    </div>
-                                </div>
-                            </div>
-                        {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-end"
-                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
-                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageUploadModalIfAllowed()"', alpine_disabled="imageUploading") }}
-                                {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitImageUpload()"', alpine_disabled="!imageFile || !imageAlt.trim() || imageUploading") }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
+        {# Image Upload Modal — loaded from the server via HTMX into this container.
+           The no-JS fallback renders the modal here server-side when ?modal=upload. #}
+            <div id="image-modal-container">
+                {% if open_modal == "upload" %}
+                    {% with assembly_id = assembly.id %}
+                        {% include "backoffice/registration/image_upload_modal.html" %}
+                    {% endwith %}
+                {% endif %}
+            </div>
 
         {# Image Details / Edit Alt Modal #}
             <template x-if="imageDetailsModalOpen && editingImage">
@@ -793,11 +718,10 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     // Assets panel state. `images` is seeded from server-side render and mutated in place
                     // so the page never reloads — uncommitted edits in the HTML editor survive.
                     images: {{ images|tojson }},
-                    // URL contract: the upload endpoint is its own POST URL; the per-image
-                    // PATCH/DELETE URL is rendered once via url_for with a sentinel UUID,
-                    // and imageItemUrl() swaps in the real id at call time. This keeps the
-                    // route-name dependency explicit instead of implying the URL hierarchy.
-                    uploadImageUrl: '{{ url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id) }}',
+                    // URL contract: the per-image PATCH/DELETE URL is rendered once via
+                    // url_for with a sentinel UUID, and imageItemUrl() swaps in the real id
+                    // at call time. This keeps the route-name dependency explicit instead of
+                    // implying the URL hierarchy. (Upload is handled by the HTMX modal.)
                     imageItemUrlTemplate: '{{ url_for("backoffice_registration.update_assembly_registration_image", assembly_id=assembly.id, image_id="00000000-0000-0000-0000-000000000000") }}',
                     imageItemUrl(id) {
                         return this.imageItemUrlTemplate.replace(
@@ -805,12 +729,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             encodeURIComponent(id),
                         );
                     },
-                    imageUploadModalOpen: false,
-                    imageUploading: false,
-                    imageFile: null,
-                    imageFileName: '',
-                    imageAlt: '',
-                    imageUploadError: '',
                     imageBeingDeletedId: '',
                     // Image details / edit-alt modal
                     imageDetailsModalOpen: false,
@@ -874,67 +792,20 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         }, 3000);
                     },
 
-                    openImageUploadModal() {
-                        this.imageFile = null;
-                        this.imageFileName = '';
-                        this.imageAlt = '';
-                        this.imageUploadError = '';
-                        this.imageUploadModalOpen = true;
-                    },
-
-                    closeImageUploadModalIfAllowed() {
-                        if (this.imageUploading) return;
-                        this.imageUploadModalOpen = false;
-                    },
-
-                    onImageFileSelected(event) {
-                        const file = event.target.files && event.target.files[0];
-                        this.imageFile = file || null;
-                        this.imageFileName = file ? file.name : '';
-                        this.imageUploadError = '';
-                    },
-
-                    submitImageUpload() {
-                        if (!this.imageFile || this.imageUploading) return;
-                        const alt = this.imageAlt.trim();
-                        if (!alt) {
-                            this.imageUploadError = '{{ _("Alt text is required for accessibility") }}';
-                            return;
+                    // The upload modal posts via HTMX; on success the server fires a
+                    // `registration-image-uploaded` event carrying the new image, which we
+                    // merge into the reactive list here (dedup against an existing row when
+                    // the same bytes were re-uploaded).
+                    onImageUploaded(event) {
+                        const image = event.detail;
+                        if (!image || !image.id) return;
+                        const existing = this.images.findIndex(img => img.id === image.id);
+                        if (existing >= 0) {
+                            this.images.splice(existing, 1, image);
+                        } else {
+                            this.images.push(image);
                         }
-                        this.imageUploading = true;
-                        this.imageUploadError = '';
-                        const formData = new FormData();
-                        formData.append('image', this.imageFile);
-                        formData.append('alt', alt);
-                        fetch(this.uploadImageUrl, {
-                            method: 'POST',
-                            headers: {
-                                'X-CSRFToken': '{{ csrf_token() }}'
-                            },
-                            body: formData
-                        })
-                            .then(async (response) => {
-                                const data = await response.json().catch(() => ({}));
-                                if (!response.ok) {
-                                    this.imageUploadError = data.error || '{{ _("Upload failed") }}';
-                                    return;
-                                }
-                                // Dedup against existing list (server returns the existing row when bytes match)
-                                const existing = this.images.findIndex(img => img.id === data.image.id);
-                                if (existing >= 0) {
-                                    this.images.splice(existing, 1, data.image);
-                                } else {
-                                    this.images.push(data.image);
-                                }
-                                this.imageUploadModalOpen = false;
-                                this.showToast('{{ _("Image uploaded") }}', 'success');
-                            })
-                            .catch(() => {
-                                this.imageUploadError = '{{ _("Network error while uploading the image") }}';
-                            })
-                            .finally(() => {
-                                this.imageUploading = false;
-                            });
+                        this.showToast('{{ _("Image uploaded") }}', 'success');
                     },
 
                     deleteImage(image) {

--- a/backend/templates/backoffice/components/button.html
+++ b/backend/templates/backoffice/components/button.html
@@ -3,7 +3,7 @@ ABOUTME: Button component macro for backoffice design system
 ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and full a11y support
 #}
 
-{% macro button(text="", variant="primary", disabled=false, alpine_disabled="", type="button", href="", id="", classes="", attrs="", leading_icon="", trailing_icon="", icon="", full_width=false, aria_label="", aria_pressed="", aria_haspopup="", aria_expanded="", aria_describedby="") %}
+{% macro button(text="", variant="primary", disabled=false, alpine_disabled="", type="button", href="", id="", classes="", attrs="", leading_icon="", trailing_icon="", icon="", full_width=false, aria_label="", aria_pressed="", aria_haspopup="", aria_expanded="", aria_describedby="", hx_get="", hx_post="", hx_target="", hx_swap="", hx_confirm="") %}
     {#
     Button component based on Figma OpenDLP UI specification.
     Renders as <a> when href is provided, otherwise <button>.
@@ -28,6 +28,13 @@ ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and ful
         id: optional id attribute
         classes: additional CSS classes to append
         attrs: additional HTML attributes (e.g., '@click="open = !open"' for Alpine.js)
+        hx_get / hx_post: HTMX request URL for this button (rendered as hx-get / hx-post).
+                          Prefer these over building hx-* by hand in `attrs`: the value is
+                          interpolated as a normal attribute, which avoids the autoescape
+                          pitfall where `'hx-x="' ~ _("...") ~ '"'` escapes the quotes.
+        hx_target: CSS selector for the HTMX swap target (hx-target)
+        hx_swap: HTMX swap strategy, e.g. "innerHTML" / "outerHTML" (hx-swap)
+        hx_confirm: confirmation prompt shown before the HTMX request (hx-confirm)
         leading_icon: HTML/SVG for icon before the label (16x16)
         trailing_icon: HTML/SVG for icon after the label (16x16)
         icon: HTML/SVG for icon-only variant (16x16)
@@ -58,6 +65,10 @@ ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and ful
 
     As a link:
         {{ button("Go to Dashboard", href="/dashboard") }}
+
+    HTMX modal trigger (progressive enhancement — href is the no-JS fallback):
+        {{ button("Upload", href=modal_url, hx_get=modal_url,
+                  hx_target="#modal-container", hx_swap="innerHTML") }}
 
     Toggle button:
         {{ button("Mute", aria_pressed="true") }}
@@ -161,6 +172,11 @@ ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and ful
             {% if aria_haspopup %}aria-haspopup="{{ aria_haspopup }}"{% endif %}
             {% if aria_expanded %}aria-expanded="{{ aria_expanded }}"{% endif %}
             {% if aria_describedby %}aria-describedby="{{ aria_describedby }}"{% endif %}
+            {% if hx_get %}hx-get="{{ hx_get }}"{% endif %}
+            {% if hx_post %}hx-post="{{ hx_post }}"{% endif %}
+            {% if hx_target %}hx-target="{{ hx_target }}"{% endif %}
+            {% if hx_swap %}hx-swap="{{ hx_swap }}"{% endif %}
+            {% if hx_confirm %}hx-confirm="{{ hx_confirm }}"{% endif %}
             {% if attrs %}{{ attrs | safe }}{% endif %}
             style="{{ all_styles }}"
             class="{{ hover_class }} {{ focus_class }} {{ classes }}"
@@ -180,6 +196,11 @@ ABOUTME: Supports primary, secondary, tertiary, icon variants with icons and ful
             {% if aria_haspopup %}aria-haspopup="{{ aria_haspopup }}"{% endif %}
             {% if aria_expanded %}aria-expanded="{{ aria_expanded }}"{% endif %}
             {% if aria_describedby %}aria-describedby="{{ aria_describedby }}"{% endif %}
+            {% if hx_get %}hx-get="{{ hx_get }}"{% endif %}
+            {% if hx_post %}hx-post="{{ hx_post }}"{% endif %}
+            {% if hx_target %}hx-target="{{ hx_target }}"{% endif %}
+            {% if hx_swap %}hx-swap="{{ hx_swap }}"{% endif %}
+            {% if hx_confirm %}hx-confirm="{{ hx_confirm }}"{% endif %}
             {% if attrs %}{{ attrs | safe }}{% endif %}
             style="{{ all_styles }}"
             class="{{ hover_class }} {{ focus_class }} {{ classes }}"

--- a/backend/templates/backoffice/registration/image_asset_list.html
+++ b/backend/templates/backoffice/registration/image_asset_list.html
@@ -1,0 +1,66 @@
+{#
+ABOUTME: Server-rendered Assets list for the registration page (HTMX, no Alpine)
+ABOUTME: Mutations re-render this fragment; pass oob=true to swap it out of band
+#}
+<ul id="image-asset-list" class="space-y-2" {% if oob %}hx-swap-oob="true"{% endif %}>
+    {% if images %}
+        {% for image in images %}
+            {% set details_url = url_for('backoffice_registration.image_details_modal', assembly_id=assembly_id, image_id=image.id) %}
+            {% set item_url = url_for('backoffice_registration.update_assembly_registration_image', assembly_id=assembly_id, image_id=image.id) %}
+            <li class="rounded-md px-3 py-2 flex items-center justify-between"
+                style="background-color: var(--color-subtle-background-panels);">
+                <a href="{{ image.public_url }}"
+                   title="{{ image.alt or image.file_name }}"
+                   target="_blank"
+                   rel="noopener"
+                   class="text-body-sm truncate flex-1 mr-2"
+                   style="color: var(--color-body-text);">{{ image.display_name }}</a>
+                <div class="flex items-center gap-1 flex-shrink-0">
+                    {# Image details / edit alt text — loads the modal over HTMX #}
+                    <a href="{{ details_url }}"
+                       hx-get="{{ details_url }}"
+                       hx-target="#image-modal-container"
+                       hx-swap="innerHTML"
+                       class="p-1.5 rounded-md transition-colors hover:bg-gray-100 inline-flex"
+                       style="color: var(--color-secondary-text);"
+                       aria-label="{{ _('Details for') }} {{ image.display_name }}">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                    </a>
+                    {# Copy <img> snippet to clipboard (delegated handler in utilities.js) #}
+                    <button type="button"
+                            data-copy-text="{{ image.img_snippet }}"
+                            data-copy-message="{{ _('Snippet copied to clipboard') }}"
+                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                            style="color: var(--color-secondary-text);"
+                            aria-label="{{ _('Copy <img> snippet for') }} {{ image.display_name }}">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                        </svg>
+                    </button>
+                    {# Delete — HTMX only (needs JS); confirm via hx-confirm #}
+                    <form hx-delete="{{ item_url }}"
+                          hx-target="#image-modal-container"
+                          hx-swap="innerHTML"
+                          hx-confirm="{{ _('Delete this image?') }} {{ image.display_name }}"
+                          class="inline-flex">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                        <button type="submit"
+                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                style="color: var(--color-secondary-text);"
+                                aria-label="{{ _('Delete') }} {{ image.display_name }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                            </svg>
+                        </button>
+                    </form>
+                </div>
+            </li>
+        {% endfor %}
+    {% else %}
+        <li class="text-body-sm text-center py-4 list-none" style="color: var(--color-secondary-text);">
+            {{ _("No images uploaded yet.") }}
+        </li>
+    {% endif %}
+</ul>

--- a/backend/templates/backoffice/registration/image_details_modal.html
+++ b/backend/templates/backoffice/registration/image_details_modal.html
@@ -1,0 +1,159 @@
+{#
+ABOUTME: Image details / edit-alt modal fragment for the registration Assets panel
+ABOUTME: Server-rendered + HTMX-driven (hx-patch edit, hx-delete); copy uses utilities.js
+#}
+{% from "backoffice/components/button.html" import button %}
+{% set item_url = url_for('backoffice_registration.update_assembly_registration_image', assembly_id=assembly_id, image_id=image.id) %}
+{% set close_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly_id) %}
+{# Backdrop overlay — an anchor so closing works without JS (full page reload) #}
+<a href="{{ close_url }}"
+   class="fixed inset-0 z-40 block"
+   style="background-color: rgba(0, 0, 0, 0.5)"
+   aria-label="{{ _('Close') }}"></a>
+{# Modal panel #}
+<div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="image-details-modal-title">
+    <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+         style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)">
+        {# Header #}
+        <div class="px-6 py-4 flex items-center justify-between"
+             style="border-bottom: 1px solid var(--color-borders-dividers)">
+            <h2 id="image-details-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                {{ _("Image details") }}
+            </h2>
+            <a href="{{ close_url }}"
+               class="p-2 rounded-lg transition-colors hover:bg-gray-100"
+               style="color: var(--color-secondary-text);"
+               aria-label="{{ _('Close') }}">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </a>
+        </div>
+        {# Content #}
+        <div class="px-6 py-4">
+            {# Thumbnail + compact metadata #}
+            <div class="rounded-md p-3 mb-4 flex gap-3" style="background-color: var(--color-subtle-background-panels);">
+                <div class="flex-shrink-0 w-16 h-16 rounded-md overflow-hidden flex items-center justify-center"
+                     style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers);">
+                    {% if image.public_url %}
+                        <img src="{{ image.public_url }}" alt="{{ image.alt or '' }}" class="max-w-full max-h-full object-contain" />
+                    {% else %}
+                        <span class="text-body-sm text-center px-1 leading-tight" style="color: var(--color-placeholder-text);">{{ _("No preview") }}</span>
+                    {% endif %}
+                </div>
+                <div class="flex-1 min-w-0 grid gap-y-1 gap-x-3 text-body-sm content-center" style="grid-template-columns: auto 1fr;">
+                    {% if image.original_filename %}
+                        <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("Original filename") }}</span>
+                        <span class="min-w-0 truncate font-mono" style="color: var(--color-body-text);" title="{{ image.original_filename }}">{{ image.original_filename }}</span>
+                    {% endif %}
+
+                    <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("Dimensions") }}</span>
+                    <span class="min-w-0" style="color: var(--color-body-text);">{{ image.width }} × {{ image.height }} {{ _("px") }}</span>
+
+                    <span class="font-medium whitespace-nowrap" style="color: var(--color-headings);">{{ _("File size") }}</span>
+                    <span class="min-w-0" style="color: var(--color-body-text);">{{ image.byte_size | filesizeformat(true) }}</span>
+                </div>
+            </div>
+
+            {# File name (read-only + copy) #}
+            <div class="mb-3">
+                <label for="image-details-filename" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                    {{ _("File name") }}
+                </label>
+                <div class="flex gap-2">
+                    <input type="text"
+                           id="image-details-filename"
+                           readonly
+                           value="{{ image.file_name }}"
+                           class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                           style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                    <button type="button"
+                            data-copy-text="{{ image.file_name }}"
+                            data-copy-message="{{ _('File name copied to clipboard') }}"
+                            class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                            style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                            aria-label="{{ _('Copy file name') }}">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            {# <img> snippet (read-only + copy) — only when there's a public URL #}
+            {% if image.img_snippet %}
+                <div class="mb-3">
+                    <label for="image-details-snippet" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                        {{ _("Image snippet") }}
+                    </label>
+                    <div class="flex gap-2">
+                        <input type="text"
+                               id="image-details-snippet"
+                               readonly
+                               value="{{ image.img_snippet }}"
+                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                        <button type="button"
+                                data-copy-text="{{ image.img_snippet }}"
+                                data-copy-message="{{ _('Snippet copied to clipboard') }}"
+                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                aria-label="{{ _('Copy image snippet') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+            {% endif %}
+
+            {# Alt-text edit form — patches this image, returns the refreshed asset list #}
+            <form id="image-details-edit"
+                  hx-patch="{{ item_url }}"
+                  hx-target="#image-modal-container"
+                  hx-swap="innerHTML">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                <label for="image-edit-alt" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                    {{ _("Alt text") }}
+                    <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
+                </label>
+                <input type="text"
+                       id="image-edit-alt"
+                       name="alt"
+                       value="{{ alt_value if error else image.alt }}"
+                       required
+                       aria-required="true"
+                       class="w-full px-3 py-2 rounded-md text-body-sm"
+                       style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                    {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
+                </p>
+                {% if error %}
+                    <div class="rounded-md p-3 mt-3"
+                         style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
+                        <p class="text-body-sm" style="color: var(--color-error-600);">{{ error }}</p>
+                    </div>
+                {% endif %}
+            </form>
+        </div>
+        {# Footer #}
+        <div class="px-6 py-3 flex gap-2 justify-between items-center"
+             style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+            {# Delete is its own form so it doesn't nest inside the edit form #}
+            <form hx-delete="{{ item_url }}"
+                  hx-target="#image-modal-container"
+                  hx-swap="innerHTML"
+                  hx-confirm="{{ _('Delete this image?') }} {{ image.display_name }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                {{ button(_("Delete image"), variant="danger", type="submit") }}
+            </form>
+            <div class="flex gap-2">
+                {{ button(_("Cancel"), variant="secondary", href=close_url) }}
+                {{ button(_("Save alt"), variant="primary", type="submit", attrs='form="image-details-edit"') }}
+            </div>
+        </div>
+    </div>
+</div>

--- a/backend/templates/backoffice/registration/image_upload_modal.html
+++ b/backend/templates/backoffice/registration/image_upload_modal.html
@@ -1,0 +1,97 @@
+{#
+ABOUTME: Image upload modal fragment for the assembly registration Assets panel
+ABOUTME: Server-rendered + HTMX-posted so it works as a full page reload when JS is off
+#}
+{% from "backoffice/components/button.html" import button %}
+{% set upload_url = url_for('backoffice_registration.upload_registration_image', assembly_id=assembly_id) %}
+{% set close_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly_id) %}
+{# Backdrop overlay — an anchor so closing works without JS (full page reload) #}
+<a href="{{ close_url }}"
+   class="fixed inset-0 z-40 block"
+   style="background-color: rgba(0, 0, 0, 0.5)"
+   aria-label="{{ _('Close') }}"></a>
+{# Modal panel #}
+<div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="image-upload-modal-title">
+    <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+         style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)">
+        <form method="post"
+              action="{{ upload_url }}"
+              enctype="multipart/form-data"
+              hx-post="{{ upload_url }}"
+              hx-target="#image-modal-container"
+              hx-swap="innerHTML"
+              hx-encoding="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            {# Header #}
+            <div class="px-6 py-4 flex items-center justify-between"
+                 style="border-bottom: 1px solid var(--color-borders-dividers)">
+                <h2 id="image-upload-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                    {{ _("Upload image") }}
+                </h2>
+                <a href="{{ close_url }}"
+                   class="p-2 rounded-lg transition-colors hover:bg-gray-100"
+                   style="color: var(--color-secondary-text);"
+                   aria-label="{{ _('Close') }}">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </a>
+            </div>
+            {# Content #}
+            <div class="px-6 py-4">
+                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                    {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. Files are downscaled and re-encoded to PNG on upload.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
+                </p>
+
+                {# Inline error (re-rendered on a failed HTMX post) #}
+                {% if error %}
+                    <div class="rounded-md p-3 mb-4"
+                         style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
+                        <p class="text-body-sm" style="color: var(--color-error-600);">{{ error }}</p>
+                    </div>
+                {% endif %}
+
+                <div class="space-y-4">
+                    <div>
+                        <label for="image-upload-file" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                            {{ _("Image file") }}
+                        </label>
+                        <input type="file"
+                               id="image-upload-file"
+                               name="image"
+                               accept="image/png,image/jpeg,image/webp"
+                               required
+                               class="w-full px-3 py-2 rounded-md text-body-sm"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                    </div>
+                    <div>
+                        <label for="image-upload-alt" class="text-body-sm font-medium block mb-1" style="color: var(--color-headings);">
+                            {{ _("Alt text") }}
+                            <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
+                        </label>
+                        <input type="text"
+                               id="image-upload-alt"
+                               name="alt"
+                               value="{{ alt_value|default('') }}"
+                               required
+                               aria-required="true"
+                               class="w-full px-3 py-2 rounded-md text-body-sm"
+                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                        <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                            {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
+                        </p>
+                    </div>
+                </div>
+            </div>
+            {# Footer #}
+            <div class="px-6 py-3 flex gap-2 justify-end"
+                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+                {{ button(_("Cancel"), variant="secondary", href=close_url) }}
+                {{ button(_("Upload"), variant="primary", type="submit") }}
+            </div>
+        </form>
+    </div>
+</div>

--- a/backend/templates/backoffice/registration/preview_modal.html
+++ b/backend/templates/backoffice/registration/preview_modal.html
@@ -1,0 +1,103 @@
+{#
+ABOUTME: Preview / Share modal fragment for the registration page (read-only)
+ABOUTME: Server-rendered + HTMX-loaded; closing is a full page reload to the page
+#}
+{% from "backoffice/components/button.html" import button %}
+{% from "backoffice/components/url_display.html" import readonly_url_display %}
+{% set close_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id) %}
+{% set preview_modal_title = _("Preview and Test Responses") if registration_status == "TEST" else _("Share Form") %}
+{# Backdrop overlay — an anchor so closing works without JS (full page reload) #}
+<a href="{{ close_url }}"
+   class="fixed inset-0 z-40 block"
+   style="background-color: rgba(0, 0, 0, 0.5)"
+   aria-label="{{ _('Close') }}"></a>
+{# Modal panel #}
+<div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="preview-modal-title">
+    <div class="pointer-events-auto w-full max-w-2xl mx-4 rounded-lg shadow-xl overflow-hidden"
+         style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)">
+        {# Header #}
+        <div class="px-6 py-4 flex items-center justify-between"
+             style="border-bottom: 1px solid var(--color-borders-dividers)">
+            <h2 id="preview-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                {{ preview_modal_title }}
+            </h2>
+            <a href="{{ close_url }}"
+               class="p-2 rounded-lg transition-colors hover:bg-gray-100"
+               style="color: var(--color-secondary-text);"
+               aria-label="{{ _('Close') }}">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </a>
+        </div>
+        {# Content #}
+        <div class="px-6 py-4 max-h-[70vh] overflow-y-auto">
+            {# Test submission notice - TEST state only #}
+            {% if registration_status == "TEST" %}
+                <div class="rounded-lg p-4 mb-6"
+                     style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
+                    <p class="text-body-sm" style="color: var(--color-warning-600);">
+                        {{ _("The form is in test mode. Submissions made via these URLs are recorded as test submissions and will not enter the selection pool.") }}
+                    </p>
+                </div>
+            {% endif %}
+
+            <div class="space-y-6">
+                {# Registration URL #}
+                {{ readonly_url_display(
+                label=_("Registration URL"),
+                hint=_("The URL for your registration form"),
+                url=registration_url
+                ) }}
+
+                {# Short URL - only if configured #}
+                {% if registration_page.short_url_slug %}
+                    {{ readonly_url_display(
+                    label=_("Short URL"),
+                    hint=_("A shorter URL for QR codes and paper invitations"),
+                    url=short_url
+                    ) }}
+                {% endif %}
+
+                {# QR Code - only when short URL is configured #}
+                {% if qr_code_data_url %}
+                    <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers);">
+                        <h3 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("QR Code") }}</h3>
+                        <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                            {{ _("Use this QR code on paper invitations") }}
+                        </p>
+
+                        <div class="flex items-start gap-6">
+                            <div class="flex-shrink-0 p-4 rounded-lg" style="background-color: white; border: 1px solid var(--color-borders-dividers);">
+                                <img src="{{ qr_code_data_url }}" alt="{{ _('QR code for registration page') }}" class="w-40 h-40" />
+                            </div>
+
+                            <div class="flex flex-col gap-2">
+                                <a href="{{ url_for('backoffice_registration.download_registration_qr_code', assembly_id=assembly.id) }}"
+                                   class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-button-md transition-colors"
+                                   style="background-color: var(--color-button-secondary-bg); color: var(--color-button-secondary-text); border: 1px solid var(--color-borders-dividers);"
+                                   download>
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                    </svg>
+                                    {{ _("Download QR Code") }}
+                                </a>
+                                <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                                    {{ _("PNG format, 400x400 pixels") }}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+        {# Footer #}
+        <div class="px-6 py-3 flex gap-2 justify-end"
+             style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+            {{ button(_("Close"), variant="secondary", href=close_url) }}
+        </div>
+    </div>
+</div>

--- a/backend/templates/backoffice/registration/skeleton_modal.html
+++ b/backend/templates/backoffice/registration/skeleton_modal.html
@@ -1,0 +1,63 @@
+{#
+ABOUTME: Form Skeleton modal fragment — server-rendered starter HTML for the registration form
+ABOUTME: HTMX-loaded; copy uses the delegated clipboard helper in utilities.js
+#}
+{% set close_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly_id) %}
+{# Backdrop overlay — an anchor so closing works without JS (full page reload) #}
+<a href="{{ close_url }}"
+   class="fixed inset-0 z-40 block"
+   style="background-color: rgba(0, 0, 0, 0.5)"
+   aria-label="{{ _('Close') }}"></a>
+{# Modal panel #}
+<div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="skeleton-modal-title">
+    <div class="pointer-events-auto w-full max-w-4xl mx-4 rounded-lg shadow-xl overflow-hidden"
+         style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)">
+        {# Header #}
+        <div class="px-6 py-4 flex items-center justify-between"
+             style="border-bottom: 1px solid var(--color-borders-dividers)">
+            <h2 id="skeleton-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                {{ _("Form Skeleton") }}
+            </h2>
+            <a href="{{ close_url }}"
+               class="p-2 rounded-lg transition-colors hover:bg-gray-100"
+               style="color: var(--color-secondary-text);"
+               aria-label="{{ _('Close') }}">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </a>
+        </div>
+        {# Content #}
+        <div class="px-6 py-4">
+            <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                {{ _("This skeleton is generated from your assembly's field definitions. Copy all or select specific parts to paste into your form.") }}
+            </p>
+            <textarea readonly
+                      id="skeleton-html-textarea"
+                      class="w-full rounded-lg p-4"
+                      rows="18"
+                      style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+                             font-size: 0.875rem;
+                             line-height: 1.5;
+                             background-color: var(--color-subtle-background-panels);
+                             border: 1px solid var(--color-borders-dividers);
+                             color: var(--color-body-text);
+                             resize: none;">{{ skeleton_html }}</textarea>
+        </div>
+        {# Footer — plain button so the data-copy-* attributes (incl. a translated
+           message) interpolate correctly; the macro's `attrs` would escape them. #}
+        <div class="px-6 py-3 flex gap-2 justify-end"
+             style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+            <button type="button"
+                    data-copy-target="skeleton-html-textarea"
+                    data-copy-message="{{ _('Copied to clipboard') }}"
+                    class="btn-secondary-hover btn-focus"
+                    style="font-family: var(--font-button); font-weight: 700; font-size: 14px; line-height: 16px; letter-spacing: 0.4px; border-radius: 4px; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 12px 16px; background-color: var(--color-button-secondary-bg); color: var(--color-button-secondary-text); border: 1px solid var(--color-button-secondary-border);">
+                {{ _("Copy All") }}
+            </button>
+        </div>
+    </div>
+</div>

--- a/backend/tests/component/test_backoffice_registration_images.py
+++ b/backend/tests/component/test_backoffice_registration_images.py
@@ -3,7 +3,6 @@
 
 import uuid
 from io import BytesIO
-from pathlib import Path
 
 import pytest
 from PIL import Image
@@ -183,7 +182,7 @@ class TestUploadRoute:
     carrying the new image so the page can update client-side and close the modal;
     a plain form post redirects back with a flash (full page reload)."""
 
-    def test_htmx_upload_returns_trigger_and_stores_image(
+    def test_htmx_upload_returns_asset_list_fragment_and_stores_image(
         self, logged_in_admin, fake_store, existing_assembly, registration_page
     ):
         response = logged_in_admin.post(
@@ -194,15 +193,18 @@ class TestUploadRoute:
         )
 
         assert response.status_code == 200
-        trigger = response.headers.get("HX-Trigger", "")
-        assert "registration-image-uploaded" in trigger
+        body = response.data.decode()
+        # An out-of-band asset-list fragment refreshes the panel (and empties the
+        # modal container, closing the modal); a toast trigger announces success.
+        assert 'id="image-asset-list"' in body
+        assert "hx-swap-oob" in body
+        assert "Hello world" in body
+        assert "show-toast" in response.headers.get("HX-Trigger", "")
 
         stored = _stored_images(fake_store, registration_page)
         assert len(stored) == 1
         assert stored[0].alt == "Hello world"
         assert stored[0].original_filename == "logo.png"
-        # The new image's id rides along in the trigger payload so Alpine can append it
-        assert str(stored[0].id) in trigger
 
     def test_htmx_upload_rejects_missing_alt_rerenders_modal(
         self, logged_in_admin, fake_store, existing_assembly, registration_page
@@ -260,130 +262,146 @@ class TestUploadRoute:
         assert _stored_images(fake_store, registration_page) == []
 
 
+class TestDetailsModalRoute:
+    """The per-image details/edit modal is loaded from the server via HTMX, opened
+    from each Assets row. Like the upload modal, a plain navigation gets the full
+    page with the modal already open so it works without JS."""
+
+    def _url(self, assembly_id, image_id) -> str:
+        return f"/backoffice/assembly/{assembly_id}/registration/images/{image_id}/details-modal"
+
+    def test_htmx_request_returns_details_fragment(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        image = _seed_image(fake_store, registration_page, alt="A logo")
+
+        response = logged_in_admin.get(self._url(existing_assembly.id, image.id), headers={"HX-Request": "true"})
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert "<html" not in body.lower()
+        # The alt-edit form patches this image and the current alt is pre-filled
+        item_url = f"/backoffice/assembly/{existing_assembly.id}/registration/images/{image.id}"
+        assert f'hx-patch="{item_url}"' in body
+        assert 'name="alt"' in body
+        assert "A logo" in body
+        # Delete control targets the same image
+        assert f'hx-delete="{item_url}"' in body
+
+    def test_plain_request_returns_full_page_with_modal_open(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        image = _seed_image(fake_store, registration_page, alt="A logo")
+
+        response = logged_in_admin.get(self._url(existing_assembly.id, image.id))
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert "<html" in body.lower()
+        item_url = f"/backoffice/assembly/{existing_assembly.id}/registration/images/{image.id}"
+        assert f'hx-patch="{item_url}"' in body
+
+    def test_requires_login(self, client, existing_assembly):
+        response = client.get(self._url(existing_assembly.id, uuid.uuid4()))
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+    def test_unknown_image_redirects_to_registration(self, logged_in_admin, existing_assembly, registration_page):
+        response = logged_in_admin.get(self._url(existing_assembly.id, uuid.uuid4()), headers={"HX-Request": "true"})
+        assert response.status_code == 302
+        assert f"/backoffice/assembly/{existing_assembly.id}/registration" in response.location
+
+
 class TestPatchRoute:
-    def test_patch_updates_alt_and_returns_image(
+    """Alt edits post (PATCH) from the details modal and return the refreshed
+    asset-list fragment (out-of-band), which also closes the modal."""
+
+    def test_patch_updates_alt_and_returns_asset_list_fragment(
         self, logged_in_admin, fake_store, existing_assembly, registration_page
     ):
         image = _seed_image(fake_store, registration_page, alt="Original")
 
         response = logged_in_admin.patch(
             f"/backoffice/assembly/{existing_assembly.id}/registration/images/{image.id}",
-            json={"alt": "Renamed"},
+            data={"alt": "Renamed"},
+            headers={"HX-Request": "true"},
         )
 
         assert response.status_code == 200
-        body = response.get_json()
-        assert body["image"]["alt"] == "Renamed"
-        assert body["image"]["id"] == str(image.id)
+        body = response.data.decode()
+        assert 'id="image-asset-list"' in body
+        assert "hx-swap-oob" in body
+        assert "Renamed" in body
 
         with FakeUnitOfWork(store=fake_store) as uow:
             assert uow.registration_images.get(image.id).alt == "Renamed"
 
-    def test_patch_rejects_missing_alt(self, logged_in_admin, fake_store, existing_assembly, registration_page):
+    def test_patch_rejects_missing_alt_rerenders_modal(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
         image = _seed_image(fake_store, registration_page, alt="Original")
 
         response = logged_in_admin.patch(
             f"/backoffice/assembly/{existing_assembly.id}/registration/images/{image.id}",
-            json={"alt": "  "},
+            data={"alt": "  "},
+            headers={"HX-Request": "true"},
         )
-        assert response.status_code == 400
+        # 422 so the modal re-renders with the error inline
+        assert response.status_code == 422
+        body = response.data.decode()
+        assert 'name="alt"' in body
+        assert "alt" in body.lower()
 
         with FakeUnitOfWork(store=fake_store) as uow:
             assert uow.registration_images.get(image.id).alt == "Original"
 
 
 class TestDeleteRoute:
-    def test_delete_returns_204_and_removes_image(
+    """Delete (DELETE) returns the refreshed asset-list fragment with the image gone."""
+
+    def test_delete_returns_asset_list_fragment_and_removes_image(
         self, logged_in_admin, fake_store, existing_assembly, registration_page
     ):
-        image = _seed_image(fake_store, registration_page)
+        image = _seed_image(fake_store, registration_page, alt="Doomed")
 
         response = logged_in_admin.delete(
             f"/backoffice/assembly/{existing_assembly.id}/registration/images/{image.id}",
+            headers={"HX-Request": "true"},
         )
 
-        assert response.status_code == 204
-        assert response.data == b""
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert 'id="image-asset-list"' in body
+        assert "hx-swap-oob" in body
         assert _stored_images(fake_store, registration_page) == []
 
 
-class TestImageDetailsModalTemplate:
-    """Structural assertions on the Image Details modal in assembly_registration.html.
-
-    The modal HTML lives inline in the registration template, gated by
-    ``<template x-if="imageDetailsModalOpen && editingImage">`` so Alpine controls
-    visibility client-side. Rendering the page through the route requires a real
-    authenticated user (the base layout reads ``current_user.global_role`` in a
-    context processor), which is heavyweight for verifying static modal markup.
-
-    We instead scan the template file and confirm the enhanced modal carries the
-    expected structural markers — thumbnail binding, read-only inputs with copy
-    handlers, danger-styled Delete button, and the renamed "Save alt" button.
-    """
+class TestImageDetailsModalRendering:
+    """Structural assertions on the server-rendered details modal, driven through
+    the route (the modal is now real HTML, so we assert on the actual response)."""
 
     @pytest.fixture
-    def modal_block(self) -> str:
-        """Return only the Image Details modal subsection of the template."""
-        path = Path(__file__).resolve().parents[2] / "templates/backoffice/assembly_registration.html"
-        text = path.read_text(encoding="utf-8")
-        start_marker = "{# Image Details / Edit Alt Modal #}"
-        end_marker = "{# Toast notification #}"
-        start = text.find(start_marker)
-        end = text.find(end_marker, start)
-        assert start != -1 and end != -1, "Image Details modal section not found in template"
-        return text[start:end]
+    def rendered_modal(self, logged_in_admin, fake_store, existing_assembly, registration_page) -> str:
+        image = _seed_image(fake_store, registration_page, alt="A logo")
+        response = logged_in_admin.get(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/images/{image.id}/details-modal",
+            headers={"HX-Request": "true"},
+        )
+        assert response.status_code == 200
+        return response.data.decode()
 
-    @pytest.fixture
-    def alpine_data_block(self) -> str:
-        """Return the Alpine data block (where the JS handlers live)."""
-        path = Path(__file__).resolve().parents[2] / "templates/backoffice/assembly_registration.html"
-        return path.read_text(encoding="utf-8")
+    def test_thumbnail_and_metadata_present(self, rendered_modal):
+        # Thumbnail uses the public URL; metadata block shows dimensions and file size
+        assert "/assets/" in rendered_modal  # public image url
+        assert "Dimensions" in rendered_modal
+        assert "File size" in rendered_modal
 
-    def test_thumbnail_binds_to_public_url_with_no_preview_fallback(self, modal_block):
-        assert ':src="editingImage.public_url"' in modal_block
-        assert ':alt="editingImage.alt' in modal_block
-        # Fallback hint when the page has no slug yet (public_url is blank)
-        assert "No preview" in modal_block
+    def test_filename_and_snippet_copy_use_clipboard_data_attrs(self, rendered_modal):
+        # Copy buttons rely on the delegated clipboard helper in utilities.js
+        assert "data-copy-text" in rendered_modal
+        assert "image-details-filename" in rendered_modal
+        assert "image-details-snippet" in rendered_modal
 
-    def test_read_only_filename_input_has_copy_handler(self, modal_block):
-        assert 'id="image-details-filename"' in modal_block
-        assert "readonly" in modal_block
-        assert ':value="editingImage.file_name"' in modal_block
-        # Click-to-select the value
-        assert "$event.target.select()" in modal_block
-        # Copy uses the new generic clipboard helper
-        assert "copyToClipboard(editingImage.file_name" in modal_block
-
-    def test_original_filename_shown_in_metadata_block_only_when_present(self, modal_block):
-        """Original filename sits inside the top metadata block alongside Dimensions
-        and File size, gated by an x-if so the row collapses out of the grid for
-        older uploads that have no original_filename stored. It's display-only —
-        no input, no copy button."""
-        assert 'x-text="editingImage.original_filename"' in modal_block
-        assert 'x-if="editingImage.original_filename"' in modal_block
-        # No standalone copy input/button for the original filename
-        assert 'id="image-details-original-filename"' not in modal_block
-        assert "copyToClipboard(editingImage.original_filename" not in modal_block
-
-    def test_read_only_snippet_input_has_copy_handler(self, modal_block):
-        assert 'id="image-details-snippet"' in modal_block
-        assert ':value="editingImage.img_snippet"' in modal_block
-        # Snippet copy reuses the existing helper (which guards on missing public URL)
-        assert "copyImageSnippet(editingImage)" in modal_block
-
-    def test_footer_has_delete_on_left_and_renamed_save_button(self, modal_block):
-        # Danger-styled Delete handler exists and is wired through a non-confirming method
-        assert 'variant="danger"' in modal_block
-        assert "deleteEditingImage()" in modal_block
-        assert "Delete image" in modal_block
-        # The primary save button is renamed to clarify what's persisted
-        assert "Save alt" in modal_block
-        # Old generic "Save" label is no longer the button text
-        assert 'button(_("Save"),' not in modal_block
-
-    def test_alpine_data_block_exposes_copy_helper_and_delete_method(self, alpine_data_block):
-        # Generic clipboard helper used by the filename copy button
-        assert "copyToClipboard(text, successMessage)" in alpine_data_block
-        # Modal-scoped delete that closes the modal on success and skips the panel's confirm()
-        assert "deleteEditingImage()" in alpine_data_block
-        assert "this.imageDetailsModalOpen = false" in alpine_data_block
+    def test_footer_has_delete_and_save_alt(self, rendered_modal):
+        assert "Delete image" in rendered_modal
+        assert "Save alt" in rendered_modal

--- a/backend/tests/component/test_backoffice_registration_images.py
+++ b/backend/tests/component/test_backoffice_registration_images.py
@@ -129,47 +129,135 @@ class TestImageRoutesRequireLogin:
         assert "/auth/login" in response.location
 
 
+class TestUploadModalRoute:
+    """The Assets panel loads the upload modal from the server via HTMX.
+
+    HX-Request gets just the modal fragment (swapped into a container); a plain
+    browser navigation gets the whole registration page with the modal already
+    open, so the feature degrades to a full page reload when JS is unavailable.
+    """
+
+    def test_htmx_request_returns_modal_fragment(self, logged_in_admin, existing_assembly, registration_page):
+        response = logged_in_admin.get(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/images/upload-modal",
+            headers={"HX-Request": "true"},
+        )
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        # A fragment, not the whole document
+        assert "<html" not in body.lower()
+        # The modal form posts the upload back to the JSON-free upload endpoint
+        upload_url = f"/backoffice/assembly/{existing_assembly.id}/registration/images"
+        assert f'action="{upload_url}"' in body
+        assert f'hx-post="{upload_url}"' in body
+        assert 'name="image"' in body
+        assert 'name="alt"' in body
+        assert "csrf_token" in body
+
+    def test_plain_request_returns_full_page_with_modal_open(
+        self, logged_in_admin, existing_assembly, registration_page
+    ):
+        response = logged_in_admin.get(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/images/upload-modal",
+        )
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        # Full document (fallback) ...
+        assert "<html" in body.lower()
+        # ... with the upload modal rendered open inside it
+        upload_url = f"/backoffice/assembly/{existing_assembly.id}/registration/images"
+        assert f'action="{upload_url}"' in body
+
+    def test_requires_login(self, client, existing_assembly):
+        response = client.get(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/images/upload-modal",
+        )
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+
 class TestUploadRoute:
-    def test_upload_with_file_and_alt_returns_201_and_stores_image(
+    """Upload is HTMX-aware: an HX-Request gets an empty body plus an HX-Trigger
+    carrying the new image so the page can update client-side and close the modal;
+    a plain form post redirects back with a flash (full page reload)."""
+
+    def test_htmx_upload_returns_trigger_and_stores_image(
         self, logged_in_admin, fake_store, existing_assembly, registration_page
     ):
         response = logged_in_admin.post(
             f"/backoffice/assembly/{existing_assembly.id}/registration/images",
-            data={
-                "image": (BytesIO(_png()), "logo.png"),
-                "alt": "Hello world",
-            },
+            data={"image": (BytesIO(_png()), "logo.png"), "alt": "Hello world"},
             content_type="multipart/form-data",
+            headers={"HX-Request": "true"},
         )
 
-        assert response.status_code == 201
-        body = response.get_json()
-        assert body["image"]["alt"] == "Hello world"
-        assert body["image"]["original_filename"] == "logo.png"
-        assert registration_page.url_slug in body["image"]["public_url"]
+        assert response.status_code == 200
+        trigger = response.headers.get("HX-Trigger", "")
+        assert "registration-image-uploaded" in trigger
 
         stored = _stored_images(fake_store, registration_page)
         assert len(stored) == 1
         assert stored[0].alt == "Hello world"
         assert stored[0].original_filename == "logo.png"
-        assert body["image"]["id"] == str(stored[0].id)
+        # The new image's id rides along in the trigger payload so Alpine can append it
+        assert str(stored[0].id) in trigger
 
-    def test_upload_rejects_missing_alt(self, logged_in_admin, existing_assembly, registration_page):
+    def test_htmx_upload_rejects_missing_alt_rerenders_modal(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/images",
+            data={"image": (BytesIO(_png()), "logo.png"), "alt": "   "},
+            content_type="multipart/form-data",
+            headers={"HX-Request": "true"},
+        )
+        # 422 so the htmx-422-swap handler re-renders the modal with the error
+        assert response.status_code == 422
+        body = response.data.decode()
+        assert "alt" in body.lower()
+        assert 'name="alt"' in body
+        assert _stored_images(fake_store, registration_page) == []
+
+    def test_htmx_upload_rejects_missing_file_rerenders_modal(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/images",
+            data={"alt": "Logo"},
+            content_type="multipart/form-data",
+            headers={"HX-Request": "true"},
+        )
+        assert response.status_code == 422
+        assert _stored_images(fake_store, registration_page) == []
+
+    def test_plain_form_upload_redirects_and_stores_image(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/images",
+            data={"image": (BytesIO(_png()), "logo.png"), "alt": "Hello world"},
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 302
+        assert f"/backoffice/assembly/{existing_assembly.id}/registration" in response.location
+
+        stored = _stored_images(fake_store, registration_page)
+        assert len(stored) == 1
+        assert stored[0].alt == "Hello world"
+
+    def test_plain_form_upload_missing_alt_redirects_without_storing(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
         response = logged_in_admin.post(
             f"/backoffice/assembly/{existing_assembly.id}/registration/images",
             data={"image": (BytesIO(_png()), "logo.png"), "alt": "   "},
             content_type="multipart/form-data",
         )
-        assert response.status_code == 400
-        assert "alt" in response.get_json()["error"].lower()
-
-    def test_upload_rejects_missing_file(self, logged_in_admin, existing_assembly, registration_page):
-        response = logged_in_admin.post(
-            f"/backoffice/assembly/{existing_assembly.id}/registration/images",
-            data={"alt": "Logo"},
-            content_type="multipart/form-data",
-        )
-        assert response.status_code == 400
+        assert response.status_code == 302
+        assert _stored_images(fake_store, registration_page) == []
 
 
 class TestPatchRoute:

--- a/backend/tests/component/test_backoffice_registration_modals.py
+++ b/backend/tests/component/test_backoffice_registration_modals.py
@@ -1,0 +1,62 @@
+# ABOUTME: Component tests for the HTMX-loaded preview/share and skeleton modals
+# ABOUTME: Drives the real GET modal routes over a FakeUnitOfWork via the test client
+
+
+import pytest
+
+from opendlp.service_layer.registration_page_service import create_registration_page_with_slugs
+from tests.fakes import FakeUnitOfWork
+
+
+@pytest.fixture
+def registration_page(fake_store, admin_user, existing_assembly):
+    with FakeUnitOfWork(store=fake_store) as uow:
+        page = create_registration_page_with_slugs(uow, admin_user.id, existing_assembly.id)
+    return page
+
+
+class TestPreviewModalRoute:
+    """The Preview / Share modal is loaded from the server via HTMX.
+
+    HX-Request gets the modal fragment; a plain navigation gets the whole page with
+    the modal already open, so it degrades to a full page reload without JS.
+    """
+
+    def _url(self, assembly_id) -> str:
+        return f"/backoffice/assembly/{assembly_id}/registration/preview-modal"
+
+    def test_htmx_request_returns_modal_fragment(self, logged_in_admin, existing_assembly, registration_page):
+        response = logged_in_admin.get(self._url(existing_assembly.id), headers={"HX-Request": "true"})
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert "<html" not in body.lower()
+        # TEST status (default for a new page) → the preview/test title + notice
+        assert "Preview and Test Responses" in body
+        assert "test mode" in body.lower()
+        # The registration URL (built from the page slug) is shown
+        assert registration_page.url_slug in body
+        # Short URL + QR are configured by create_registration_page_with_slugs
+        assert "QR Code" in body
+
+    def test_plain_request_returns_full_page_with_modal_open(
+        self, logged_in_admin, existing_assembly, registration_page
+    ):
+        response = logged_in_admin.get(self._url(existing_assembly.id))
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert "<html" in body.lower()
+        assert "Preview and Test Responses" in body
+        assert registration_page.url_slug in body
+
+    def test_requires_login(self, client, existing_assembly):
+        response = client.get(self._url(existing_assembly.id))
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+    def test_no_registration_page_redirects(self, logged_in_admin, existing_assembly):
+        # No registration page created → nothing to preview
+        response = logged_in_admin.get(self._url(existing_assembly.id), headers={"HX-Request": "true"})
+        assert response.status_code == 302
+        assert f"/backoffice/assembly/{existing_assembly.id}/registration" in response.location

--- a/backend/tests/component/test_backoffice_registration_modals.py
+++ b/backend/tests/component/test_backoffice_registration_modals.py
@@ -60,3 +60,39 @@ class TestPreviewModalRoute:
         response = logged_in_admin.get(self._url(existing_assembly.id), headers={"HX-Request": "true"})
         assert response.status_code == 302
         assert f"/backoffice/assembly/{existing_assembly.id}/registration" in response.location
+
+
+class TestSkeletonModalRoute:
+    """The Form Skeleton modal is loaded from the server via HTMX, with the
+    generated starter HTML server-rendered into the textarea."""
+
+    def _url(self, assembly_id) -> str:
+        return f"/backoffice/assembly/{assembly_id}/registration/skeleton-modal"
+
+    def test_htmx_request_returns_modal_fragment(self, logged_in_admin, existing_assembly, registration_page):
+        response = logged_in_admin.get(self._url(existing_assembly.id), headers={"HX-Request": "true"})
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert "<html" not in body.lower()
+        assert "Form Skeleton" in body
+        assert "<textarea" in body
+        assert 'id="skeleton-html-textarea"' in body
+        # Copy uses the delegated clipboard helper, reading the textarea content
+        assert 'data-copy-target="skeleton-html-textarea"' in body
+
+    def test_plain_request_returns_full_page_with_modal_open(
+        self, logged_in_admin, existing_assembly, registration_page
+    ):
+        response = logged_in_admin.get(self._url(existing_assembly.id))
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert "<html" in body.lower()
+        assert "Form Skeleton" in body
+        assert 'id="skeleton-html-textarea"' in body
+
+    def test_requires_login(self, client, existing_assembly):
+        response = client.get(self._url(existing_assembly.id))
+        assert response.status_code == 302
+        assert "/auth/login" in response.location

--- a/backend/tests/e2e/test_backoffice_registration.py
+++ b/backend/tests/e2e/test_backoffice_registration.py
@@ -30,11 +30,14 @@ def test_create_assembly_registration_page_success(
         assert page.url_slug
 
 
-def test_get_registration_skeleton_success(logged_in_admin: FlaskClient, existing_assembly, admin_user: User):
-    """The skeleton endpoint returns generated starter HTML as JSON."""
-    response = logged_in_admin.get(_registration_url(existing_assembly.id, "/skeleton"))
+def test_get_registration_skeleton_modal_success(logged_in_admin: FlaskClient, existing_assembly, admin_user: User):
+    """The skeleton modal endpoint returns the generated starter HTML in a modal fragment."""
+    response = logged_in_admin.get(
+        _registration_url(existing_assembly.id, "/skeleton-modal"),
+        headers={"HX-Request": "true"},
+    )
 
     assert response.status_code == 200
-    payload = response.get_json()
-    assert "html" in payload
-    assert isinstance(payload["html"], str)
+    body = response.data.decode()
+    assert "Form Skeleton" in body
+    assert "<textarea" in body

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -1055,6 +1055,7 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:442
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:200
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:521
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:543
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:91
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:126
@@ -1101,6 +1102,7 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:466
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:479
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:524
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:546
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:76
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:408
@@ -1298,6 +1300,7 @@ msgstr "Vissza a regisztrációhoz"
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:280
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:476
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:551
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
@@ -1347,7 +1350,7 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:461
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:528
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:614
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:656
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
@@ -1357,47 +1360,47 @@ msgstr "Az oldal nem elérhető"
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:560
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:602
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:566
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:608
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:569
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:616
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:611
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:658
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:591
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:633
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:596
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:598
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:638
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:640
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:626
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:668
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:629
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:671
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:649
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:691
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:652
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:694
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
@@ -3214,8 +3217,8 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_data.html:508
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
-#: templates/backoffice/assembly_registration.html:212
-#: templates/backoffice/assembly_registration.html:231
+#: templates/backoffice/assembly_registration.html:217
+#: templates/backoffice/assembly_registration.html:237
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:37
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -3258,8 +3261,8 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:411
 #: templates/backoffice/edit_assembly.html:100
+#: templates/backoffice/registration/preview_modal.html:51
 #, fuzzy
 msgid "Registration URL"
 msgstr "Vissza a regisztrációhoz"
@@ -3590,8 +3593,8 @@ msgstr "Módosítsa a számot."
 
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
 #: templates/backoffice/assembly_edit_respondent.html:21
-#: templates/backoffice/assembly_registration.html:215
-#: templates/backoffice/assembly_registration.html:234
+#: templates/backoffice/assembly_registration.html:220
+#: templates/backoffice/assembly_registration.html:240
 #: templates/backoffice/assembly_respondents.html:126
 #: templates/backoffice/assembly_selection.html:81
 #: templates/backoffice/assembly_selection.html:299
@@ -4341,7 +4344,7 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
-#: templates/backoffice/assembly_registration.html:273
+#: templates/backoffice/assembly_registration.html:279
 #: templates/backoffice/registration/image_upload_modal.html:93
 msgid "Upload"
 msgstr ""
@@ -4455,46 +4458,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:412
+#: templates/backoffice/registration/preview_modal.html:52
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:419
+#: templates/backoffice/registration/preview_modal.html:59
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:420
 #: templates/backoffice/edit_assembly.html:112
+#: templates/backoffice/registration/preview_modal.html:60
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:428
+#: templates/backoffice/registration/preview_modal.html:68
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:430
+#: templates/backoffice/registration/preview_modal.html:70
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:436
+#: templates/backoffice/registration/preview_modal.html:75
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:448
+#: templates/backoffice/registration/preview_modal.html:86
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:451
+#: templates/backoffice/registration/preview_modal.html:89
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4702,12 +4705,12 @@ msgid ""
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:206
-#: templates/backoffice/assembly_registration.html:364
+#: templates/backoffice/assembly_registration.html:210
+#: templates/backoffice/registration/preview_modal.html:8
 msgid "Preview and Test Responses"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:213
+#: templates/backoffice/assembly_registration.html:218
 #: templates/backoffice/components/edit_number_to_select_modal.html:38
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4720,40 +4723,38 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:225
-#: templates/backoffice/assembly_registration.html:239
-#: templates/backoffice/assembly_registration.html:364
+#: templates/backoffice/assembly_registration.html:230
+#: templates/backoffice/assembly_registration.html:245
+#: templates/backoffice/registration/preview_modal.html:8
 msgid "Share Form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:232
+#: templates/backoffice/assembly_registration.html:238
 #, fuzzy
 msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:243
-#: templates/backoffice/assembly_registration.html:244
+#: templates/backoffice/assembly_registration.html:249
+#: templates/backoffice/assembly_registration.html:250
 msgid "Registration is closed — the form URL redirects to the closed page"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:262
+#: templates/backoffice/assembly_registration.html:268
 #, fuzzy
 msgid "Assets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:288
+#: templates/backoffice/assembly_registration.html:294
 #, python-format
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:322
+#: templates/backoffice/assembly_registration.html:328
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:328
-#: templates/backoffice/assembly_registration.html:390
-#: templates/backoffice/assembly_registration.html:462
+#: templates/backoffice/assembly_registration.html:334
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:54
@@ -4764,37 +4765,34 @@ msgstr "Rétegzett kiválasztás"
 #: templates/backoffice/registration/image_details_modal.html:29
 #: templates/backoffice/registration/image_upload_modal.html:12
 #: templates/backoffice/registration/image_upload_modal.html:37
+#: templates/backoffice/registration/preview_modal.html:13
+#: templates/backoffice/registration/preview_modal.html:30
+#: templates/backoffice/registration/preview_modal.html:100
 #, fuzzy
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:337
+#: templates/backoffice/assembly_registration.html:343
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:355
+#: templates/backoffice/assembly_registration.html:361
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:403
-msgid ""
-"The form is in test mode. Submissions made via these URLs are recorded as"
-" test submissions and will not enter the selection pool."
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:533
+#: templates/backoffice/assembly_registration.html:432
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:552
+#: templates/backoffice/assembly_registration.html:443
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:555
+#: templates/backoffice/assembly_registration.html:446
 msgid "Failed to copy to clipboard"
 msgstr ""
 
@@ -7286,6 +7284,12 @@ msgstr ""
 
 #: templates/backoffice/registration/image_upload_modal.html:60
 msgid "Image file"
+msgstr ""
+
+#: templates/backoffice/registration/preview_modal.html:43
+msgid ""
+"The form is in test mode. Submissions made via these URLs are recorded as"
+" test submissions and will not enter the selection pool."
 msgstr ""
 
 #: templates/backoffice/respondent_field_schema/view.html:22

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-25 17:23+0100\n"
+"POT-Creation-Date: 2026-06-26 12:48+0000\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1053,7 +1053,7 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:160
 #: src/opendlp/entrypoints/blueprints/backoffice.py:395
 #: src/opendlp/entrypoints/blueprints/backoffice.py:442
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:162
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:190
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:91
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:126
@@ -1092,14 +1092,14 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:297
 #: src/opendlp/entrypoints/blueprints/backoffice.py:391
 #: src/opendlp/entrypoints/blueprints/backoffice.py:438
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:166
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:250
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:281
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:306
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:351
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:412
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:440
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:464
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:194
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:278
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:309
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:334
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:379
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:410
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:529
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:553
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:76
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:408
@@ -1255,135 +1255,140 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:172
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:200
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:183
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:211
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:184
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:212
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:187
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:215
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:190
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:218
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:193
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:221
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:196
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:224
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:197
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:225
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:242
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:408
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:270
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:407
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:246
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:278
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:410
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:438
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:462
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:274
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:306
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:409
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:527
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:551
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:261
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:289
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:273
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:301
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:286
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:314
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:291
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:319
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:304
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:347
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:332
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:375
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:309
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:337
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:355
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:383
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:382
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:465
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:388
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:471
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:392
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:428
-#: templates/backoffice/assembly_registration.html:901
-#: templates/backoffice/assembly_registration.html:1034
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:474
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:517
+#: templates/backoffice/assembly_registration.html:905
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:416
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:496
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:434
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:458
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:506
+#: templates/backoffice/assembly_registration.html:808
+#, fuzzy
+msgid "Image uploaded"
+msgstr "Új jelszó"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:523
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:547
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:436
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:460
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:525
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:549
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:443
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:532
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:467
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:556
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -3200,13 +3205,13 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_data.html:508
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
-#: templates/backoffice/assembly_registration.html:211
-#: templates/backoffice/assembly_registration.html:230
-#: templates/backoffice/assembly_registration.html:598
-#: templates/backoffice/assembly_registration.html:756
+#: templates/backoffice/assembly_registration.html:212
+#: templates/backoffice/assembly_registration.html:231
+#: templates/backoffice/assembly_registration.html:681
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:37
 #: templates/backoffice/components/respondent_status_form.html:87
+#: templates/backoffice/registration/image_upload_modal.html:92
 #: templates/backoffice/respondents/confirm_upload_diff.html:107
 #: templates/backoffice/targets/category_block.html:47
 #: templates/backoffice/targets/category_block.html:228
@@ -3244,7 +3249,7 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:456
+#: templates/backoffice/assembly_registration.html:462
 #: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Registration URL"
@@ -3576,8 +3581,8 @@ msgstr "Módosítsa a számot."
 
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
 #: templates/backoffice/assembly_edit_respondent.html:21
-#: templates/backoffice/assembly_registration.html:214
-#: templates/backoffice/assembly_registration.html:233
+#: templates/backoffice/assembly_registration.html:215
+#: templates/backoffice/assembly_registration.html:234
 #: templates/backoffice/assembly_respondents.html:126
 #: templates/backoffice/assembly_selection.html:81
 #: templates/backoffice/assembly_selection.html:299
@@ -4101,7 +4106,7 @@ msgstr ""
 "beállításokat? Ez a művelet nem vonható vissza."
 
 #: templates/backoffice/assembly_data.html:82
-#: templates/backoffice/assembly_registration.html:332
+#: templates/backoffice/assembly_registration.html:338
 #: templates/backoffice/targets/category_block.html:32
 #: templates/backoffice/targets/category_block.html:157
 #: templates/targets/components/category_block.html:21
@@ -4327,8 +4332,8 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
-#: templates/backoffice/assembly_registration.html:268
-#: templates/backoffice/assembly_registration.html:599
+#: templates/backoffice/assembly_registration.html:273
+#: templates/backoffice/registration/image_upload_modal.html:93
 msgid "Upload"
 msgstr ""
 
@@ -4441,46 +4446,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:457
+#: templates/backoffice/assembly_registration.html:463
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:464
+#: templates/backoffice/assembly_registration.html:470
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:465
+#: templates/backoffice/assembly_registration.html:471
 #: templates/backoffice/edit_assembly.html:112
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:473
+#: templates/backoffice/assembly_registration.html:479
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:475
+#: templates/backoffice/assembly_registration.html:481
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:481
+#: templates/backoffice/assembly_registration.html:487
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:493
+#: templates/backoffice/assembly_registration.html:499
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:496
+#: templates/backoffice/assembly_registration.html:502
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4605,95 +4610,95 @@ msgstr ""
 msgid "Registration"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:31
+#: templates/backoffice/assembly_registration.html:32
 #, fuzzy
 msgid "Registration Form Configuration"
 msgstr "Beállítások mentése"
 
-#: templates/backoffice/assembly_registration.html:53
+#: templates/backoffice/assembly_registration.html:54
 #, fuzzy
 msgid "Registration page not created"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:56
+#: templates/backoffice/assembly_registration.html:57
 msgid ""
 "Before you can configure the registration form, you need to create a "
 "registration page from the Details tab."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:59
+#: templates/backoffice/assembly_registration.html:60
 #, fuzzy
 msgid "Go to Details tab"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_registration.html:83
+#: templates/backoffice/assembly_registration.html:84
 #, fuzzy
 msgid "Registration Form HTML"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:93
-#: templates/backoffice/assembly_registration.html:117
-#: templates/backoffice/assembly_registration.html:141
+#: templates/backoffice/assembly_registration.html:94
+#: templates/backoffice/assembly_registration.html:118
+#: templates/backoffice/assembly_registration.html:142
 msgid "Published"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:99
+#: templates/backoffice/assembly_registration.html:100
 #, fuzzy
 msgid "Closed"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:106
-#: templates/backoffice/assembly_registration.html:132
+#: templates/backoffice/assembly_registration.html:107
+#: templates/backoffice/assembly_registration.html:133
 #, fuzzy
 msgid "Test"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:118
+#: templates/backoffice/assembly_registration.html:119
 msgid "Form goes live; submissions enter the selection pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:126
+#: templates/backoffice/assembly_registration.html:127
 msgid "Closed for Submissions"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:127
+#: templates/backoffice/assembly_registration.html:128
 msgid ""
 "Visitors are redirected to a registration-closed page; no new submissions"
 " are accepted."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:133
+#: templates/backoffice/assembly_registration.html:134
 msgid ""
 "Form stays public, but new submissions are flagged as test entries and "
 "skipped from the pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:142
+#: templates/backoffice/assembly_registration.html:143
 msgid "Form goes live again; new submissions enter the selection pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:149
+#: templates/backoffice/assembly_registration.html:150
 #, fuzzy
 msgid "Change status"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:164
+#: templates/backoffice/assembly_registration.html:165
 msgid "Show Form Skeleton"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:174
+#: templates/backoffice/assembly_registration.html:175
 msgid ""
 "Paste your HTML form code below. The only required placeholders are {{ "
 "form_action }} for the form's action attribute and {{ csrf_form_element "
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:205
-#: templates/backoffice/assembly_registration.html:409
+#: templates/backoffice/assembly_registration.html:206
+#: templates/backoffice/assembly_registration.html:415
 msgid "Preview and Test Responses"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:212
+#: templates/backoffice/assembly_registration.html:213
 #: templates/backoffice/components/edit_number_to_select_modal.html:38
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4706,243 +4711,213 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:224
-#: templates/backoffice/assembly_registration.html:238
-#: templates/backoffice/assembly_registration.html:409
+#: templates/backoffice/assembly_registration.html:225
+#: templates/backoffice/assembly_registration.html:239
+#: templates/backoffice/assembly_registration.html:415
 msgid "Share Form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:231
+#: templates/backoffice/assembly_registration.html:232
 #, fuzzy
 msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:242
 #: templates/backoffice/assembly_registration.html:243
+#: templates/backoffice/assembly_registration.html:244
 msgid "Registration is closed — the form URL redirects to the closed page"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:261
+#: templates/backoffice/assembly_registration.html:262
 #, fuzzy
 msgid "Assets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:282
+#: templates/backoffice/assembly_registration.html:288
 #, python-format
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:289
+#: templates/backoffice/assembly_registration.html:295
 #, fuzzy
 msgid "No images uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:311
+#: templates/backoffice/assembly_registration.html:317
 #, fuzzy
 msgid "Details for"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/assembly_registration.html:321
+#: templates/backoffice/assembly_registration.html:327
 msgid "Copy <img> snippet for"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:367
+#: templates/backoffice/assembly_registration.html:373
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:373
-#: templates/backoffice/assembly_registration.html:435
-#: templates/backoffice/assembly_registration.html:507
-#: templates/backoffice/assembly_registration.html:542
-#: templates/backoffice/assembly_registration.html:633
+#: templates/backoffice/assembly_registration.html:379
+#: templates/backoffice/assembly_registration.html:441
+#: templates/backoffice/assembly_registration.html:513
+#: templates/backoffice/assembly_registration.html:558
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:54
 #: templates/backoffice/components/modal.html:133
 #: templates/backoffice/components/replacement_modal.html:170
 #: templates/backoffice/components/selection_progress_modal.html:89
+#: templates/backoffice/registration/image_upload_modal.html:12
+#: templates/backoffice/registration/image_upload_modal.html:37
 #, fuzzy
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:382
+#: templates/backoffice/assembly_registration.html:388
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:400
+#: templates/backoffice/assembly_registration.html:406
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:448
+#: templates/backoffice/assembly_registration.html:454
 msgid ""
 "The form is in test mode. Submissions made via these URLs are recorded as"
 " test submissions and will not enter the selection pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:535
-#, fuzzy
-msgid "Upload image"
-msgstr "Kész"
-
 #: templates/backoffice/assembly_registration.html:551
-#, python-format
-msgid ""
-"Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
-"Files are downscaled and re-encoded to PNG on upload."
+#, fuzzy
+msgid "Image details"
+msgstr "Meghívó kód"
+
+#: templates/backoffice/assembly_registration.html:577
+msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:557
-msgid "Image file"
+#: templates/backoffice/assembly_registration.html:584
+msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:573
-#: templates/backoffice/assembly_registration.html:729
+#: templates/backoffice/assembly_registration.html:589
+#, fuzzy
+msgid "Dimensions"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/assembly_registration.html:594
+msgid "px"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:597
+msgid "File size"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:605
+#, fuzzy
+msgid "File name"
+msgstr "Keresztnév"
+
+#: templates/backoffice/assembly_registration.html:616
+msgid "File name copied to clipboard"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:619
+#, fuzzy
+msgid "Copy file name"
+msgstr "Keresztnév"
+
+#: templates/backoffice/assembly_registration.html:630
+#, fuzzy
+msgid "Image snippet"
+msgstr "Jelentések a folyamatról"
+
+#: templates/backoffice/assembly_registration.html:644
+msgid "Copy image snippet"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:654
+#: templates/backoffice/registration/image_upload_modal.html:72
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:585
-#: templates/backoffice/assembly_registration.html:741
+#: templates/backoffice/assembly_registration.html:666
+#: templates/backoffice/registration/image_upload_modal.html:84
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:626
-#, fuzzy
-msgid "Image details"
-msgstr "Meghívó kód"
-
-#: templates/backoffice/assembly_registration.html:652
-msgid "No preview"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:659
-msgid "Original filename"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:664
-#, fuzzy
-msgid "Dimensions"
-msgstr "Kieső emberek pótlása új kiválasztással"
-
-#: templates/backoffice/assembly_registration.html:669
-msgid "px"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:672
-msgid "File size"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:680
-#, fuzzy
-msgid "File name"
-msgstr "Keresztnév"
-
-#: templates/backoffice/assembly_registration.html:691
-msgid "File name copied to clipboard"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:694
-#, fuzzy
-msgid "Copy file name"
-msgstr "Keresztnév"
-
-#: templates/backoffice/assembly_registration.html:705
-#, fuzzy
-msgid "Image snippet"
-msgstr "Jelentések a folyamatról"
-
-#: templates/backoffice/assembly_registration.html:719
-msgid "Copy image snippet"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:754
+#: templates/backoffice/assembly_registration.html:679
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:757
+#: templates/backoffice/assembly_registration.html:682
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:842
+#: templates/backoffice/assembly_registration.html:760
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:861
-#: templates/backoffice/assembly_registration.html:980
+#: templates/backoffice/assembly_registration.html:779
+#: templates/backoffice/assembly_registration.html:851
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:864
-#: templates/backoffice/assembly_registration.html:974
-#: templates/backoffice/assembly_registration.html:981
+#: templates/backoffice/assembly_registration.html:782
+#: templates/backoffice/assembly_registration.html:845
+#: templates/backoffice/assembly_registration.html:852
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:919
-#, fuzzy
-msgid "Upload failed"
-msgstr "Kész"
-
-#: templates/backoffice/assembly_registration.html:930
-#, fuzzy
-msgid "Image uploaded"
-msgstr "Új jelszó"
-
-#: templates/backoffice/assembly_registration.html:933
-#, fuzzy
-msgid "Network error while uploading the image"
-msgstr "Hiba történt a gyűlés frissítése közben"
-
-#: templates/backoffice/assembly_registration.html:942
+#: templates/backoffice/assembly_registration.html:813
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:953
-#: templates/backoffice/assembly_registration.html:1013
+#: templates/backoffice/assembly_registration.html:824
+#: templates/backoffice/assembly_registration.html:884
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:957
-#: templates/backoffice/assembly_registration.html:1020
+#: templates/backoffice/assembly_registration.html:828
+#: templates/backoffice/assembly_registration.html:891
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:960
-#: templates/backoffice/assembly_registration.html:1023
+#: templates/backoffice/assembly_registration.html:831
+#: templates/backoffice/assembly_registration.html:894
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:969
+#: templates/backoffice/assembly_registration.html:840
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:973
+#: templates/backoffice/assembly_registration.html:844
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1050
+#: templates/backoffice/assembly_registration.html:921
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1058
+#: templates/backoffice/assembly_registration.html:929
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1061
+#: templates/backoffice/assembly_registration.html:932
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -7323,6 +7298,22 @@ msgstr ""
 #, fuzzy
 msgid "Source File"
 msgstr "Sikerült"
+
+#: templates/backoffice/registration/image_upload_modal.html:32
+#, fuzzy
+msgid "Upload image"
+msgstr "Kész"
+
+#: templates/backoffice/registration/image_upload_modal.html:46
+#, python-format
+msgid ""
+"Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
+"Files are downscaled and re-encoded to PNG on upload."
+msgstr ""
+
+#: templates/backoffice/registration/image_upload_modal.html:60
+msgid "Image file"
+msgstr ""
 
 #: templates/backoffice/respondent_field_schema/view.html:22
 msgid ""
@@ -12998,3 +12989,10 @@ msgstr ""
 
 #~ msgid "URL copied to clipboard"
 #~ msgstr ""
+
+#~ msgid "Upload failed"
+#~ msgstr "Kész"
+
+#~ msgid "Network error while uploading the image"
+#~ msgstr "Hiba történt a gyűlés frissítése közben"
+

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-26 12:48+0000\n"
+"POT-Creation-Date: 2026-06-26 12:49+0000\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1053,7 +1053,8 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:160
 #: src/opendlp/entrypoints/blueprints/backoffice.py:395
 #: src/opendlp/entrypoints/blueprints/backoffice.py:442
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:190
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:200
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:521
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:91
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:126
@@ -1092,14 +1093,14 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:297
 #: src/opendlp/entrypoints/blueprints/backoffice.py:391
 #: src/opendlp/entrypoints/blueprints/backoffice.py:438
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:194
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:278
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:309
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:334
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:379
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:410
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:529
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:553
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:204
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:288
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:319
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:344
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:389
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:466
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:479
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:524
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:76
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:408
@@ -1255,143 +1256,151 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:200
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:210
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:211
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:221
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:212
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:222
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:215
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:225
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:218
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:228
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:221
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:231
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:224
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:234
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:225
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:235
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:270
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:407
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:280
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:476
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:274
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:306
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:409
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:527
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:551
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:284
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:316
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:465
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:478
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:289
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:299
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:301
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:311
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:314
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:324
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:319
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:329
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:332
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:375
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:342
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:385
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:337
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:347
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:383
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:393
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:465
-#, fuzzy
-msgid "No file was selected"
-msgstr "Táblázat lapfülei"
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:471
-msgid "Failed to read the uploaded file"
-msgstr ""
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:474
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:517
-#: templates/backoffice/assembly_registration.html:905
-msgid "Alt text is required for accessibility"
-msgstr ""
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:496
-#, fuzzy
-msgid "An error occurred while uploading the image"
-msgstr "Hiba történt a gyűlés frissítése közben"
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:506
-#: templates/backoffice/assembly_registration.html:808
-#, fuzzy
-msgid "Image uploaded"
-msgstr "Új jelszó"
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:523
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:547
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:461
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:528
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:614
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:525
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:549
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:463
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:532
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:560
+#, fuzzy
+msgid "No file was selected"
+msgstr "Táblázat lapfülei"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:566
+msgid "Failed to read the uploaded file"
+msgstr ""
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:569
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:616
+msgid "Alt text is required for accessibility"
+msgstr ""
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:591
+#, fuzzy
+msgid "An error occurred while uploading the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:596
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:598
+#, fuzzy
+msgid "Image uploaded"
+msgstr "Új jelszó"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:626
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:556
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:629
+#, fuzzy
+msgid "Image updated"
+msgstr "Utoljára módosítva"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:649
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:652
+#, fuzzy
+msgid "Image deleted"
+msgstr "Kiválasztás"
 
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:54
 msgid "Please review and save the selection settings before checking data."
@@ -3207,10 +3216,10 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_form.html:96
 #: templates/backoffice/assembly_registration.html:212
 #: templates/backoffice/assembly_registration.html:231
-#: templates/backoffice/assembly_registration.html:681
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:37
 #: templates/backoffice/components/respondent_status_form.html:87
+#: templates/backoffice/registration/image_details_modal.html:154
 #: templates/backoffice/registration/image_upload_modal.html:92
 #: templates/backoffice/respondents/confirm_upload_diff.html:107
 #: templates/backoffice/targets/category_block.html:47
@@ -3249,7 +3258,7 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:462
+#: templates/backoffice/assembly_registration.html:411
 #: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Registration URL"
@@ -4106,7 +4115,7 @@ msgstr ""
 "beállításokat? Ez a művelet nem vonható vissza."
 
 #: templates/backoffice/assembly_data.html:82
-#: templates/backoffice/assembly_registration.html:338
+#: templates/backoffice/registration/image_asset_list.html:52
 #: templates/backoffice/targets/category_block.html:32
 #: templates/backoffice/targets/category_block.html:157
 #: templates/targets/components/category_block.html:21
@@ -4446,46 +4455,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:463
+#: templates/backoffice/assembly_registration.html:412
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:470
+#: templates/backoffice/assembly_registration.html:419
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:471
+#: templates/backoffice/assembly_registration.html:420
 #: templates/backoffice/edit_assembly.html:112
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:479
+#: templates/backoffice/assembly_registration.html:428
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:481
+#: templates/backoffice/assembly_registration.html:430
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:487
+#: templates/backoffice/assembly_registration.html:436
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:499
+#: templates/backoffice/assembly_registration.html:448
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:502
+#: templates/backoffice/assembly_registration.html:451
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4694,7 +4703,7 @@ msgid ""
 msgstr ""
 
 #: templates/backoffice/assembly_registration.html:206
-#: templates/backoffice/assembly_registration.html:415
+#: templates/backoffice/assembly_registration.html:364
 msgid "Preview and Test Responses"
 msgstr ""
 
@@ -4713,7 +4722,7 @@ msgstr ""
 
 #: templates/backoffice/assembly_registration.html:225
 #: templates/backoffice/assembly_registration.html:239
-#: templates/backoffice/assembly_registration.html:415
+#: templates/backoffice/assembly_registration.html:364
 msgid "Share Form"
 msgstr ""
 
@@ -4737,190 +4746,57 @@ msgstr "Kezdés dátuma"
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:295
-#, fuzzy
-msgid "No images uploaded yet."
-msgstr "Feladat állapota"
-
-#: templates/backoffice/assembly_registration.html:317
-#, fuzzy
-msgid "Details for"
-msgstr "Hiba részletei"
-
-#: templates/backoffice/assembly_registration.html:327
-msgid "Copy <img> snippet for"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:373
+#: templates/backoffice/assembly_registration.html:322
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:379
-#: templates/backoffice/assembly_registration.html:441
-#: templates/backoffice/assembly_registration.html:513
-#: templates/backoffice/assembly_registration.html:558
+#: templates/backoffice/assembly_registration.html:328
+#: templates/backoffice/assembly_registration.html:390
+#: templates/backoffice/assembly_registration.html:462
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:54
 #: templates/backoffice/components/modal.html:133
 #: templates/backoffice/components/replacement_modal.html:170
 #: templates/backoffice/components/selection_progress_modal.html:89
+#: templates/backoffice/registration/image_details_modal.html:12
+#: templates/backoffice/registration/image_details_modal.html:29
 #: templates/backoffice/registration/image_upload_modal.html:12
 #: templates/backoffice/registration/image_upload_modal.html:37
 #, fuzzy
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:388
+#: templates/backoffice/assembly_registration.html:337
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:406
+#: templates/backoffice/assembly_registration.html:355
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:454
+#: templates/backoffice/assembly_registration.html:403
 msgid ""
 "The form is in test mode. Submissions made via these URLs are recorded as"
 " test submissions and will not enter the selection pool."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:551
-#, fuzzy
-msgid "Image details"
-msgstr "Meghívó kód"
-
-#: templates/backoffice/assembly_registration.html:577
-msgid "No preview"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:584
-msgid "Original filename"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:589
-#, fuzzy
-msgid "Dimensions"
-msgstr "Kieső emberek pótlása új kiválasztással"
-
-#: templates/backoffice/assembly_registration.html:594
-msgid "px"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:597
-msgid "File size"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:605
-#, fuzzy
-msgid "File name"
-msgstr "Keresztnév"
-
-#: templates/backoffice/assembly_registration.html:616
-msgid "File name copied to clipboard"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:619
-#, fuzzy
-msgid "Copy file name"
-msgstr "Keresztnév"
-
-#: templates/backoffice/assembly_registration.html:630
-#, fuzzy
-msgid "Image snippet"
-msgstr "Jelentések a folyamatról"
-
-#: templates/backoffice/assembly_registration.html:644
-msgid "Copy image snippet"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:654
-#: templates/backoffice/registration/image_upload_modal.html:72
-#, fuzzy
-msgid "Alt text"
-msgstr "Kezdés dátuma"
-
-#: templates/backoffice/assembly_registration.html:666
-#: templates/backoffice/registration/image_upload_modal.html:84
-msgid ""
-"Describes the image for screen-reader users and is used as the file's "
-"display name in the asset list."
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:679
-#, fuzzy
-msgid "Delete image"
-msgstr "Kezdés dátuma"
-
-#: templates/backoffice/assembly_registration.html:682
-#, fuzzy
-msgid "Save alt"
-msgstr "Elkezdve"
-
-#: templates/backoffice/assembly_registration.html:760
+#: templates/backoffice/assembly_registration.html:533
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:779
-#: templates/backoffice/assembly_registration.html:851
+#: templates/backoffice/assembly_registration.html:552
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:782
-#: templates/backoffice/assembly_registration.html:845
-#: templates/backoffice/assembly_registration.html:852
+#: templates/backoffice/assembly_registration.html:555
 msgid "Failed to copy to clipboard"
 msgstr ""
-
-#: templates/backoffice/assembly_registration.html:813
-#, fuzzy
-msgid "Delete this image?"
-msgstr "Kezdés dátuma"
-
-#: templates/backoffice/assembly_registration.html:824
-#: templates/backoffice/assembly_registration.html:884
-msgid "Failed to delete image"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:828
-#: templates/backoffice/assembly_registration.html:891
-#, fuzzy
-msgid "Image deleted"
-msgstr "Kiválasztás"
-
-#: templates/backoffice/assembly_registration.html:831
-#: templates/backoffice/assembly_registration.html:894
-#, fuzzy
-msgid "Network error while deleting the image"
-msgstr "Hiba történt a gyűlés frissítése közben"
-
-#: templates/backoffice/assembly_registration.html:840
-msgid "No public URL available yet"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:844
-msgid "Snippet copied to clipboard"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:921
-#, fuzzy
-msgid "Failed to update image"
-msgstr "Utoljára módosítva"
-
-#: templates/backoffice/assembly_registration.html:929
-#, fuzzy
-msgid "Image updated"
-msgstr "Utoljára módosítva"
-
-#: templates/backoffice/assembly_registration.html:932
-#, fuzzy
-msgid "Network error while updating the image"
-msgstr "Hiba történt a gyűlés frissítése közben"
 
 #: templates/backoffice/assembly_respondents.html:30
 #, fuzzy
@@ -7298,6 +7174,103 @@ msgstr ""
 #, fuzzy
 msgid "Source File"
 msgstr "Sikerült"
+
+#: templates/backoffice/registration/image_asset_list.html:26
+#, fuzzy
+msgid "Details for"
+msgstr "Hiba részletei"
+
+#: templates/backoffice/registration/image_asset_list.html:34
+#: templates/backoffice/registration/image_details_modal.html:101
+msgid "Snippet copied to clipboard"
+msgstr ""
+
+#: templates/backoffice/registration/image_asset_list.html:37
+msgid "Copy <img> snippet for"
+msgstr ""
+
+#: templates/backoffice/registration/image_asset_list.html:46
+#: templates/backoffice/registration/image_details_modal.html:149
+#, fuzzy
+msgid "Delete this image?"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/registration/image_asset_list.html:63
+#, fuzzy
+msgid "No images uploaded yet."
+msgstr "Feladat állapota"
+
+#: templates/backoffice/registration/image_details_modal.html:24
+#, fuzzy
+msgid "Image details"
+msgstr "Meghívó kód"
+
+#: templates/backoffice/registration/image_details_modal.html:44
+msgid "No preview"
+msgstr ""
+
+#: templates/backoffice/registration/image_details_modal.html:49
+msgid "Original filename"
+msgstr ""
+
+#: templates/backoffice/registration/image_details_modal.html:53
+#, fuzzy
+msgid "Dimensions"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/registration/image_details_modal.html:54
+msgid "px"
+msgstr ""
+
+#: templates/backoffice/registration/image_details_modal.html:56
+msgid "File size"
+msgstr ""
+
+#: templates/backoffice/registration/image_details_modal.html:64
+#, fuzzy
+msgid "File name"
+msgstr "Keresztnév"
+
+#: templates/backoffice/registration/image_details_modal.html:75
+msgid "File name copied to clipboard"
+msgstr ""
+
+#: templates/backoffice/registration/image_details_modal.html:78
+#, fuzzy
+msgid "Copy file name"
+msgstr "Keresztnév"
+
+#: templates/backoffice/registration/image_details_modal.html:90
+#, fuzzy
+msgid "Image snippet"
+msgstr "Jelentések a folyamatról"
+
+#: templates/backoffice/registration/image_details_modal.html:104
+msgid "Copy image snippet"
+msgstr ""
+
+#: templates/backoffice/registration/image_details_modal.html:120
+#: templates/backoffice/registration/image_upload_modal.html:72
+#, fuzzy
+msgid "Alt text"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/registration/image_details_modal.html:132
+#: templates/backoffice/registration/image_upload_modal.html:84
+msgid ""
+"Describes the image for screen-reader users and is used as the file's "
+"display name in the asset list."
+msgstr ""
+
+#: templates/backoffice/registration/image_details_modal.html:151
+#, fuzzy
+msgid "Delete image"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/registration/image_details_modal.html:155
+#, fuzzy
+msgid "Save alt"
+msgstr "Elkezdve"
 
 #: templates/backoffice/registration/image_upload_modal.html:32
 #, fuzzy
@@ -12994,5 +12967,20 @@ msgstr ""
 #~ msgstr "Kész"
 
 #~ msgid "Network error while uploading the image"
+#~ msgstr "Hiba történt a gyűlés frissítése közben"
+
+#~ msgid "Failed to delete image"
+#~ msgstr ""
+
+#~ msgid "Network error while deleting the image"
+#~ msgstr "Hiba történt a gyűlés frissítése közben"
+
+#~ msgid "No public URL available yet"
+#~ msgstr ""
+
+#~ msgid "Failed to update image"
+#~ msgstr "Utoljára módosítva"
+
+#~ msgid "Network error while updating the image"
 #~ msgstr "Hiba történt a gyűlés frissítése közben"
 

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -1053,9 +1053,10 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:160
 #: src/opendlp/entrypoints/blueprints/backoffice.py:395
 #: src/opendlp/entrypoints/blueprints/backoffice.py:442
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:200
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:521
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:543
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:206
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:345
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:538
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:560
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:91
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:126
@@ -1094,15 +1095,15 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:297
 #: src/opendlp/entrypoints/blueprints/backoffice.py:391
 #: src/opendlp/entrypoints/blueprints/backoffice.py:438
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:204
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:288
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:319
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:344
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:389
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:466
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:479
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:524
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:546
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:210
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:294
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:325
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:348
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:406
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:483
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:496
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:541
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:563
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:76
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:408
@@ -1258,149 +1259,143 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:210
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:216
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:221
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:227
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:222
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:228
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:225
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:231
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:228
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:234
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:231
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:237
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:234
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:240
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:235
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:241
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:280
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:476
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:551
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:286
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:493
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:568
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:284
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:316
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:465
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:478
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:290
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:322
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:482
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:495
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:299
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:305
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:311
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:317
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:324
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:330
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:329
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:335
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:342
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:385
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:402
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:347
-#, fuzzy
-msgid "An error occurred while generating the form skeleton"
-msgstr "Hiba történt a gyűlés létrehozásakor"
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:393
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:410
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:461
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:528
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:656
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:478
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:545
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:673
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:463
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:480
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:602
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:619
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:608
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:625
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:611
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:658
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:628
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:675
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:633
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:650
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:638
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:640
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:655
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:657
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:668
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:685
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:671
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:688
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:691
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:708
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:694
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:711
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
@@ -3217,8 +3212,8 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_data.html:508
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
-#: templates/backoffice/assembly_registration.html:217
-#: templates/backoffice/assembly_registration.html:237
+#: templates/backoffice/assembly_registration.html:221
+#: templates/backoffice/assembly_registration.html:241
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:37
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -3593,8 +3588,8 @@ msgstr "Módosítsa a számot."
 
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
 #: templates/backoffice/assembly_edit_respondent.html:21
-#: templates/backoffice/assembly_registration.html:220
-#: templates/backoffice/assembly_registration.html:240
+#: templates/backoffice/assembly_registration.html:224
+#: templates/backoffice/assembly_registration.html:244
 #: templates/backoffice/assembly_respondents.html:126
 #: templates/backoffice/assembly_selection.html:81
 #: templates/backoffice/assembly_selection.html:299
@@ -4344,7 +4339,7 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
-#: templates/backoffice/assembly_registration.html:279
+#: templates/backoffice/assembly_registration.html:283
 #: templates/backoffice/registration/image_upload_modal.html:93
 msgid "Upload"
 msgstr ""
@@ -4694,23 +4689,23 @@ msgstr ""
 msgid "Change status"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:165
+#: templates/backoffice/assembly_registration.html:168
 msgid "Show Form Skeleton"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:175
+#: templates/backoffice/assembly_registration.html:179
 msgid ""
 "Paste your HTML form code below. The only required placeholders are {{ "
 "form_action }} for the form's action attribute and {{ csrf_form_element "
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:210
+#: templates/backoffice/assembly_registration.html:214
 #: templates/backoffice/registration/preview_modal.html:8
 msgid "Preview and Test Responses"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:218
+#: templates/backoffice/assembly_registration.html:222
 #: templates/backoffice/components/edit_number_to_select_modal.html:38
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4723,77 +4718,30 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:230
-#: templates/backoffice/assembly_registration.html:245
+#: templates/backoffice/assembly_registration.html:234
+#: templates/backoffice/assembly_registration.html:249
 #: templates/backoffice/registration/preview_modal.html:8
 msgid "Share Form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:238
+#: templates/backoffice/assembly_registration.html:242
 #, fuzzy
 msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:249
-#: templates/backoffice/assembly_registration.html:250
+#: templates/backoffice/assembly_registration.html:253
+#: templates/backoffice/assembly_registration.html:254
 msgid "Registration is closed — the form URL redirects to the closed page"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:268
+#: templates/backoffice/assembly_registration.html:272
 #, fuzzy
 msgid "Assets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:294
+#: templates/backoffice/assembly_registration.html:298
 #, python-format
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:328
-#, fuzzy
-msgid "Form Skeleton"
-msgstr "Rétegzett kiválasztás"
-
-#: templates/backoffice/assembly_registration.html:334
-#: templates/backoffice/components/db_selection_progress_modal.html:117
-#: templates/backoffice/components/manage_tabs_progress_modal.html:111
-#: templates/backoffice/components/modal.html:54
-#: templates/backoffice/components/modal.html:133
-#: templates/backoffice/components/replacement_modal.html:170
-#: templates/backoffice/components/selection_progress_modal.html:89
-#: templates/backoffice/registration/image_details_modal.html:12
-#: templates/backoffice/registration/image_details_modal.html:29
-#: templates/backoffice/registration/image_upload_modal.html:12
-#: templates/backoffice/registration/image_upload_modal.html:37
-#: templates/backoffice/registration/preview_modal.html:13
-#: templates/backoffice/registration/preview_modal.html:30
-#: templates/backoffice/registration/preview_modal.html:100
-#, fuzzy
-msgid "Close"
-msgstr "Menü bezárása"
-
-#: templates/backoffice/assembly_registration.html:343
-msgid ""
-"This skeleton is generated from your assembly's field definitions. Copy "
-"all or select specific parts to paste into your form."
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:361
-msgid "Copy All"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:432
-#, fuzzy
-msgid "An error occurred while fetching the form skeleton"
-msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
-
-#: templates/backoffice/assembly_registration.html:443
-#: templates/backoffice/components/url_display.html:37
-msgid "Copied to clipboard"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:446
-msgid "Failed to copy to clipboard"
 msgstr ""
 
 #: templates/backoffice/assembly_respondents.html:30
@@ -5799,6 +5747,25 @@ msgstr "Megszakítás"
 msgid "Put Task in Background"
 msgstr "Az oldal nem elérhető"
 
+#: templates/backoffice/components/db_selection_progress_modal.html:117
+#: templates/backoffice/components/manage_tabs_progress_modal.html:111
+#: templates/backoffice/components/modal.html:54
+#: templates/backoffice/components/modal.html:133
+#: templates/backoffice/components/replacement_modal.html:170
+#: templates/backoffice/components/selection_progress_modal.html:89
+#: templates/backoffice/registration/image_details_modal.html:12
+#: templates/backoffice/registration/image_details_modal.html:29
+#: templates/backoffice/registration/image_upload_modal.html:12
+#: templates/backoffice/registration/image_upload_modal.html:37
+#: templates/backoffice/registration/preview_modal.html:13
+#: templates/backoffice/registration/preview_modal.html:30
+#: templates/backoffice/registration/preview_modal.html:100
+#: templates/backoffice/registration/skeleton_modal.html:10
+#: templates/backoffice/registration/skeleton_modal.html:27
+#, fuzzy
+msgid "Close"
+msgstr "Menü bezárása"
+
 #: templates/backoffice/components/edit_number_to_select_modal.html:8
 #, fuzzy
 msgid "Edit Number to Select"
@@ -5984,6 +5951,11 @@ msgstr "Kiválasztás"
 #: templates/backoffice/components/url_display.html:36
 #: templates/backoffice/components/url_display.html:38
 msgid "Copy URL to clipboard"
+msgstr ""
+
+#: templates/backoffice/components/url_display.html:37
+#: templates/backoffice/registration/skeleton_modal.html:56
+msgid "Copied to clipboard"
 msgstr ""
 
 #: templates/backoffice/patterns/_ajax.html:9
@@ -7290,6 +7262,21 @@ msgstr ""
 msgid ""
 "The form is in test mode. Submissions made via these URLs are recorded as"
 " test submissions and will not enter the selection pool."
+msgstr ""
+
+#: templates/backoffice/registration/skeleton_modal.html:22
+#, fuzzy
+msgid "Form Skeleton"
+msgstr "Rétegzett kiválasztás"
+
+#: templates/backoffice/registration/skeleton_modal.html:36
+msgid ""
+"This skeleton is generated from your assembly's field definitions. Copy "
+"all or select specific parts to paste into your form."
+msgstr ""
+
+#: templates/backoffice/registration/skeleton_modal.html:59
+msgid "Copy All"
 msgstr ""
 
 #: templates/backoffice/respondent_field_schema/view.html:22
@@ -12987,4 +12974,13 @@ msgstr ""
 
 #~ msgid "Network error while updating the image"
 #~ msgstr "Hiba történt a gyűlés frissítése közben"
+
+#~ msgid "An error occurred while generating the form skeleton"
+#~ msgstr "Hiba történt a gyűlés létrehozásakor"
+
+#~ msgid "An error occurred while fetching the form skeleton"
+#~ msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
+
+#~ msgid "Failed to copy to clipboard"
+#~ msgstr ""
 


### PR DESCRIPTION
The registrations images uses JSON endpoints and quite a bit of embedded JS. This is a spike to see what it would look like if we made it more HTMX heavy. I'm hoping this will mean we can test more logic in python and reduce the untested JS in the template.

To be evaluated together.