### PR TITLE
Add Emails tab to Registration

### DIFF
--- a/backend/docs/agent/615-auto-reply-email-ui/code-review-implementation-plan.md
+++ b/backend/docs/agent/615-auto-reply-email-ui/code-review-implementation-plan.md
@@ -1,0 +1,97 @@
+# Incremental Implementation Plan
+
+Ordered by risk + coupling: quick low-risk fixes first, then docs, then tests, then refactors that need thinking. Each step should be one commit (or a couple of tight ones), reviewable in isolation.
+
+## Step 0 — Rebase onto `main`
+
+Drops the 617 noise from the diff. Do this before anything else so the PR shape reflects only 615 work.
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+Verify: `git diff --merge-base main --stat` should shrink dramatically. Run tests.
+
+## Step 1 — Security footgun: escape stepper attributes
+
+Highest-impact, tiniest change. In `templates/backoffice/components/stepper.html:63-68`, escape each value before `|safe`. Either:
+- `{% set _ = extra_attrs.append(key ~ '="' ~ (value | e) ~ '"') %}`
+- Or drop `|safe` and use `|forceescape` on the joined string.
+
+Add a `test_stepper_macro` case that passes a value containing `"` and asserts the output stays inside the attribute.
+
+## Step 2 — Silent except → debug log
+
+`backoffice_registration.py:344-346, 352-354`: add `logger.debug("auto_reply_template_load_failed", assembly_id=..., reason="not_found"|"forbidden")` in the two except arms. One-file change.
+
+## Step 3 — Logging convention cleanup (mechanical)
+
+Sweep in a single commit — pure refactor, no behaviour change:
+- `entrypoints/decorators.py:75, 122, 135, 203` — f-strings → structured kwargs.
+- `gsheets_legacy.py`, `admin.py`, `main.py` — `logger.error(...)` inside catch-all `except Exception` → `logger.exception(...)` (drop the redundant `error=str(e)` where the traceback now carries it).
+
+Verify: `grep -n 'logger\.error' src/opendlp/entrypoints/blueprints/{gsheets_legacy,admin,main}.py` after the sweep, cross-check each remaining one is *not* in a catch-all.
+
+## Step 4 — Config documentation
+
+Two-file change, no code:
+- `docs/configuration.md` — extend "Configuration Validation" with the console-adapter rejection; extend `SECRET_KEY` section with the HMAC-key usage + rotation implication.
+- `env.example:139-143` — one-line comment: "production startup fails if this is `console`".
+
+## Step 5 — Extract dev-secret constant
+
+`config.py:49-51` and `571` both hardcode `"dev-secret-key-change-in-production"`. Pull to a module-level `_DEV_SECRET_KEY = "..."` so the production guard can't silently drift. Trivial.
+
+## Step 6 — Test cleanup
+
+Split into three commits if you want them reviewable:
+1. `test_backoffice_registration_email.py:238-312` — remove `update_email_template`/`create_email_template` mocks, drive `EmailTemplateInvalid` with empty strings, `NotFoundError` with a stray UUID. Drop the `RuntimeError` case.
+2. `test_backoffice_registration_email.py:285-296` — replace the tautological assert with a concrete-destination check.
+3. `test_dev_email_handlers.py:95-124` — swap the local fixtures for `tests/component/conftest.py`'s (`fake_store`, `existing_assembly`, `admin_user`). Move the `patch(current_user)` calls to `session_transaction` login.
+4. `test_stepper_macro.py:38-45` — anchor assertions on `<span class="sr-only">` (or parse the HTML with `BeautifulSoup` — already a project dep).
+
+## Step 7 — Accessibility fixes (template-only)
+
+- `stepper.html:83, 112` — swap the bare `!` for a warning-triangle SVG (mirror the checkmark).
+- `stepper.html:48-52` — drop the outer `<nav aria-label>`, keep it only on `<ol role="tablist">`.
+- `stepper.html` docstring — add a "Dependencies: requires `x-scroll-preserve-links` from `backoffice/base.html` if `preserve_scroll=true`" note.
+- `service_docs/_emails.html` — bump interior h4s to h3.
+- `assembly_registration.html:52` — h3 → h2.
+- `assembly_registration.html:432-448` — variable-copy row: add `aria-readonly="true"` to the input (or restructure to `<code>` + button).
+- `assembly_registration.html:232, 242, 253` — `_("Details for %(name)s", name=image.display_name)` etc., built server-side.
+
+Manually verify with a screen reader (VoiceOver) — or at least keyboard tab through the stepper.
+
+## Step 8 — Alpine `@click` string-arg pattern
+
+`assembly_registration.html:440` — switch to `data-copy-expr="{{ variable.expr }}" data-copy-msg="{{ _('...') }}" @click="copyToClipboard($el)"`. Update `copyToClipboard` in `alpine-components.js` to read from `$el.dataset` when passed a DOM element. Grep for other call sites and migrate them together — this is a mini-refactor across the file.
+
+## Step 9 — Business logic → service layer
+
+Bigger, riskier. Do this after everything above is green.
+
+- Move `_load_auto_reply_context` fallback logic into `email_template_service.get_editor_context_for_assembly(uow, user_id, assembly_id)` returning a dataclass with `template`, `all_templates`, `assigned_id`.
+- Move `_dispatch_email_action` enable-vs-assign rule into `email_template_service.enable_auto_reply(uow, assembly_id, template_id | None)`.
+- Move `_create_default_auto_reply_template` into either `registration_page_service.create_registration_page_with_slugs` or `email_template_service.seed_default_auto_reply`.
+- Blueprint becomes thin: one `with bootstrap.get_flask_uow() as uow:` per request, service calls inside.
+
+Add unit tests at the service layer for each rule. Trim the component tests once real service coverage exists.
+
+## Step 10 — BDD happy path
+
+Add a scenario for "manager creates registration page → enables auto-reply → edits template → previews → publishes" under `tests/bdd/`. Match the existing project style. Update `delete_all_except_standard_users()` in `tests/bdd/conftest.py` if the new flow creates rows that aren't already covered.
+
+## Step 11 — Optional: log_redaction DI cleanup
+
+`log_redaction.py` — remove the `opendlp.config` import, take `secret` as a required arg on `hash_email`. Update the two call sites (`login_rate_limit_service.py`, wherever else) to pass it. Eliminates the latent circular import.
+
+## Step 12 — Optional: extract inline Alpine controller
+
+`assembly_registration.html:895-1180` → move to `static/backoffice/js/registration-page-controller.js` as `Alpine.data("registrationPageController", ...)`. Pass `url_for` / translated strings / `images|tojson` via `data-*` attributes on the root `<div x-data>`.
+
+Skip if you're happy with the inline version — the CSP nonce covers it.
+
+---
+
+**Ship boundary suggestion:** steps 0-7 in this PR (safe, tightly scoped), step 8 if you have appetite. Steps 9-12 as a follow-up PR — they change architecture and deserve separate review focus.

--- a/backend/docs/agent/615-auto-reply-email-ui/code-review.md
+++ b/backend/docs/agent/615-auto-reply-email-ui/code-review.md
@@ -1,0 +1,77 @@
+# Code Review — `615-auto-reply-email-ui`
+
+The branch mixes two pieces of work in the merge-base diff — **615** (auto-reply email UI, stepper macro, multi-step registration editor) and **617** (log redaction / structured logging), which was independently merged to `main` via PR #188. If you rebase before opening the 615 PR, the 617 noise will drop out. Overall quality is high; nothing blocks. The main "should-fix" clusters are (1) leftover f-string logging + `.error()`-instead-of-`.exception()` in the touched blueprints, (2) a few over-mocked component tests, (3) missing doc updates for the new production check and the new use of `SECRET_KEY` as an HMAC key, and (4) a latent HTML-escape footgun in the new stepper macro.
+
+## Code Quality Rules
+
+**Should-fix**
+- `src/opendlp/entrypoints/decorators.py:75-77, 122, 135-136, 203-205` — 4 log calls still use f-strings after the structlog conversion. Convert to structured kwargs (`user_id=str(current_user.id)`, `endpoint=request.endpoint`, `role=...`).
+- Catch-all `except Exception as e: logger.error(...)` in code the branch touched — should be `.exception(...)`:
+  - `gsheets_legacy.py` ~21 spots; `admin.py` ~14; `main.py` ~7. `backoffice_registration.py:504` already does it right.
+- `backoffice_registration.py:344-346, 352-354` — silent `except (EmailTemplateNotFoundError, InsufficientPermissions): email_template = None`. Add a `logger.debug(...)` so "no template assigned" vs "permission denied at load time" is distinguishable.
+
+**Nits**
+- `log_redaction.py:92` — `secret: str | None = None` violates the "prefer empty string default" preference, but the sentinel is legitimate here for DI.
+- `logging.py` — missing ABOUTME header (pre-existed on main; opportunistic fix).
+
+## Testing
+
+**Should-fix**
+- `tests/component/test_backoffice_registration_email.py:238-312` — over-mocks `update_email_template` / `create_email_template` to raise, which `docs/testing.md:539-544` explicitly forbids. `EmailTemplateInvalid` is reachable via the empty-strings pattern already used in `test_dev_email_handlers.py:173`; `NotFoundError` via a stray UUID. Drop the mocks.
+- `test_backoffice_registration_email.py:285-296` — assertion is a tautology (`"…" not in loc or "…" not in loc`). Assert on the concrete destination.
+- `tests/component/test_dev_email_handlers.py:95-124` — reinvents fixtures instead of reusing `tests/component/conftest.py` (`fake_store` / `existing_assembly` / `admin_user`). Consolidate.
+- **BDD gap.** No `features/` or `tests/bdd/` scenario for the new multi-step editor / auto-reply UI. Given this is a substantial user-facing journey, at least a happy-path scenario is warranted. The e2e test drives HTTP, not the browser.
+- `tests/unit/test_stepper_macro.py:38-45` — `"completed" in html` / `"has errors" in html` matches almost any incidental copy. Anchor on the actual `<span class="sr-only">` or parse the HTML.
+
+**Nits**
+- `tests/e2e/test_health_check_monitoring.py` — collapsing per-URL loops loses coverage of the `/health` aggregate wiring.
+- `capture_json_handler` fixture in `tests/conftest.py:429-455` is a nice pattern — replaces the wrong-tool `caplog` assertions for structlog output.
+
+## Architecture
+
+**Should-fix**
+- `log_redaction.py:99` — module-load import of `opendlp.config`. `logging.py` imports `log_redaction` at load and is one of the earliest imports in `flask_app.py`. Fine today, but any future logging in `config.py` would cycle. Consider taking the secret at the call site (`login_rate_limit_service.py:70` already knows the config) so `log_redaction.py` becomes a pure helper.
+- `backoffice_registration.py:325-467` — auto-reply "prefer assigned else first template" fallback (`_load_auto_reply_context`) and the enable-vs-assign dispatch (`_dispatch_email_action`) are business rules that belong in `email_template_service`, not the blueprint. Same file opens 24 separate short UoW transactions per request — push multi-step reads into one service call.
+
+**Nits**
+- `_create_default_auto_reply_template` (`backoffice_registration.py:514-538`) is a side-effect of creating a registration page; belongs in `registration_page_service.create_registration_page_with_slugs` or `email_template_service.seed_default_auto_reply`.
+- `config.py:579-580` production check is good; consider a matching runtime guard in `bootstrap.py` where the adapter is constructed.
+- `gsheets_legacy.py` +570 lines confirmed to be pure logging/kwargs conversion, no logic drift.
+
+## Configuration
+
+- **Env vars added:** none. **Env vars removed:** none.
+
+**Should-fix**
+- `docs/configuration.md` not updated for the new production check that rejects `EMAIL_ADAPTER=console` (config.py:578-580). Same gap in `env.example:139-143`.
+- `SECRET_KEY` is now also the HMAC key for `hash_email` (log_redaction.py:92-102). Rotating it invalidates log-correlation tokens — worth documenting under `SECRET_KEY` (docs/configuration.md:55-60) and under "Rotate secrets regularly" (line 413).
+
+**Nits**
+- `"dev-secret-key-change-in-production"` is hardcoded at both config.py:49-51 and config.py:571 — extract a constant so the production guard can't silently drift.
+
+## Templates & Accessibility
+
+The stepper's ARIA/keyboard/SR contract is correct: roving tabindex via `tabsKeyboard`, `role="tab"`+`aria-selected`+`aria-controls` in tabs mode, `aria-current="step"` in wizard mode, panels wired with matching ids + `aria-labelledby`, and done/error state announced via `sr-only` suffixes ("completed" / "has errors"). i18n is essentially complete in the new files.
+
+**Should-fix**
+- `stepper.html:63-68` — the extra-attrs pass-through builds `key="value"` strings and applies `|safe`. No `|e` on `value`. Latent XSS/attribute-break footgun if any caller ever passes a value containing `"` (including a translated string). Escape each value or use `|forceescape` before `|safe`.
+- `service_docs/_emails.html` heading hierarchy jumps h2 → h4 throughout. The `card()` macro emits h2, then interior labels are h4 with no intervening h3.
+- `assembly_registration.html:52` — page h1 (line 29) is followed by h3 in the "no registration page" panel. Bump to h2.
+- `assembly_registration.html:432-448` — variable-copy row: `<label for="variable-N">` on a `readonly` input will invite "edit text" hints in SR. Consider `<code>` + button, or add `aria-readonly="true"`.
+
+**Nits**
+- `stepper.html:83, 112` — bare `!` for error state relies on colour + text. A warning-triangle SVG (matching the checkmark) would help WCAG 1.4.1.
+- `stepper.html:48-52` — `aria-label` on both the outer `<nav>` and inner `<ol role="tablist">` is redundant.
+- `assembly_registration.html:232, 242, 253` — `"Details for" + image.display_name` isn't translator-reorderable. Use `%(name)s` server-side.
+
+## JavaScript & CSP
+
+All inline scripts carry `nonce="{{ csp_nonce }}"`, CSP-safe `@alpinejs/csp@3.15.8` build is in use, JS logic lives in `static/backoffice/js/alpine-components.js`, AJAX includes `X-CSRFToken`. No `eval` / `new Function` / unsafe `.innerHTML`.
+
+**Should-fix**
+- `stepper.html:48` uses `x-scroll-preserve-links` (registered in `static/js/alpine-scroll-manager.js`, loaded by `backoffice/base.html:29`). If the stepper is used outside backoffice base, it silently no-ops. Document the dependency in the macro docstring.
+- `assembly_registration.html:440` accretes another `@click="copyToClipboard('lit1', 'lit2')"` (CLAUDE.md flags "`@click` handlers cannot have string arguments"). The CSP Alpine build accepts literals in practice — the pattern already exists on main — but if the constraint is meant strictly, prefer `data-copy-*` attributes + `copyToClipboard($el)`.
+
+**Nits**
+- Big inline `registrationPageController` script (`assembly_registration.html:895-1180`, ~285 lines) — justifiable due to Jinja interpolation, but pushing to `Alpine.data(...)` with values via `data-*` attributes would match `frontend_security.md`'s "prefer external files".
+- `service_docs/_emails.html`, `showcase/stepper_component.html`, `patterns/_stepper.html` add many `style="color: var(--color-...)"` inline attributes. Static tokens — could be utility classes. Not a CSP issue, aesthetic.

--- a/backend/docs/agent/615-auto-reply-email-ui/stepper-manual-test-plan.md
+++ b/backend/docs/agent/615-auto-reply-email-ui/stepper-manual-test-plan.md
@@ -1,0 +1,192 @@
+# Stepper component — manual test plan
+
+Hand this plan to the Chrome Claude extension. Complete each item and tick it off with
+✅ / ❌ / ⚠️ (partial). Note any surprises, unexpected screenshots, or console errors
+next to the item.
+
+## Environment
+
+- **Base URL**: `http://127.0.0.1:5615`
+- **Login**: use an admin account (developer tools tabs are admin-only).
+- **Browser**: Chrome, latest.
+- **Preconditions**: at least one assembly exists whose Registration page has been
+  created. If not, create one from an assembly's *Details* tab first.
+
+## Report format
+
+For each test, report:
+
+- ✅ / ❌ / ⚠️
+- One-line observation (what you saw)
+- Screenshot **only** when the outcome is unexpected
+- Any console errors or accessibility-tree warnings from DevTools
+
+---
+
+## Part A — Stepper showcase page
+
+**URL**: `http://127.0.0.1:5615/backoffice/dev/patterns?tab=stepper`
+
+### A1 — Page renders
+
+- [ ] The Patterns page loads without a 500 error.
+- [ ] The "Stepper" tab is present in the tab bar and is currently selected.
+- [ ] The blue info banner (🪜 Stepper) is visible at the top.
+
+### A2 — Tabs-mode example (first card)
+
+- [ ] Three steps render horizontally: **1 Registration page**, **2 Auto-reply email**, **3 Preview and publish**.
+- [ ] Step 1 has a **green** pill with a **checkmark** icon (done state).
+- [ ] Step 2 has a **brand-color** (dark red / brand-400) pill with the number **2** and the label is **bold** (active state).
+- [ ] Step 3 has a **gray** pill with the number **3** (inactive state).
+- [ ] Connector lines are visible between the pills and stretch to fill the row.
+
+### A3 — Wizard-mode example (second card)
+
+- [ ] Three steps render: **1 Sign the agreement** (done), **2 Verify your email** (active), **3 Choose a plan** (dimmed/disabled).
+- [ ] Step 3 appears at reduced opacity and has no hover cursor when hovered.
+- [ ] Clicking step 3 does **not** navigate (the URL should not change).
+
+### A4 — State reference (third card)
+
+- [ ] Four rows are visible with labels: *active*, *inactive*, *done*, *error*.
+- [ ] The error step shows a **red** pill with an **`!`** and the label is red.
+
+### A5 — Keyboard navigation (tabs mode)
+
+Use the first card's tabs-mode stepper. The stepper opts into **manual activation**:
+arrow / Home / End only move focus, they should **not** navigate. Enter/Space
+activates.
+
+- [ ] Tab into the stepper — the outline appears **only** on the active step (step 2).
+- [ ] Press **→ (Right arrow)** — focus moves to the next step and its outline appears. **The URL must not change.**
+- [ ] Press **← (Left arrow)** — focus moves back. **The URL must not change.**
+- [ ] Press **Home** — focus jumps to step 1. **URL unchanged.**
+- [ ] Press **End** — focus jumps to step 3. **URL unchanged.**
+- [ ] Press **Enter** on a focused step — the URL updates to include `&step=<key>` and the page navigates. Focus is preserved and visible on the destination step.
+
+### A6 — Focus behaviour (mouse vs keyboard)
+
+- [ ] Click any step with the mouse. Expected: the URL updates, and **no visible outline** appears on the clicked step after navigation.
+- [ ] Now press **Tab** to move focus back into the stepper. Expected: the visible outline **does** appear on the focused step.
+
+### A6b — Suspected route-change / focus-preservation bug
+
+Hypothesis: because each step is a real navigation (a link click that reloads the
+page), the stepper uses the `x-focus-preserve` directive. On a **keyboard** click
+(Enter on a focused step), the directive appends `#focus=<step-id>` to the URL and
+the destination page programmatically calls `.focus()` on the matching element via
+the `DOMContentLoaded` handler — this correctly re-shows the outline for keyboard
+users. But on browsers/OSes where a **mouse** click *also* focuses the link first
+(Windows Chrome, Firefox on any OS), `document.activeElement === el` becomes true
+for a mouse click too, the same `#focus=` hash is appended, and after navigation the
+programmatic `.focus()` may re-match `:focus-visible` on the destination page —
+producing a visible outline that the user did **not** trigger with the keyboard.
+
+Report the following for **each** of Chrome (macOS), Chrome (Windows), and Firefox
+(any OS) you can reach — even if just one browser, note which:
+
+- **Browser + OS**: _____
+- [ ] After a **mouse click** on step 2, inspect the URL bar before the fragment is
+      cleaned up. Does it briefly include `#focus=reg-steps-tab-two` (or similar)?
+      Yes / No.
+- [ ] After a mouse click has completed navigation, is a visible focus outline
+      shown on the newly-active step **without** any keyboard input first? Yes / No.
+- [ ] Repeat with the **keyboard** (Tab to a step, press Enter). Outline visible on
+      destination? Yes / No (should be **Yes**).
+- [ ] Optional: in DevTools Console, run `document.activeElement` immediately
+      after a mouse click on the link (before it navigates) — is it the link, or
+      is it `<body>`? Report the tagName / class.
+
+If mouse click yields an outline in browsers other than macOS Chrome/Safari, that
+confirms the hypothesis: the `focus-preserve` directive should gate on the input
+modality (e.g. only append `#focus=` when the click's `event.detail === 0`, which
+means a keyboard-generated click) instead of relying on `document.activeElement`.
+
+### A7 — Screen-reader semantics (DevTools → Accessibility panel)
+
+- [ ] In tabs mode, the container element has `role="tablist"`, `aria-label` **is present** on the same element (should equal the value passed to the macro), and each step's link has `role="tab"` with `aria-selected` set to `true` on the active one and `false` on the others.
+- [ ] In wizard mode, the container element has `role="list"`, and the active step has `aria-current="step"`. The disabled step has `aria-disabled="true"` and is not in the tab order (`tabindex="-1"` implicitly via `<span>`).
+
+---
+
+## Part B — Assembly Registration tab
+
+**URL**: `http://127.0.0.1:5615/backoffice/assembly/<ASSEMBLY_ID>/registration`
+
+Replace `<ASSEMBLY_ID>` with the UUID of an assembly whose Registration page has
+already been created.
+
+### B1 — Page renders and the stepper appears
+
+- [ ] The page loads without a 500 error.
+- [ ] Above the "Registration Form HTML" section there is a three-step stepper: **1 Registration page**, **2 Auto-reply email**, **3 Preview and publish**.
+- [ ] Step 1 is active (brand-color pill, bold label). Steps 2 and 3 are inactive (gray).
+
+### B2 — Default section is *Registration page*
+
+- [ ] With no `?section=` in the URL (or `?section=form`), the existing HTML editor + Assets panel is visible.
+- [ ] The status badge (Test/Published/Closed) still renders next to the section title.
+
+### B3 — Switching to *Auto-reply email*
+
+- [ ] Click **step 2 (Auto-reply email)**. The URL updates to `?section=email`.
+- [ ] The HTML editor and Assets panel are hidden.
+- [ ] A placeholder card with the heading **"Auto-reply email"** and the message **"Coming soon — you will be able to edit the email respondents receive after registering."** is visible.
+- [ ] Step 2 now shows as active (brand-color pill, bold label); step 1 is now inactive.
+
+### B4 — Switching to *Preview and publish*
+
+- [ ] Click **step 3 (Preview and publish)**. The URL updates to `?section=preview`.
+- [ ] A placeholder card with the heading **"Preview and publish"** is visible with a "Coming soon" message.
+- [ ] Step 3 is active; steps 1 and 2 are inactive.
+
+### B5 — Returning to step 1
+
+- [ ] Click **step 1 (Registration page)**. The URL updates to `?section=form`.
+- [ ] The full HTML editor + Assets panel is back and still functional (open a modal like "Show Form Skeleton" to confirm the Alpine controller re-initialised).
+
+### B6 — Direct navigation via URL
+
+- [ ] Manually visit `.../registration?section=email` in the address bar → the email placeholder loads, step 2 is active.
+- [ ] Manually visit `.../registration?section=preview` → the preview placeholder loads, step 3 is active.
+- [ ] Manually visit `.../registration?section=nonsense` → the page falls back to the form (step 1 active).
+
+### B7 — Stepper does NOT appear when no registration page exists
+
+For this, use an assembly that has **not** had its Registration page created yet.
+
+- [ ] The warning panel "Registration page not created" is shown as before.
+- [ ] The three-step stepper is **not** visible on this page (there is nothing to step through yet).
+
+### B8 — Keyboard nav in the real page
+
+- [ ] From the top of the page, Tab through until focus reaches the stepper. Confirm keyboard behaviour matches Part A5 (arrow keys move focus, Enter navigates).
+- [ ] Focus outline is only visible on keyboard focus, not on mouse click.
+
+---
+
+## Part C — Cross-cutting
+
+### C1 — No console errors
+
+- [ ] With the DevTools Console open, run through **A2, A5, B3–B5**. Expected: zero uncaught errors or Alpine warnings.
+
+### C2 — CSP compliance
+
+- [ ] In DevTools Console, verify no `Content Security Policy` violations are logged when navigating between sections.
+
+### C3 — Responsive layout
+
+- [ ] Narrow the viewport to ~640px. The stepper should still render horizontally; labels stay on one line (they use `white-space: nowrap`). If wrapping happens, note it as a visual regression.
+
+---
+
+## Summary
+
+At the end of the run, report:
+
+- Total pass / fail / partial counts.
+- The three highest-impact issues you found (if any), each with one screenshot.
+- Any accessibility concerns from the DevTools Accessibility tree that are not
+  already covered above.

--- a/backend/docs/agent/615-auto-reply-email-ui/stepper-manual-test-report.md
+++ b/backend/docs/agent/615-auto-reply-email-ui/stepper-manual-test-report.md
@@ -1,0 +1,68 @@
+# Stepper component — Manual Test Run Results
+
+**Environment:** Chrome (macOS), logged in as Admin User, base URL `http://127.0.0.1:5615`
+**Assembly used for Part B:** Blabla (`76aca524-69ed-4b5e-9e72-6aa5a473b63e`) — has a Published registration page
+**Date:** 2026-07-01
+
+---
+
+## Part A — Stepper showcase page
+
+**URL:** `http://127.0.0.1:5615/backoffice/dev/patterns?tab=stepper`
+
+### A1 — Page renders
+- ✅ Patterns page loads, no 500.
+- ✅ "Stepper" tab present and selected (bold + underlined).
+- ✅ Blue 🪜 Stepper info banner visible at top.
+
+### A2 — Tabs-mode example
+- ✅ Three steps horizontal: 1 Registration page / 2 Auto-reply email / 3 Preview and publish.
+- ✅ Step 1 = green pill + checkmark (done).
+- ✅ Step 2 = brand dark-red pill "2", label bold (active).
+- ✅ Step 3 = gray pill "3" (inactive).
+- ✅ Connector lines present and stretch to fill the row.
+
+### A3 — Wizard-mode example
+- ✅ 1 Sign the agreement (done/green), 2 Verify your email (active/red), 3 Choose a plan (dimmed).
+- ✅ Step 3 at reduced opacity, default (non-pointer) cursor on hover.
+- ✅ Clicking step 3 did not change the URL. DOM confirms it renders as a `<span>` (not a link), so it is genuinely non-navigable.
+
+### A4 — State reference
+- ✅ Four rows: active, inactive, done, error.
+- ✅ Error step = red pill with "!" and red label.
+
+### A5 — Keyboard navigation (tabs mode)
+- ✅ Tab into stepper lands on the active step (step 2) only; outline appears there. Roving tabindex confirmed in DOM (active tab `tabindex="0"`, others `-1`).
+- ✅ → moves to next step; ← moves back; Home → step 1; End → step 3.
+- ✅ Enter navigates and the URL includes `&step=<key>`.
+- ⚠️ **Implementation note:** every arrow/Home/End/Enter press is a *real page navigation* (the URL's `step=` changes and the page reloads), not in-page focus movement. Focus is re-applied after reload via a `#focus=` hash, but re-showing of the outline was **inconsistent**: it reliably reappeared after → (URL gained `#focus=…`), but after ←, Home and End the URL had no `#focus=` hash and no visible outline was restored. Functionally focus/selection lands on the right step; the visible outline is just not always preserved.
+
+### A6 — Focus behaviour (mouse vs keyboard)
+- ✅ Mouse click updates the URL; on the showcase page no outline appeared on the clicked step after navigation.
+- ✅ Pressing Tab afterwards does show the outline on the focused step.
+
+### A6b — Route-change / focus-preservation
+- **Browser + OS tested:** Chrome (macOS) only — Windows Chrome and Firefox are not reachable from this environment, so those rows are unverified.
+- Mouse click → `#focus=` fragment in URL? **No** on macOS Chrome (final URL was e.g. `?section=email` / `&step=two` with no `#focus=` hash).
+- Visible outline after mouse-click navigation without keyboard? **Yes, intermittently.** On the *real* registration page a pure mouse click on a freshly-loaded page repeatedly produced a focus outline on the destination step (clearest on step 2). It did **not** appear on the showcase page and was inconsistent for step 3. See Issue #1.
+- Keyboard (Tab→Enter) outline on destination? ✅ Yes (expected).
+- `document.activeElement` after a mouse click: it is **the clicked link (`<A>`)**. Control test: arriving at the same URL by typing it in the address bar leaves `activeElement = <body>` with no outline. So the outline only appears when arriving via a link click, because the destination link is re-focused — exactly the precondition the hypothesis describes.
+
+### A7 — Screen-reader semantics (verified via DOM inspection)
+- ✅ Tabs mode: container `role="tablist"`; each step `role="tab"`; `aria-selected="true"` on the active step, `"false"` on the others.
+- ✅ Wizard mode: container `role="list"`; active step has `aria-current="step"`; disabled step is a `<span>` with `aria-disabled="true"` and is not in the tab order.
+- ⚠️ Minor: the tabs-mode `<tablist>` container had no `aria-label` on the rendered showcase example (the macro is called with `aria_label="Registration setup steps"` in the code sample, but the attribute wasn't present on the element). Low impact, but worth confirming the label is emitted.
+
+---
+
+## Part B — Assembly Registration tab
+
+**URL:** `http://127.0.0.1:5615/backoffice/assembly/76aca524-69ed-4b5e-9e72-6aa5a473b63e/registration`
+
+- **B1** ✅ Loads (no 500); three-step stepper above "Registration Form HTML"; step 1 active (red pill, bold), steps 2/3 gray.
+- **B2** ✅ No `?section=` → HTML editor + Assets panel visible; "Published" status badge renders next to the title.
+- **B3** ✅ Click step 2 → `?section=email`; editor/Assets hidden; "Auto-reply email" placeholder with the exact "Coming soon — …after registering." copy; step 2 active, step 1 inactive.
+- **B4** ✅ Click step 3 → `?section=preview`; "Preview and publish" placeholder with a Coming-soon message; step 3 active, 1 & 2 inactive.
+- **B5** ✅ Click step 1 → `?section=form`; editor + Assets panel back; "Show Form Skeleton" modal opens correctly → Alpine controller re-initialised.
+- **B6** ✅ Direct URL `?section=email` → email placeholder, step 2 active; `?section=preview` → preview, step 3 active; `?section=nonsense` → falls back to the form with step 1 active (URL keeps `nonsense` but content is the form).
+- **B7** ⚠️ **Not tested — blocked.** Both existing assemblies (Blabla, and Citizens' Assembly on AI) already have a Registration page created, so there is no "not

--- a/backend/justfile
+++ b/backend/justfile
@@ -126,6 +126,10 @@ flsh: flask-shell
 flask $FLASK_APP="src/opendlp/entrypoints/flask_app.py":
   @uv run flask run --debug
 
+# run flask locally on a custom port (default 5001)
+flask-port port="5001" $FLASK_APP="src/opendlp/entrypoints/flask_app.py":
+  @uv run flask run --port={{port}} --debug
+
 # run flask for BDD tests - the BDD tests will use this server if it exists
 flask-bdd:
   # env vars are set inline to override any values from .env (loaded by set dotenv-load)

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -529,7 +529,8 @@ def _create_default_auto_reply_template(assembly_id: uuid.UUID) -> None:
             body_html=defaults["body_html"],
         )
     except Exception as e:
-        logger.warning(
+        # Non-fatal: log with traceback per code_quality_rules for catch-all blocks.
+        logger.exception(
             "Failed to seed default auto-reply email template",
             assembly_id=str(assembly_id),
             user_id=str(current_user.id),

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -341,7 +341,22 @@ def _load_auto_reply_context(registration_page: Any, assembly_id: uuid.UUID) -> 
         try:
             email_template = get_email_template(bootstrap.get_flask_uow(), current_user.id, template_id)
             auto_reply_enabled = True
-        except (EmailTemplateNotFoundError, InsufficientPermissions):
+        except EmailTemplateNotFoundError:
+            logger.debug(
+                "auto_reply_template_load_failed",
+                assembly_id=str(assembly_id),
+                template_id=str(template_id),
+                reason="not_found",
+            )
+            email_template = None
+        except InsufficientPermissions:
+            logger.debug(
+                "auto_reply_template_load_failed",
+                assembly_id=str(assembly_id),
+                template_id=str(template_id),
+                user_id=str(current_user.id),
+                reason="forbidden",
+            )
             email_template = None
 
     if email_template is None:
@@ -350,6 +365,12 @@ def _load_auto_reply_context(registration_page: Any, assembly_id: uuid.UUID) -> 
             if templates:
                 email_template = templates[0]
         except InsufficientPermissions:
+            logger.debug(
+                "auto_reply_template_list_failed",
+                assembly_id=str(assembly_id),
+                user_id=str(current_user.id),
+                reason="forbidden",
+            )
             email_template = None
 
     problems = auto_reply_readiness_problems(bootstrap.get_flask_uow(), assembly_id)

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -96,6 +96,12 @@ def _image_to_dict(image: RegistrationImage, url_slug: str) -> dict[str, Any]:
         "width": image.width,
         "height": image.height,
         "byte_size": image.byte_size,
+        # Pre-computed accessible labels — built server-side with %(name)s placeholders
+        # so translators can reorder the parts. Concatenating in the template
+        # (e.g. "Delete " + display_name) hard-codes English word order.
+        "aria_label_details": _("Details for %(name)s", name=display_name),
+        "aria_label_copy_snippet": _("Copy <img> snippet for %(name)s", name=display_name),
+        "aria_label_delete": _("Delete %(name)s", name=display_name),
     }
 
 

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -139,6 +139,11 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
         # have no save path so we always keep them read-only regardless of the param.
         edit_mode = request.args.get("edit") == "1" and registration_status != "CLOSED"
 
+        # Sub-section within the Registration tab (stepper). Default to the form editor.
+        active_section = request.args.get("section", "form")
+        if active_section not in ("form", "email", "preview"):
+            active_section = "form"
+
         return render_template(
             "backoffice/assembly_registration.html",
             assembly=nav.assembly,
@@ -159,6 +164,7 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             max_image_upload_mb=get_max_image_upload_mb(),
             allowed_image_formats=sorted(ALLOWED_INPUT_FORMATS),
             edit_mode=edit_mode,
+            active_section=active_section,
         ), 200
     except InsufficientPermissions as e:
         logger.warning(

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -27,7 +27,17 @@ from opendlp.domain.registration_page import (
 from opendlp.entrypoints.blueprints.registration import registration_url, short_url
 from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
 from opendlp.service_layer.assembly_service import get_assembly_nav_context
+from opendlp.service_layer.email_template_service import (
+    assign_auto_reply_template,
+    auto_reply_readiness_problems,
+    create_email_template,
+    get_email_template,
+    list_email_templates,
+    update_email_template,
+)
 from opendlp.service_layer.exceptions import (
+    EmailTemplateInvalid,
+    EmailTemplateNotFoundError,
     ImageQuotaExceeded,
     InsufficientPermissions,
     NotFoundError,
@@ -144,6 +154,11 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
         if active_section not in ("form", "email", "preview"):
             active_section = "form"
 
+        # Auto-reply email data — the template (if assigned) plus readiness problems.
+        email_template, auto_reply_enabled, email_readiness_problems = _load_auto_reply_context(
+            registration_page, assembly_id
+        )
+
         return render_template(
             "backoffice/assembly_registration.html",
             assembly=nav.assembly,
@@ -165,6 +180,9 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             allowed_image_formats=sorted(ALLOWED_INPUT_FORMATS),
             edit_mode=edit_mode,
             active_section=active_section,
+            email_template=email_template,
+            auto_reply_enabled=auto_reply_enabled,
+            email_readiness_problems=email_readiness_problems,
         ), 200
     except InsufficientPermissions as e:
         logger.warning(
@@ -286,6 +304,213 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
         return redirect_preserving_scroll(error_redirect_url)
 
 
+def _load_auto_reply_context(registration_page: Any, assembly_id: uuid.UUID) -> tuple[Any, bool, list[dict[str, str]]]:
+    """Load the auto-reply template and readiness problems for the view route.
+
+    Prefers the template currently assigned to the page. When nothing is assigned
+    (either because the switch is off, or the template was auto-created and not
+    yet turned on) falls back to the first template stored for the assembly, so
+    the editor still shows the pre-created copy for the manager to work on.
+    """
+    email_template = None
+    auto_reply_enabled = False
+    email_readiness_problems: list[dict[str, str]] = []
+    if registration_page is None:
+        return email_template, auto_reply_enabled, email_readiness_problems
+
+    template_id = registration_page.auto_reply_email_template_id
+    if template_id is not None:
+        try:
+            email_template = get_email_template(bootstrap.get_flask_uow(), current_user.id, template_id)
+            auto_reply_enabled = True
+        except (EmailTemplateNotFoundError, InsufficientPermissions):
+            email_template = None
+
+    if email_template is None:
+        try:
+            templates = list_email_templates(bootstrap.get_flask_uow(), current_user.id, assembly_id)
+            if templates:
+                email_template = templates[0]
+        except InsufficientPermissions:
+            email_template = None
+
+    problems = auto_reply_readiness_problems(bootstrap.get_flask_uow(), assembly_id)
+    email_readiness_problems = [{"severity": p.severity.value, "message": p.message} for p in problems]
+    return email_template, auto_reply_enabled, email_readiness_problems
+
+
+def _default_email_template_content() -> dict[str, str]:
+    """Sensible starter values for a freshly-created auto-reply template.
+
+    The name is not shown to respondents; it's a manager-facing label. When we
+    later support multiple templates per assembly we'll expose it in the UI —
+    for now it's a stable default so the domain-level requirement is satisfied
+    without any manager input.
+    """
+    return {
+        "name": _("Registration auto-reply"),
+        "subject": _("Thanks for registering for {{ assembly.title }}"),
+        "body_html": _(
+            "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
+            "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
+            "<p>We'll be in touch about the assembly on {{ assembly.first_assembly_date }}.</p>\n"
+            "<p>Best wishes,<br>The team</p>"
+        ),
+    }
+
+
+def _email_section_url(assembly_id: uuid.UUID, edit: bool = False) -> str:
+    kwargs: dict[str, Any] = {"assembly_id": assembly_id, "section": "email"}
+    if edit:
+        kwargs["edit"] = "1"
+    return url_for("backoffice_registration.view_assembly_registration", **kwargs)
+
+
+def _handle_email_action_create(assembly_id: uuid.UUID) -> str:
+    """Create a stub auto-reply template, assign it, and return the redirect URL (edit mode)."""
+    defaults = _default_email_template_content()
+    template = create_email_template(
+        bootstrap.get_flask_uow(),
+        current_user.id,
+        assembly_id,
+        name=defaults["name"],
+        subject=defaults["subject"],
+        body_html=defaults["body_html"],
+    )
+    assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, template.id)
+    flash(_("Auto-reply email created. Edit it below and click Save."), "success")
+    return _email_section_url(assembly_id, edit=True)
+
+
+def _handle_email_action_enable(assembly_id: uuid.UUID, current_template_id: uuid.UUID | None) -> str:
+    if current_template_id is None:
+        flash(_("Please set up the auto-reply email first."), "warning")
+        return _email_section_url(assembly_id)
+    assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, current_template_id)
+    flash(_("Auto-reply enabled. Respondents will now receive this email after registering."), "success")
+    return _email_section_url(assembly_id)
+
+
+def _handle_email_action_disable(assembly_id: uuid.UUID) -> str:
+    assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, None)
+    flash(_("Auto-reply disabled. Respondents will no longer receive this email."), "success")
+    return _email_section_url(assembly_id)
+
+
+def _handle_email_action_save(assembly_id: uuid.UUID, current_template_id: uuid.UUID | None) -> str:
+    if current_template_id is None:
+        flash(_("There is no auto-reply email to save yet — set one up first."), "warning")
+        return _email_section_url(assembly_id)
+    # Name is intentionally not overwritten here — the UI doesn't expose it yet,
+    # so we keep the value that was set at auto-creation time. Once multi-template
+    # support ships we'll add name to the form and pass it here.
+    update_email_template(
+        bootstrap.get_flask_uow(),
+        current_user.id,
+        current_template_id,
+        subject=request.form.get("template_subject", "").strip(),
+        body_html=request.form.get("template_body_html", ""),
+    )
+    flash(_("Auto-reply email saved."), "success")
+    return _email_section_url(assembly_id)
+
+
+def _dispatch_email_action(action: str, assembly_id: uuid.UUID) -> str:
+    """Run the requested action and return the URL to redirect to.
+
+    Raises the service-layer exceptions the caller handles centrally.
+    """
+    get_assembly_nav_context(bootstrap.get_flask_uow, current_user.id, assembly_id, "")
+    result = get_registration_page_with_source(bootstrap.get_flask_uow(), current_user.id, assembly_id)
+    if result is None:
+        raise RegistrationPageNotFoundError(f"No registration page for assembly {assembly_id}")
+
+    # For enable/save we prefer the id that came in the form (from the switch or editor form) —
+    # this lets the switch turn on a template that isn't yet assigned. Fall back to what's
+    # currently assigned on the page for enable, and require it for save.
+    posted_template_id = request.form.get("template_id", "").strip()
+    posted_id = uuid.UUID(posted_template_id) if posted_template_id else None
+    current_template_id = result[0].auto_reply_email_template_id
+
+    if action == "create":
+        return _handle_email_action_create(assembly_id)
+    if action == "enable":
+        return _handle_email_action_enable(assembly_id, posted_id or current_template_id)
+    if action == "disable":
+        return _handle_email_action_disable(assembly_id)
+    return _handle_email_action_save(assembly_id, posted_id or current_template_id)
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/email/save", methods=["POST"])
+@login_required
+def save_assembly_registration_email(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Create, update, enable or disable the auto-reply email template.
+
+    Action-based POST endpoint:
+
+    - create   → create a template with default copy and assign it as the auto-reply.
+                 Lands the user in edit mode so they can immediately customise it.
+    - save     → update name / subject / body_html on the existing template.
+    - enable   → assign the template as the page's auto-reply (switch on).
+    - disable  → unassign the template (switch off). The template row is kept
+                 so re-enabling later is one click.
+    """
+    action = request.form.get("action", "save")
+    try:
+        return redirect_preserving_scroll(_dispatch_email_action(action, assembly_id))
+    except EmailTemplateInvalid as e:
+        for problem in e.problems:
+            flash(problem, "error")
+        return redirect_preserving_scroll(_email_section_url(assembly_id, edit=True))
+    except EmailTemplateNotFoundError:
+        flash(_("The auto-reply email could not be found."), "error")
+        return redirect_preserving_scroll(_email_section_url(assembly_id))
+    except RegistrationPageNotFoundError:
+        flash(_("Please create a registration page first from the Details tab."), "warning")
+        return redirect(url_for("backoffice.view_assembly", assembly_id=assembly_id))
+    except InsufficientPermissions:
+        flash(_("You don't have permission to modify this assembly"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+    except NotFoundError:
+        flash(_("Assembly not found"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+    except Exception as e:
+        logger.exception(
+            "Save assembly registration email error",
+            assembly_id=str(assembly_id),
+            user_id=str(current_user.id),
+            error=str(e),
+        )
+        flash(_("An error occurred while saving the auto-reply email"), "error")
+        return redirect_preserving_scroll(_email_section_url(assembly_id))
+
+
+def _create_default_auto_reply_template(assembly_id: uuid.UUID) -> None:
+    """Best-effort: seed a default auto-reply email template for a new page.
+
+    Not fatal — if this fails (validation, race, etc.) we log and let the manager
+    hit the "Set up auto-reply" fallback in the UI. Deliberately leaves the
+    template unassigned so the auto-reply switch defaults to OFF.
+    """
+    try:
+        defaults = _default_email_template_content()
+        create_email_template(
+            bootstrap.get_flask_uow(),
+            current_user.id,
+            assembly_id,
+            name=defaults["name"],
+            subject=defaults["subject"],
+            body_html=defaults["body_html"],
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to seed default auto-reply email template",
+            assembly_id=str(assembly_id),
+            user_id=str(current_user.id),
+            error=str(e),
+        )
+
+
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/create", methods=["POST"])
 @login_required
 def create_assembly_registration_page(assembly_id: uuid.UUID) -> ResponseReturnValue:
@@ -293,6 +518,7 @@ def create_assembly_registration_page(assembly_id: uuid.UUID) -> ResponseReturnV
     try:
         uow = bootstrap.get_flask_uow()
         create_registration_page_with_slugs(uow, current_user.id, assembly_id)
+        _create_default_auto_reply_template(assembly_id)
         flash(
             _("Registration page created. URLs have been generated automatically and can be edited below."),
             "success",

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -231,19 +231,32 @@ def _handle_registration_action(action: str, user_id: uuid.UUID, assembly_id: uu
     return _("Registration form saved")
 
 
+_SAVE_ACTIONS = frozenset({"save", "save_and_next"})
+
+
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/save", methods=["POST"])
 @login_required
 def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
-    """Save and publish registration form HTML content."""
+    """Save the registration HTML and/or trigger a lifecycle transition.
+
+    Actions:
+      - save            → update HTML; land back in read-only on the form step.
+      - save_and_next   → update HTML; advance to the auto-reply email step.
+      - publish         → transition TEST → PUBLISHED. No HTML update.
+      - unpublish / close / reopen — deprecated lifecycle transitions kept for
+                          backwards compatibility with older POSTs; the UI no
+                          longer offers them.
+    """
     action = request.form.get("action", "save")
-    # If the user was editing (action="save") and the request fails, keep them in
-    # edit mode so they can fix and retry. Status transitions only fire from
-    # read-only mode (the dropdown is disabled while editing), so they land back
-    # in read-only on error.
-    view_kwargs: dict[str, Any] = {"assembly_id": assembly_id}
-    if action == "save":
-        view_kwargs["edit"] = "1"
-    error_redirect_url = url_for("backoffice_registration.view_assembly_registration", **view_kwargs)
+    # On failure of a save action, land back in edit mode of the form step so the
+    # user can fix and retry. Non-save actions (publish/etc) come from the read-only
+    # preview step, so failure just lands them back on the preview step.
+    error_kwargs: dict[str, Any] = {"assembly_id": assembly_id, "section": "form"}
+    if action in _SAVE_ACTIONS:
+        error_kwargs["edit"] = "1"
+    elif action == "publish":
+        error_kwargs["section"] = "preview"
+    error_redirect_url = url_for("backoffice_registration.view_assembly_registration", **error_kwargs)
     try:
         # Verify user has permission to access this assembly (side effect: raises if unauthorized)
         get_assembly_nav_context(
@@ -253,17 +266,22 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             "",
         )
 
-        html_content = request.form.get("html_content", "")
-
-        # Update HTML content (will raise RegistrationPageNotFoundError if page doesn't exist)
-        uow = bootstrap.get_flask_uow()
-        update_registration_page_html(uow, current_user.id, assembly_id, html_content)
+        # Only save-family actions carry HTML content. Publish/close/etc post from
+        # buttons that don't render the editor, so guard against blanking the HTML.
+        if "html_content" in request.form:
+            uow = bootstrap.get_flask_uow()
+            update_registration_page_html(uow, current_user.id, assembly_id, request.form["html_content"])
 
         flash_message = _handle_registration_action(action, current_user.id, assembly_id)
         flash(flash_message, "success")
-        # Success drops ?edit=1 — the user lands back in read-only.
+        # save_and_next advances to the email step; everything else lands back on the form step.
+        next_section = "email" if action == "save_and_next" else "form"
         return redirect_preserving_scroll(
-            url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly_id)
+            url_for(
+                "backoffice_registration.view_assembly_registration",
+                assembly_id=assembly_id,
+                section=next_section,
+            )
         )
     except RegistrationPageNotReady as e:
         # Show specific validation errors for publishing
@@ -397,7 +415,9 @@ def _handle_email_action_disable(assembly_id: uuid.UUID) -> str:
     return _email_section_url(assembly_id)
 
 
-def _handle_email_action_save(assembly_id: uuid.UUID, current_template_id: uuid.UUID | None) -> str:
+def _handle_email_action_save(
+    assembly_id: uuid.UUID, current_template_id: uuid.UUID | None, *, advance: bool = False
+) -> str:
     if current_template_id is None:
         flash(_("There is no auto-reply email to save yet — set one up first."), "warning")
         return _email_section_url(assembly_id)
@@ -412,6 +432,12 @@ def _handle_email_action_save(assembly_id: uuid.UUID, current_template_id: uuid.
         body_html=request.form.get("template_body_html", ""),
     )
     flash(_("Auto-reply email saved."), "success")
+    if advance:
+        return url_for(
+            "backoffice_registration.view_assembly_registration",
+            assembly_id=assembly_id,
+            section="preview",
+        )
     return _email_section_url(assembly_id)
 
 
@@ -438,7 +464,7 @@ def _dispatch_email_action(action: str, assembly_id: uuid.UUID) -> str:
         return _handle_email_action_enable(assembly_id, posted_id or current_template_id)
     if action == "disable":
         return _handle_email_action_disable(assembly_id)
-    return _handle_email_action_save(assembly_id, posted_id or current_template_id)
+    return _handle_email_action_save(assembly_id, posted_id or current_template_id, advance=(action == "save_and_next"))
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/email/save", methods=["POST"])

--- a/backend/src/opendlp/entrypoints/blueprints/dev.py
+++ b/backend/src/opendlp/entrypoints/blueprints/dev.py
@@ -1268,7 +1268,17 @@ def patterns() -> ResponseReturnValue:
 
     # Get active tab from query parameter, default to 'dropdown'
     active_tab = request.args.get("tab", "dropdown")
-    valid_tabs = ["dropdown", "form", "ajax", "file-upload", "progress", "pagination", "scroll", "floating-alerts"]
+    valid_tabs = [
+        "dropdown",
+        "form",
+        "ajax",
+        "file-upload",
+        "progress",
+        "pagination",
+        "scroll",
+        "floating-alerts",
+        "stepper",
+    ]
     if active_tab not in valid_tabs:
         active_tab = "dropdown"
 

--- a/backend/src/opendlp/entrypoints/blueprints/dev.py
+++ b/backend/src/opendlp/entrypoints/blueprints/dev.py
@@ -32,12 +32,24 @@ from opendlp.service_layer.assembly_service import (
     update_csv_config,
     update_selection_settings,
 )
+from opendlp.service_layer.email_template_service import (
+    assign_auto_reply_template,
+    auto_reply_readiness_problems,
+    create_email_template,
+    delete_email_template,
+    get_email_template,
+    list_email_templates,
+    update_email_template,
+)
 from opendlp.service_layer.exceptions import (
+    EmailTemplateInvalid,
+    EmailTemplateNotFoundError,
     ImageQuotaExceeded,
     InsufficientPermissions,
     InvalidSelection,
     NotFoundError,
     RegistrationImageNotFoundError,
+    RegistrationPageNotFoundError,
 )
 from opendlp.service_layer.permissions import has_global_admin
 from opendlp.service_layer.registration_image_service import (
@@ -128,7 +140,17 @@ def service_docs() -> ResponseReturnValue:
 
     # Get active tab from query parameter, default to 'respondents'
     active_tab = request.args.get("tab", "respondents")
-    valid_tabs = ["respondents", "targets", "config", "selection", "assembly", "registration", "fields", "images"]
+    valid_tabs = [
+        "respondents",
+        "targets",
+        "config",
+        "selection",
+        "assembly",
+        "registration",
+        "fields",
+        "images",
+        "emails",
+    ]
     if active_tab not in valid_tabs:
         active_tab = "respondents"
 
@@ -1036,6 +1058,148 @@ def _handle_get_registration_image_for_serving(uow: Any, params: dict[str, Any])
     return {"status": "success", "found": True, "image": _serialise_image(image)}
 
 
+def _serialise_email_template(template: Any) -> dict[str, Any]:
+    return {
+        "id": str(template.id),
+        "assembly_id": str(template.assembly_id),
+        "name": template.name,
+        "subject": template.subject,
+        "body_html_preview": template.body_html[:300] + "..." if len(template.body_html) > 300 else template.body_html,
+        "body_html_bytes": len(template.body_html.encode("utf-8")),
+        "created_at": template.created_at.isoformat() if template.created_at else None,
+        "updated_at": template.updated_at.isoformat() if template.updated_at else None,
+    }
+
+
+def _handle_create_email_template(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle create_email_template service call."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+    name = params.get("name", "")
+    subject = params.get("subject", "")
+    body_html = params.get("body_html", "")
+    try:
+        template = create_email_template(
+            uow=uow,
+            user_id=current_user.id,
+            assembly_id=assembly_id,
+            name=name,
+            subject=subject,
+            body_html=body_html,
+        )
+        return {"status": "success", "template": _serialise_email_template(template)}
+    except EmailTemplateInvalid as e:
+        return {"status": "error", "error": str(e), "error_type": "EmailTemplateInvalid", "problems": e.problems}
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_list_email_templates(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle list_email_templates service call."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+    try:
+        templates = list_email_templates(uow=uow, user_id=current_user.id, assembly_id=assembly_id)
+        return {
+            "status": "success",
+            "total_count": len(templates),
+            "templates": [_serialise_email_template(t) for t in templates],
+        }
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_get_email_template(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle get_email_template service call."""
+    template_id = uuid.UUID(params["template_id"])
+    try:
+        template = get_email_template(uow=uow, user_id=current_user.id, template_id=template_id)
+        return {"status": "success", "template": _serialise_email_template(template)}
+    except EmailTemplateNotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "EmailTemplateNotFoundError"}
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_update_email_template(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle update_email_template service call."""
+    template_id = uuid.UUID(params["template_id"])
+    try:
+        template = update_email_template(
+            uow=uow,
+            user_id=current_user.id,
+            template_id=template_id,
+            name=params.get("name"),
+            subject=params.get("subject"),
+            body_html=params.get("body_html"),
+        )
+        return {"status": "success", "template": _serialise_email_template(template)}
+    except EmailTemplateInvalid as e:
+        return {"status": "error", "error": str(e), "error_type": "EmailTemplateInvalid", "problems": e.problems}
+    except EmailTemplateNotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "EmailTemplateNotFoundError"}
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_delete_email_template(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle delete_email_template service call."""
+    template_id = uuid.UUID(params["template_id"])
+    try:
+        delete_email_template(uow=uow, user_id=current_user.id, template_id=template_id)
+        return {"status": "success", "deleted_template_id": str(template_id)}
+    except EmailTemplateNotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "EmailTemplateNotFoundError"}
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_assign_auto_reply_template(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle assign_auto_reply_template service call. Pass empty/null template_id to clear."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+    template_id_raw = params.get("template_id")
+    template_id = uuid.UUID(template_id_raw) if template_id_raw else None
+    try:
+        assign_auto_reply_template(
+            uow=uow,
+            user_id=current_user.id,
+            assembly_id=assembly_id,
+            template_id=template_id,
+        )
+        return {
+            "status": "success",
+            "assembly_id": str(assembly_id),
+            "auto_reply_email_template_id": str(template_id) if template_id else None,
+        }
+    except EmailTemplateNotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "EmailTemplateNotFoundError"}
+    except RegistrationPageNotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "RegistrationPageNotFoundError"}
+    except InsufficientPermissions as e:
+        return {"status": "error", "error": str(e), "error_type": "InsufficientPermissions"}
+    except NotFoundError as e:
+        return {"status": "error", "error": str(e), "error_type": "NotFoundError"}
+
+
+def _handle_auto_reply_readiness_problems(uow: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Handle auto_reply_readiness_problems service call."""
+    assembly_id = uuid.UUID(params["assembly_id"])
+    problems = auto_reply_readiness_problems(uow=uow, assembly_id=assembly_id)
+    return {
+        "status": "success",
+        "problem_count": len(problems),
+        "problems": [{"severity": p.severity.value, "message": p.message} for p in problems],
+    }
+
+
 # Mapping of service names to their handler functions
 _SERVICE_HANDLERS: dict[str, Callable[[Any, dict[str, Any]], dict[str, Any]]] = {
     "import_respondents_from_csv": _handle_import_respondents,
@@ -1064,6 +1228,13 @@ _SERVICE_HANDLERS: dict[str, Callable[[Any, dict[str, Any]], dict[str, Any]]] = 
     "set_registration_image_alt": _handle_set_registration_image_alt,
     "list_image_snippets": _handle_list_image_snippets,
     "get_registration_image_for_serving": _handle_get_registration_image_for_serving,
+    "create_email_template": _handle_create_email_template,
+    "list_email_templates": _handle_list_email_templates,
+    "get_email_template": _handle_get_email_template,
+    "update_email_template": _handle_update_email_template,
+    "delete_email_template": _handle_delete_email_template,
+    "assign_auto_reply_template": _handle_assign_auto_reply_template,
+    "auto_reply_readiness_problems": _handle_auto_reply_readiness_problems,
 }
 
 

--- a/backend/static/backoffice/js/alpine-components.js
+++ b/backend/static/backoffice/js/alpine-components.js
@@ -146,8 +146,13 @@ document.addEventListener("alpine:init", function () {
     /**
      * Focus preserve directive
      *
-     * Automatically appends focus hash to href when clicking a link,
-     * if the element has data-focus-id and keyboard focus.
+     * Automatically appends focus hash to href when a **keyboard-initiated**
+     * click activates a link. Gates on `event.detail === 0` — a MouseEvent's
+     * `detail` is the click count for real pointer clicks (>= 1), and is 0
+     * for clicks synthesised from keyboard activation (Enter/Space on a
+     * focused element, or a scripted `.click()` call). This avoids reviving a
+     * visible focus outline on the destination page after a mouse click on
+     * browsers/OSes that focus links on click (Windows Chrome, Firefox).
      *
      * Usage:
      *   <a href="/page" data-focus-id="my-link" x-data x-focus-preserve>Link</a>
@@ -155,7 +160,8 @@ document.addEventListener("alpine:init", function () {
     Alpine.directive("focus-preserve", function (el) {
         el.addEventListener("click", function (event) {
             var focusId = el.dataset.focusId;
-            if (focusId && document.activeElement === el && el.href) {
+            var isKeyboardClick = event.detail === 0;
+            if (isKeyboardClick && focusId && el.href) {
                 event.preventDefault();
                 window.location.href = el.href + "#focus=" + focusId;
             }
@@ -519,16 +525,25 @@ document.addEventListener("alpine:init", function () {
      * - Home: Move to first tab
      * - End: Move to last tab
      *
-     * Uses automatic activation (focus moves and navigates simultaneously).
+     * Activation modes (per the WAI-ARIA APG):
+     * - "automatic" (default): focus movement also activates the tab
+     *   (synthesises a click). Suitable when panel switching is cheap.
+     * - "manual": arrow keys only move focus. The user presses Enter or
+     *   Space to activate the focused tab. Prefer this when tab activation
+     *   causes a full page navigation, so arrow-key exploration doesn't
+     *   trigger reload after reload.
      *
      * Usage:
-     *   <ul role="tablist" x-data="tabsKeyboard()" @keydown="handleKeydown($event)">
+     *   <ul role="tablist"
+     *       x-data="tabsKeyboard({ activation: 'manual' })"
+     *       @keydown="handleKeydown($event)">
      *     <li role="presentation">
      *       <a role="tab" href="?tab=one" tabindex="0">Tab 1</a>
      *     </li>
      *   </ul>
      */
-    Alpine.data("tabsKeyboard", function () {
+    Alpine.data("tabsKeyboard", function (config) {
+        var activation = config && config.activation === "manual" ? "manual" : "automatic";
         return {
             handleKeydown: function (event) {
                 var key = event.key;
@@ -573,8 +588,11 @@ document.addEventListener("alpine:init", function () {
                     event.preventDefault();
                     var targetTab = tabs[newIndex];
                     targetTab.focus();
-                    // Automatic activation - navigate when focus moves
-                    targetTab.click();
+                    if (activation === "automatic") {
+                        // Follow the link when focus moves
+                        targetTab.click();
+                    }
+                    // Manual mode: focus only, wait for Enter/Space to activate
                 }
             },
         };

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -582,7 +582,7 @@
     }
 
     .stepper-link:focus-visible {
-        outline: 2px solid var(--color-focus-ring);
+        outline: 2px solid;
         outline-offset: 4px;
     }
 

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -529,6 +529,131 @@
     }
 
     /* ========================================
+       STEPPER COMPONENT STYLES
+       Numbered step navigation. Same panel-id
+       convention as .tab-bar; visual is
+       numbered pill + label + connector line.
+       ======================================== */
+
+    /* Container: horizontal row of steps */
+    .stepper {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 0;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    /* Each step item — grows so the connector fills the row */
+    .stepper-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex: 0 0 auto;
+    }
+
+    /* All but the last item grow to distribute space */
+    .stepper-item:not(:last-child) {
+        flex: 1 1 auto;
+    }
+
+    /* Connector line drawn as pseudo-element after each item except the last */
+    .stepper-item:not(:last-child)::after {
+        content: '';
+        flex: 1 1 auto;
+        min-width: 24px;
+        height: 1px;
+        margin-left: 8px;
+        background-color: var(--color-borders-dividers);
+    }
+
+    /* The clickable step (anchor) or disabled span */
+    .stepper-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        text-decoration: none;
+        color: inherit;
+        cursor: pointer;
+        border-radius: 12px;
+        padding: 2px 4px;
+    }
+
+    .stepper-link:focus-visible {
+        outline: 2px solid var(--color-focus-ring);
+        outline-offset: 4px;
+    }
+
+    .stepper-link:focus:not(:focus-visible) {
+        outline: none;
+    }
+
+    /* Numbered/iconed pill */
+    .stepper-number {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        border-radius: 16px;
+        font-family: var(--font-body);
+        font-size: 14px;
+        font-weight: 500;
+        line-height: 16px;
+        letter-spacing: 0.1px;
+        color: #FFFFFF;
+        background-color: var(--color-secondary-text);
+        flex-shrink: 0;
+    }
+
+    .stepper-label {
+        font-family: var(--font-body);
+        font-size: 14px;
+        line-height: 20px;
+        letter-spacing: 0.25px;
+        font-weight: 400;
+        color: var(--color-secondary-text);
+        white-space: nowrap;
+    }
+
+    /* States — set on the <li>, inherited into number/label */
+    .stepper-item-active .stepper-number {
+        background-color: var(--color-primary-action);
+    }
+    .stepper-item-active .stepper-label {
+        color: var(--color-headings);
+        font-weight: 500;
+    }
+
+    .stepper-item-done .stepper-number {
+        background-color: var(--color-success-400);
+    }
+    .stepper-item-done .stepper-label {
+        color: var(--color-headings);
+    }
+
+    .stepper-item-error .stepper-number {
+        background-color: var(--color-error-400);
+    }
+    .stepper-item-error .stepper-label {
+        color: var(--color-error-600);
+        font-weight: 500;
+    }
+
+    /* Disabled step (wizard mode locked): dim + no pointer */
+    .stepper-link[aria-disabled="true"] {
+        cursor: not-allowed;
+        opacity: 0.6;
+    }
+
+    /* Hover — only for non-active, non-disabled steps in tabs mode */
+    .stepper-link:not([aria-disabled="true"]):hover .stepper-label {
+        color: var(--color-headings);
+    }
+
+    /* ========================================
        BREADCRUMB COMPONENT STYLES
        Navigation trail with CSS-based separators
        ======================================== */

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -85,18 +85,18 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                      role="tabpanel"
                      aria-labelledby="reg-steps-tab-form"
                      tabindex="0">
-        {# Editor (form) takes the remaining width on the left, Assets panel is a
-           fixed-width column on the right. The panel sits OUTSIDE the form so
-           uploading or deleting an image never submits the HTML editor — unsaved
-           edits in the textarea are preserved. #}
-                    <div class="flex flex-col lg:flex-row gap-6">
-                        <div class="flex-1 min-w-0">
-                            <form method="post"
-                                  action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
-                                  x-data
-                                  x-preserve-scroll-on-submit>
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-
+        {# Editor takes the remaining width on the left, Assets panel is a fixed-width column on the right.
+           The whole two-column layout + CTA row sit inside a single form so the CTAs align to the far
+           right edge of the whole layout (not just the left column's edge) and the sticky assets panel
+           unsticks at the flex-row's bottom rather than trailing past the CTAs. The assets buttons all
+           use type="button" so they never accidentally submit the editor form. #}
+                    <form method="post"
+                          action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
+                          x-data
+                          x-preserve-scroll-on-submit>
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                        <div class="flex flex-col lg:flex-row gap-6">
+                            <div class="flex-1 min-w-0">
             {# Registration Form HTML Section #}
                                 <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
                                     <div class="flex items-center justify-between mb-4">
@@ -167,120 +167,120 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                                     </div>
                                 </section>
+                            </div>
 
-                    {# Bottom CTAs — outside the editor box, right-aligned. Same shape across all three steps:
-                       Read = Edit + Next, Edit = Cancel + Save + Save and next. Primary is the forward action. #}
-                                {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form", edit="1") %}
-                                {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form") %}
-                                {% set next_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="email") %}
-                                {% set save_label = _("Save and Republish") if registration_status == "PUBLISHED" else _("Save") %}
-                                {% set save_next_label = _("Save and Republish and next →") if registration_status == "PUBLISHED" else _("Save and next →") %}
-                                <div class="flex justify-end gap-3 mt-4">
-                                    {% if edit_mode %}
-                                        {{ button(_("Cancel"), variant="secondary", href=view_url) }}
-                                        {{ button(save_label, type="submit", variant="secondary", attrs='name="action" value="save"') }}
-                                        {{ button(save_next_label, type="submit", variant="primary", attrs='name="action" value="save_and_next"') }}
-                                    {% else %}
-                                        {% if registration_status != "CLOSED" %}
-                                            {{ button(_("Edit"), variant="secondary", href=edit_url) }}
-                                        {% endif %}
-                                        {{ button(_("Next →"), variant="primary", href=next_url) }}
-                                    {% endif %}
-                                </div>
-                            </form>
-                        </div>
-
-            {# Assets panel (image library). Lives outside the editor form so its
-               buttons never submit the HTML editor. Initial list is rendered
-               server-side; uploads/deletes mutate the Alpine `images` array in
-               place, no page reload required. #}
-                        <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
-                            <section class="rounded-lg p-6 sticky top-4 w-full"
-                                     style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                                <div class="flex items-center justify-between mb-4">
-                                    <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
-                                    {% set upload_icon %}
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
-                                        </svg>
-                                    {% endset %}
-                                    {{ button(
-                                    _("Upload"),
-                                    variant="tertiary",
-                                    leading_icon=upload_icon,
-                                    attrs='type="button" @click="openImageUploadModal()"'
-                                    ) }}
-                                </div>
+            {# Assets panel (image library). Buttons all use type="button" so they never
+               submit the parent editor form. Initial list is rendered server-side; uploads
+               and deletes mutate the Alpine `images` array in place, no page reload required. #}
+                            <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
+                                <section class="rounded-lg p-6 sticky top-4 w-full"
+                                         style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                    <div class="flex items-center justify-between mb-4">
+                                        <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
+                                        {% set upload_icon %}
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
+                                            </svg>
+                                        {% endset %}
+                                        {{ button(
+                                        _("Upload"),
+                                        variant="tertiary",
+                                        leading_icon=upload_icon,
+                                        attrs='type="button" @click="openImageUploadModal()"'
+                                        ) }}
+                                    </div>
 
                     {# Format / size hint #}
-                                <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
-                                     style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                    </svg>
-                                    <p class="text-body-sm" style="color: var(--color-info-700);">
-                                        {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
-                                    </p>
-                                </div>
+                                    <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
+                                         style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                        <p class="text-body-sm" style="color: var(--color-info-700);">
+                                            {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
+                                        </p>
+                                    </div>
 
                     {# Empty state #}
-                                <template x-if="!images.length">
-                                    <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
-                                        {{ _("No images uploaded yet.") }}
-                                    </p>
-                                </template>
+                                    <template x-if="!images.length">
+                                        <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
+                                            {{ _("No images uploaded yet.") }}
+                                        </p>
+                                    </template>
 
                     {# Image list #}
-                                <ul class="space-y-2" x-show="images.length" x-cloak>
-                                    <template x-for="image in images" :key="image.id">
-                                        <li class="rounded-md px-3 py-2 flex items-center justify-between"
-                                            style="background-color: var(--color-subtle-background-panels);">
-                                            <a :href="image.public_url"
-                                               :title="image.alt || image.file_name"
-                                               target="_blank"
-                                               rel="noopener"
-                                               class="text-body-sm truncate flex-1 mr-2"
-                                               style="color: var(--color-body-text);"
-                                               x-text="image.display_name"></a>
-                                            <div class="flex items-center gap-1 flex-shrink-0">
+                                    <ul class="space-y-2" x-show="images.length" x-cloak>
+                                        <template x-for="image in images" :key="image.id">
+                                            <li class="rounded-md px-3 py-2 flex items-center justify-between"
+                                                style="background-color: var(--color-subtle-background-panels);">
+                                                <a :href="image.public_url"
+                                                   :title="image.alt || image.file_name"
+                                                   target="_blank"
+                                                   rel="noopener"
+                                                   class="text-body-sm truncate flex-1 mr-2"
+                                                   style="color: var(--color-body-text);"
+                                                   x-text="image.display_name"></a>
+                                                <div class="flex items-center gap-1 flex-shrink-0">
                                     {# Image details / edit alt text #}
-                                                <button type="button"
-                                                        @click="openImageDetailsModal(image)"
-                                                        class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                        style="color: var(--color-secondary-text);"
-                                                        :aria-label="'{{ _('Details for') }} ' + image.display_name">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                                    </svg>
-                                                </button>
+                                                    <button type="button"
+                                                            @click="openImageDetailsModal(image)"
+                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                            style="color: var(--color-secondary-text);"
+                                                            :aria-label="'{{ _('Details for') }} ' + image.display_name">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                        </svg>
+                                                    </button>
                                     {# Copy <img> snippet to clipboard #}
-                                                <button type="button"
-                                                        @click="copyImageSnippet(image)"
-                                                        class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                        style="color: var(--color-secondary-text);"
-                                                        :aria-label="'{{ _('Copy <img> snippet for') }} ' + image.display_name">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                    </svg>
-                                                </button>
+                                                    <button type="button"
+                                                            @click="copyImageSnippet(image)"
+                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                            style="color: var(--color-secondary-text);"
+                                                            :aria-label="'{{ _('Copy <img> snippet for') }} ' + image.display_name">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                        </svg>
+                                                    </button>
                                     {# Delete #}
-                                                <button type="button"
-                                                        @click="deleteImage(image)"
-                                                        :disabled="imageBeingDeletedId === image.id"
-                                                        class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                        style="color: var(--color-secondary-text);"
-                                                        :aria-label="'{{ _('Delete') }} ' + image.display_name">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
-                                                    </svg>
-                                                </button>
-                                            </div>
-                                        </li>
-                                    </template>
-                                </ul>
-                            </section>
-                        </aside>
-                    </div>
+                                                    <button type="button"
+                                                            @click="deleteImage(image)"
+                                                            :disabled="imageBeingDeletedId === image.id"
+                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                            style="color: var(--color-secondary-text);"
+                                                            :aria-label="'{{ _('Delete') }} ' + image.display_name">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                                                        </svg>
+                                                    </button>
+                                                </div>
+                                            </li>
+                                        </template>
+                                    </ul>
+                                </section>
+                            </aside>
+                        </div>
+
+                        {# Bottom CTAs — sit below the whole two-column layout so they align to the far right
+                           of the page (past the sticky aside), not the left column's edge. Same shape across
+                           all three stepper steps. #}
+                        {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form", edit="1") %}
+                        {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form") %}
+                        {% set next_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="email") %}
+                        {% set save_label = _("Save and Republish") if registration_status == "PUBLISHED" else _("Save") %}
+                        {% set save_next_label = _("Save and Republish and next →") if registration_status == "PUBLISHED" else _("Save and next →") %}
+                        <div class="flex justify-end gap-3 mt-4">
+                            {% if edit_mode %}
+                                {{ button(_("Cancel"), variant="secondary", href=view_url) }}
+                                {{ button(save_label, type="submit", variant="secondary", attrs='name="action" value="save"') }}
+                                {{ button(save_next_label, type="submit", variant="primary", attrs='name="action" value="save_and_next"') }}
+                            {% else %}
+                                {% if registration_status != "CLOSED" %}
+                                    {{ button(_("Edit"), variant="secondary", href=edit_url) }}
+                                {% endif %}
+                                {{ button(_("Next →"), variant="primary", href=next_url) }}
+                            {% endif %}
+                        </div>
+                    </form>
                 </div>
             {% endif %}
 
@@ -345,17 +345,17 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         </div>
 
                         {# Two-box layout mirroring the form section: editor on the left (2/3), variables reference
-                           on the right (1/3, sticky). The two panels start at the same vertical offset, which is
-                           pushed down together by the send toggle above. #}
-                        <div class="flex flex-col lg:flex-row gap-6">
-                            <div class="flex-1 min-w-0">
-                                <form method="post"
-                                      action="{{ email_save_url }}"
-                                      x-data
-                                      x-preserve-scroll-on-submit>
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                                    <input type="hidden" name="action" value="save" />
-
+                           on the right (1/3, sticky). The form wraps both columns and the CTA row so the CTAs
+                           align to the far right of the whole layout and the sticky aside unsticks at the
+                           flex-row's bottom. #}
+                        <form method="post"
+                              action="{{ email_save_url }}"
+                              x-data
+                              x-preserve-scroll-on-submit>
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                            <input type="hidden" name="action" value="save" />
+                            <div class="flex flex-col lg:flex-row gap-6">
+                                <div class="flex-1 min-w-0">
                                     <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
                                         <div class="flex items-center justify-between mb-4 gap-4">
                                             <h2 class="text-heading-lg" style="color: var(--color-headings);">
@@ -393,75 +393,76 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                                         </div>
                                     </section>
+                                </div>
 
-                    {# Bottom CTAs — mirror the S1 pattern: outside the editor box, right-aligned. #}
-                                    {% set email_edit_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email', edit='1') %}
-                                    {% set email_view_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
-                                    {% set preview_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='preview') %}
-                                    <div class="flex justify-end gap-3 mt-4">
-                                        {% if edit_mode %}
-                                            {{ button(_("Cancel"), variant="secondary", href=email_view_url) }}
-                                            {{ button(_("Save"), type="submit", variant="secondary", attrs='name="action" value="save"') }}
-                                            {{ button(_("Save and next →"), type="submit", variant="primary", attrs='name="action" value="save_and_next"') }}
-                                        {% else %}
-                                            {{ button(_("Edit"), variant="secondary", href=email_edit_url) }}
-                                            {{ button(_("Next →"), variant="primary", href=preview_url) }}
-                                        {% endif %}
-                                    </div>
-                                </form>
+                                {# Variables reference sidebar — styled like the Assets panel from the form section. #}
+                                <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
+                                    <section class="rounded-lg p-6 sticky top-4 w-full"
+                                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                        <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
+                                            {{ _("Available variables") }}
+                                        </h2>
+                                        <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                            {{ _("Click a variable to select it, then copy and paste into the subject or body. Missing values render as an empty string.") }}
+                                        </p>
+                                        {% set variables = [
+                                        {"expr": "{{ assembly.title }}", "label": _("Assembly title")},
+                                        {"expr": "{{ assembly.question }}", "label": _("Assembly question")},
+                                        {"expr": "{{ assembly.first_assembly_date }}", "label": _("First assembly date (ISO)")},
+                                        {"expr": "{{ respondent.first_name }}", "label": _("Respondent first name")},
+                                        {"expr": "{{ respondent.first_name_or_friend }}", "label": _("First name, or 'Friend' as a fallback")},
+                                        {"expr": "{{ respondent.full_name }}", "label": _("Respondent full name")},
+                                        {"expr": "{{ respondent.email }}", "label": _("Respondent email address")}
+                                        ] %}
+                                        <ul class="space-y-3">
+                                            {% for variable in variables %}
+                                                <li>
+                                                    <label for="variable-{{ loop.index0 }}"
+                                                           class="text-body-sm font-medium block mb-1"
+                                                           style="color: var(--color-headings);">
+                                                        {{ variable.label }}
+                                                    </label>
+                                                    <div class="flex gap-2">
+                                                        <input type="text"
+                                                               id="variable-{{ loop.index0 }}"
+                                                               readonly
+                                                               value="{{ variable.expr }}"
+                                                               @click="$event.target.select()"
+                                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                                        <button type="button"
+                                                                @click="copyToClipboard('{{ variable.expr }}', '{{ _('Variable copied to clipboard') }}')"
+                                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                                                aria-label="{{ _('Copy %(label)s variable', label=variable.label) }}">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                            </svg>
+                                                        </button>
+                                                    </div>
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    </section>
+                                </aside>
                             </div>
 
-                            {# Variables reference sidebar — styled like the Assets panel from the form section. #}
-                            <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
-                                <section class="rounded-lg p-6 sticky top-4 w-full"
-                                         style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                                    <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
-                                        {{ _("Available variables") }}
-                                    </h2>
-                                    <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                        {{ _("Click a variable to select it, then copy and paste into the subject or body. Missing values render as an empty string.") }}
-                                    </p>
-                                    {% set variables = [
-                                    {"expr": "{{ assembly.title }}", "label": _("Assembly title")},
-                                    {"expr": "{{ assembly.question }}", "label": _("Assembly question")},
-                                    {"expr": "{{ assembly.first_assembly_date }}", "label": _("First assembly date (ISO)")},
-                                    {"expr": "{{ respondent.first_name }}", "label": _("Respondent first name")},
-                                    {"expr": "{{ respondent.first_name_or_friend }}", "label": _("First name, or 'Friend' as a fallback")},
-                                    {"expr": "{{ respondent.full_name }}", "label": _("Respondent full name")},
-                                    {"expr": "{{ respondent.email }}", "label": _("Respondent email address")}
-                                    ] %}
-                                    <ul class="space-y-3">
-                                        {% for variable in variables %}
-                                            <li>
-                                                <label for="variable-{{ loop.index0 }}"
-                                                       class="text-body-sm font-medium block mb-1"
-                                                       style="color: var(--color-headings);">
-                                                    {{ variable.label }}
-                                                </label>
-                                                <div class="flex gap-2">
-                                                    <input type="text"
-                                                           id="variable-{{ loop.index0 }}"
-                                                           readonly
-                                                           value="{{ variable.expr }}"
-                                                           @click="$event.target.select()"
-                                                           class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
-                                                           style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
-                                                    <button type="button"
-                                                            @click="copyToClipboard('{{ variable.expr }}', '{{ _('Variable copied to clipboard') }}')"
-                                                            class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                            style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
-                                                            aria-label="{{ _('Copy %(label)s variable', label=variable.label) }}">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                        </svg>
-                                                    </button>
-                                                </div>
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                </section>
-                            </aside>
-                        </div>
+                            {# Bottom CTAs — sit below both columns and align to the far right of the layout,
+                               matching the S1 pattern. #}
+                            {% set email_edit_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email', edit='1') %}
+                            {% set email_view_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
+                            {% set preview_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='preview') %}
+                            <div class="flex justify-end gap-3 mt-4">
+                                {% if edit_mode %}
+                                    {{ button(_("Cancel"), variant="secondary", href=email_view_url) }}
+                                    {{ button(_("Save"), type="submit", variant="secondary", attrs='name="action" value="save"') }}
+                                    {{ button(_("Save and next →"), type="submit", variant="primary", attrs='name="action" value="save_and_next"') }}
+                                {% else %}
+                                    {{ button(_("Edit"), variant="secondary", href=email_edit_url) }}
+                                    {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                                {% endif %}
+                            </div>
+                        </form>
                     {% endif %}
                 </div>
             {% endif %}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -454,11 +454,14 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             </div>
 
                             {# Bottom CTAs — sit below both columns and align to the far right of the layout,
-                               matching the S1 pattern. #}
+                               matching the S1 pattern. Back sits on the far left (mr-auto pushes it away
+                               from the right-side group). #}
                             {% set email_edit_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email', edit='1') %}
                             {% set email_view_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
                             {% set preview_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='preview') %}
+                            {% set back_to_form_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='form') %}
                             <div class="flex justify-end gap-3 mt-4">
+                                <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
                                 {% if edit_mode %}
                                     {{ button(_("Cancel"), variant="secondary", href=email_view_url) }}
                                     {{ button(_("Save"), type="submit", variant="secondary", attrs='name="action" value="save"') }}
@@ -540,10 +543,13 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         {% endif %}
                     </section>
 
-                    {# Bottom CTA — Publish is the primary happy-path action in TEST. Once PUBLISHED the badge on
-                       step 1 conveys the state; CLOSED is terminal (no Reopen in the UI). #}
-                    {% if registration_status == "TEST" and registration_page %}
-                        <div class="flex justify-end gap-3 mt-4">
+                    {# Bottom CTAs — Back on the left is always available; Publish is the primary happy-path
+                       action in TEST. Once PUBLISHED the badge above the stepper conveys the state;
+                       CLOSED is terminal (no Reopen in the UI). #}
+                    {% set back_to_email_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
+                    <div class="flex justify-end gap-3 mt-4">
+                        <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_email_url) }}</span>
+                        {% if registration_status == "TEST" and registration_page %}
                             <form method="post"
                                   action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
                                   x-data
@@ -552,8 +558,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 <input type="hidden" name="action" value="publish" />
                                 {{ button(_("Publish"), type="submit", variant="primary") }}
                             </form>
-                        </div>
-                    {% endif %}
+                        {% endif %}
+                    </div>
                 </div>
             {% endif %}
         {% endif %}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -211,62 +211,30 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                         ) }}
 
                     {# Footer: review the form + save edits. Status transitions live in the header dropdown.
-                       The primary action slot toggles between Edit (read-only, default) and Save/Cancel (edit_mode). #}
-                                        <div class="flex justify-end gap-3">
-                                            {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, edit="1") %}
-                                            {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id) %}
-                        {# Preview / Share lives next to Save — "view what you just edited" pairs with "save it" #}
-                                            {% if registration_status == "TEST" %}
-                                                {% set eye_icon %}
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                                                    </svg>
-                                                {% endset %}
-                                                {{ button(
-                                                _("Preview and Test Responses"),
-                                                variant="tertiary",
-                                                leading_icon=eye_icon,
-                                                attrs='@click="openPreviewModal()"'
-                                                ) }}
+                       The primary action slot toggles between Edit (read-only, default) and Save/Cancel (edit_mode).
+                       Share/Preview lives on the Preview-and-publish step of the stepper, not next to Save. #}
+                                        {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, edit="1") %}
+                                        {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id) %}
+                                        {% if registration_status == "TEST" %}
+                                            <div class="flex justify-end gap-3">
                                                 {% if edit_mode %}
                                                     {{ button(_("Cancel"), variant="secondary", href=view_url) }}
                                                     {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
                                                 {% else %}
                                                     {{ button(_("Edit"), variant="primary", href=edit_url) }}
                                                 {% endif %}
-                                            {% else %}
-                                                {% set link_icon %}
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                                                    </svg>
-                                                {% endset %}
-                                                {% if registration_status == "PUBLISHED" %}
-                                                    {{ button(
-                                                    _("Share Form"),
-                                                    variant="tertiary",
-                                                    leading_icon=link_icon,
-                                                    attrs='@click="openPreviewModal()"'
-                                                    ) }}
-                                                    {% if edit_mode %}
-                                                        {{ button(_("Cancel"), variant="secondary", href=view_url) }}
-                                                        {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
-                                                    {% else %}
-                                                        {{ button(_("Edit"), variant="primary", href=edit_url) }}
-                                                    {% endif %}
+                                            </div>
+                                        {% elif registration_status == "PUBLISHED" %}
+                                            <div class="flex justify-end gap-3">
+                                                {% if edit_mode %}
+                                                    {{ button(_("Cancel"), variant="secondary", href=view_url) }}
+                                                    {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
                                                 {% else %}
-                                {# CLOSED: no save (form is redirecting) and no Edit — admins must reopen first. #}
-                                                    {{ button(
-                                                    _("Share Form"),
-                                                    variant="tertiary",
-                                                    leading_icon=link_icon,
-                                                    disabled=true,
-                                                    aria_label=_("Registration is closed — the form URL redirects to the closed page"),
-                                                    attrs='title="' ~ _("Registration is closed — the form URL redirects to the closed page") ~ '"'
-                                                    ) }}
+                                                    {{ button(_("Edit"), variant="primary", href=edit_url) }}
                                                 {% endif %}
-                                            {% endif %}
-                                        </div>
+                                            </div>
+                                        {% endif %}
+                                        {# CLOSED: no save (form is redirecting) and no Edit — admins must reopen first. #}
                                     </div>
                                 </section>
                             </form>
@@ -547,15 +515,84 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 <div id="reg-steps-panel-preview"
                      role="tabpanel"
                      aria-labelledby="reg-steps-tab-preview"
-                     tabindex="0"
-                     class="rounded-lg p-6"
-                     style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                    <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">
-                        {{ _("Preview and publish") }}
-                    </h2>
-                    <p class="text-body-md" style="color: var(--color-secondary-text);">
-                        {{ _("Coming soon — a combined preview of the registration form and the auto-reply email, together with the publish controls.") }}
-                    </p>
+                     tabindex="0">
+                    <section class="rounded-lg p-6"
+                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                        <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
+                            {{ _("Preview and publish") }}
+                        </h2>
+
+                        {# Status banner — mirrors what the modal used to show in TEST, and adds an equivalent
+                           notice for the CLOSED state where the URL now points to the closed-page redirect. #}
+                        {% if registration_status == "TEST" %}
+                            <div class="rounded-lg p-4 mb-6"
+                                 style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
+                                <p class="text-body-sm" style="color: var(--color-warning-600);">
+                                    {{ _("The form is in test mode. Submissions made via these URLs are recorded as test submissions and will not enter the selection pool.") }}
+                                </p>
+                            </div>
+                        {% elif registration_status == "CLOSED" %}
+                            <div class="rounded-lg p-4 mb-6"
+                                 style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
+                                <p class="text-body-sm" style="color: var(--color-error-600);">
+                                    {{ _("Registration is closed — visitors who follow these URLs are redirected to the closed page.") }}
+                                </p>
+                            </div>
+                        {% endif %}
+
+                        {% if registration_page %}
+                            <div class="space-y-6">
+                                {# Registration URL #}
+                                {{ readonly_url_display(
+                                label=_("Registration URL"),
+                                hint=_("The URL for your registration form"),
+                                url=registration_url
+                                ) }}
+
+                                {# Short URL — only if configured #}
+                                {% if registration_page.short_url_slug %}
+                                    {{ readonly_url_display(
+                                    label=_("Short URL"),
+                                    hint=_("A shorter URL for QR codes and paper invitations"),
+                                    url=short_url
+                                    ) }}
+                                {% endif %}
+
+                                {# QR Code — only when short URL is configured #}
+                                {% if qr_code_data_url %}
+                                    <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers);">
+                                        <h3 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("QR Code") }}</h3>
+                                        <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                            {{ _("Use this QR code on paper invitations") }}
+                                        </p>
+
+                                        <div class="flex items-start gap-6">
+                                            <div class="flex-shrink-0 p-4 rounded-lg" style="background-color: white; border: 1px solid var(--color-borders-dividers);">
+                                                <img src="{{ qr_code_data_url }}"
+                                                     alt="{{ _('QR code for registration page') }}"
+                                                     class="w-40 h-40" />
+                                            </div>
+
+                                            <div class="flex flex-col gap-2">
+                                                <a href="{{ url_for('backoffice_registration.download_registration_qr_code', assembly_id=assembly.id) }}"
+                                                   class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-button-md transition-colors"
+                                                   style="background-color: var(--color-button-secondary-bg); color: var(--color-button-secondary-text); border: 1px solid var(--color-borders-dividers);"
+                                                   download>
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                                    </svg>
+                                                    {{ _("Download QR Code") }}
+                                                </a>
+                                                <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                                                    {{ _("PNG format, 400x400 pixels") }}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    </section>
                 </div>
             {% endif %}
         {% endif %}
@@ -620,114 +657,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     </div>
                 </div>
             </template>
-
-        {# Preview / Share Modal - rendered for TEST and PUBLISHED (CLOSED button is disabled) #}
-            {% if registration_status in ("TEST", "PUBLISHED") and registration_page %}
-                {% set preview_modal_title = _("Preview and Test Responses") if registration_status == "TEST" else _("Share Form") %}
-                <template x-if="previewModalOpen">
-                    <div x-cloak>
-                    {# Backdrop overlay #}
-                        <div class="fixed inset-0 z-40"
-                             style="background-color: rgba(0, 0, 0, 0.5)"
-                             @click="closePreviewModal()"
-                             @keydown.escape.window="closePreviewModal()"></div>
-                    {# Modal panel #}
-                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                             role="dialog"
-                             aria-modal="true"
-                             aria-labelledby="preview-modal-title">
-                            <div class="pointer-events-auto w-full max-w-2xl mx-4 rounded-lg shadow-xl overflow-hidden"
-                                 style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
-                                 @click.stop>
-                            {# Header #}
-                                <div class="px-6 py-4 flex items-center justify-between"
-                                     style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                    <h2 id="preview-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
-                                        {{ preview_modal_title }}
-                                    </h2>
-                                    <button type="button"
-                                            @click="closePreviewModal()"
-                                            class="p-2 rounded-lg transition-colors hover:bg-gray-100"
-                                            style="color: var(--color-secondary-text);"
-                                            aria-label="{{ _('Close') }}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                        </svg>
-                                    </button>
-                                </div>
-                            {# Content #}
-                                <div class="px-6 py-4 max-h-[70vh] overflow-y-auto">
-                                {# Test submission notice - TEST state only #}
-                                    {% if registration_status == "TEST" %}
-                                        <div class="rounded-lg p-4 mb-6"
-                                             style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
-                                            <p class="text-body-sm" style="color: var(--color-warning-600);">
-                                                {{ _("The form is in test mode. Submissions made via these URLs are recorded as test submissions and will not enter the selection pool.") }}
-                                            </p>
-                                        </div>
-                                    {% endif %}
-
-                                    <div class="space-y-6">
-                                    {# Registration URL #}
-                                        {{ readonly_url_display(
-                                        label=_("Registration URL"),
-                                        hint=_("The URL for your registration form"),
-                                        url=registration_url
-                                        ) }}
-
-                                    {# Short URL - only if configured #}
-                                        {% if registration_page.short_url_slug %}
-                                            {{ readonly_url_display(
-                                            label=_("Short URL"),
-                                            hint=_("A shorter URL for QR codes and paper invitations"),
-                                            url=short_url
-                                            ) }}
-                                        {% endif %}
-
-                                    {# QR Code - only when short URL is configured #}
-                                        {% if qr_code_data_url %}
-                                            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers);">
-                                                <h3 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("QR Code") }}</h3>
-                                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                                    {{ _("Use this QR code on paper invitations") }}
-                                                </p>
-
-                                                <div class="flex items-start gap-6">
-                                                    <div class="flex-shrink-0 p-4 rounded-lg" style="background-color: white; border: 1px solid var(--color-borders-dividers);">
-                                                        <img src="{{ qr_code_data_url }}"
-                                                             alt="{{ _('QR code for registration page') }}"
-                                                             class="w-40 h-40" />
-                                                    </div>
-
-                                                    <div class="flex flex-col gap-2">
-                                                        <a href="{{ url_for('backoffice_registration.download_registration_qr_code', assembly_id=assembly.id) }}"
-                                                           class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-button-md transition-colors"
-                                                           style="background-color: var(--color-button-secondary-bg); color: var(--color-button-secondary-text); border: 1px solid var(--color-borders-dividers);"
-                                                           download>
-                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                                                            </svg>
-                                                            {{ _("Download QR Code") }}
-                                                        </a>
-                                                        <p class="text-body-sm" style="color: var(--color-secondary-text);">
-                                                            {{ _("PNG format, 400x400 pixels") }}
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        {% endif %}
-                                    </div>
-                                </div>
-                            {# Footer #}
-                                <div class="px-6 py-3 flex gap-2 justify-end"
-                                     style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
-                                    {{ button(_("Close"), variant="secondary", attrs='@click="closePreviewModal()"') }}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </template>
-            {% endif %}
 
         {# Image Upload Modal #}
             <template x-if="imageUploadModalOpen">
@@ -1002,7 +931,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     skeletonLoading: false,
                     skeletonModalOpen: false,
                     skeletonHtml: '',
-                    previewModalOpen: false,
                     toastVisible: false,
                     toastMessage: '',
                     toastType: 'success',
@@ -1062,14 +990,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                     closeSkeletonModal() {
                         this.skeletonModalOpen = false;
-                    },
-
-                    openPreviewModal() {
-                        this.previewModalOpen = true;
-                    },
-
-                    closePreviewModal() {
-                        this.previewModalOpen = false;
                     },
 
                     copySkeletonToClipboard() {

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -496,38 +496,46 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                         {{ _("Available variables") }}
                                     </h2>
                                     <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                        {{ _("Paste any of these into the subject or body. Missing values render as an empty string.") }}
+                                        {{ _("Click a variable to select it, then copy and paste into the subject or body. Missing values render as an empty string.") }}
                                     </p>
-                                    <dl class="text-body-sm space-y-3" style="color: var(--color-body-text);">
-                                        <div>
-                                            <dt class="font-mono">{{ '{{ assembly.title }}' }}</dt>
-                                            <dd style="color: var(--color-secondary-text);">{{ _("Assembly title") }}</dd>
-                                        </div>
-                                        <div>
-                                            <dt class="font-mono">{{ '{{ assembly.question }}' }}</dt>
-                                            <dd style="color: var(--color-secondary-text);">{{ _("Assembly question") }}</dd>
-                                        </div>
-                                        <div>
-                                            <dt class="font-mono">{{ '{{ assembly.first_assembly_date }}' }}</dt>
-                                            <dd style="color: var(--color-secondary-text);">{{ _("First assembly date (ISO)") }}</dd>
-                                        </div>
-                                        <div>
-                                            <dt class="font-mono">{{ '{{ respondent.first_name }}' }}</dt>
-                                            <dd style="color: var(--color-secondary-text);">{{ _("Respondent first name") }}</dd>
-                                        </div>
-                                        <div>
-                                            <dt class="font-mono">{{ '{{ respondent.first_name_or_friend }}' }}</dt>
-                                            <dd style="color: var(--color-secondary-text);">{{ _("First name, or 'Friend' as a fallback") }}</dd>
-                                        </div>
-                                        <div>
-                                            <dt class="font-mono">{{ '{{ respondent.full_name }}' }}</dt>
-                                            <dd style="color: var(--color-secondary-text);">{{ _("Respondent full name") }}</dd>
-                                        </div>
-                                        <div>
-                                            <dt class="font-mono">{{ '{{ respondent.email }}' }}</dt>
-                                            <dd style="color: var(--color-secondary-text);">{{ _("Respondent email address") }}</dd>
-                                        </div>
-                                    </dl>
+                                    {% set variables = [
+                                    {"expr": "{{ assembly.title }}", "label": _("Assembly title")},
+                                    {"expr": "{{ assembly.question }}", "label": _("Assembly question")},
+                                    {"expr": "{{ assembly.first_assembly_date }}", "label": _("First assembly date (ISO)")},
+                                    {"expr": "{{ respondent.first_name }}", "label": _("Respondent first name")},
+                                    {"expr": "{{ respondent.first_name_or_friend }}", "label": _("First name, or 'Friend' as a fallback")},
+                                    {"expr": "{{ respondent.full_name }}", "label": _("Respondent full name")},
+                                    {"expr": "{{ respondent.email }}", "label": _("Respondent email address")}
+                                    ] %}
+                                    <ul class="space-y-3">
+                                        {% for variable in variables %}
+                                            <li>
+                                                <label for="variable-{{ loop.index0 }}"
+                                                       class="text-body-sm font-medium block mb-1"
+                                                       style="color: var(--color-headings);">
+                                                    {{ variable.label }}
+                                                </label>
+                                                <div class="flex gap-2">
+                                                    <input type="text"
+                                                           id="variable-{{ loop.index0 }}"
+                                                           readonly
+                                                           value="{{ variable.expr }}"
+                                                           @click="$event.target.select()"
+                                                           class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                                                           style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                                    <button type="button"
+                                                            @click="copyToClipboard('{{ variable.expr }}', '{{ _('Variable copied to clipboard') }}')"
+                                                            class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                            style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                                            aria-label="{{ _('Copy %(label)s variable', label=variable.label) }}">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                        </svg>
+                                                    </button>
+                                                </div>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
                                 </section>
                             </aside>
                         </div>

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -80,6 +80,36 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
             preserve_scroll=true
             ) }}
 
+            {# Whole-artifact status. Sits below the stepper so it applies to all three steps —
+               the form HTML, the auto-reply email, and the preview all share this state. #}
+            {% if registration_status == "TEST" %}
+                <div class="rounded-lg p-4 mb-6"
+                     role="alert"
+                     style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
+                    <p class="text-body-md" style="color: var(--color-warning-600);">
+                        <span class="font-semibold">⚠️ {{ _("Test mode") }}:</span>
+                        {{ _("Submissions are recorded as test entries and don't enter the selection pool. Publish the registration when you're ready to go live.") }}
+                    </p>
+                </div>
+            {% elif registration_status == "CLOSED" %}
+                <div class="rounded-lg p-4 mb-6"
+                     role="alert"
+                     style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
+                    <p class="text-body-md" style="color: var(--color-error-600);">
+                        <span class="font-semibold">⛔ {{ _("Registration closed") }}:</span>
+                        {{ _("Visitors who follow the form URL are redirected to the closed page.") }}
+                    </p>
+                </div>
+            {% elif registration_status == "PUBLISHED" %}
+                <div class="mb-6">
+                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
+                          style="background-color: var(--color-success-100); color: var(--color-success-600);">
+                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-success-400);"></span>
+                        {{ _("Published") }}
+                    </span>
+                </div>
+            {% endif %}
+
             {% if active_section == "form" %}
                 <div id="reg-steps-panel-form"
                      role="tabpanel"
@@ -100,37 +130,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
             {# Registration Form HTML Section #}
                                 <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
                                     <div class="flex items-center justify-between mb-4">
-                                        <div class="flex items-center gap-3">
-                                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration Form HTML") }}</h2>
-
-                        {# Publication status indicator (tri-state). Wrapped in a fixed-min-width slot so the
-                           variable badge width ("Test" / "Published" / "Closed") doesn't shift everything to
-                           its right as the status changes. #}
-                                            <div class="inline-flex items-center" style="min-width: 7rem;">
-                                                {% if registration_status == "PUBLISHED" %}
-                                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                                          style="background-color: var(--color-success-100); color: var(--color-success-600);">
-                                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-success-400);"></span>
-                                                        {{ _("Published") }}
-                                                    </span>
-                                                {% elif registration_status == "CLOSED" %}
-                                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                                          style="background-color: var(--color-error-100); color: var(--color-error-600);">
-                                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-error-400);"></span>
-                                                        {{ _("Closed") }}
-                                                    </span>
-                                                {% else %}
-                                {# TEST status (default) #}
-                                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                                          style="background-color: var(--color-warning-100); color: var(--color-warning-600);">
-                                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-warning-400);"></span>
-                                                        {{ _("Test") }}
-                                                    </span>
-                                                {% endif %}
-                                            </div>
-
-                                        </div>
-                     {# Header right: editorial helper only (status controls live on the left next to the badge) #}
+                                        <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration Form HTML") }}</h2>
+                     {# Header right: editorial helper — status is shown globally above the stepper now. #}
                                         <div class="flex items-center gap-2">
                                             {% set code_icon %}
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -324,27 +325,20 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             </form>
                         </section>
                     {% else %}
-                        {# Send-auto-reply toggle: outside both boxes, top-left, auto-submits on change so it feels
-                           like a proper toggle. The `action` field flips based on the current state, so the checkbox
-                           value doesn't need to be read; toggling always inverts the state. #}
-                        <div class="flex justify-start mb-4">
-                            <form method="post"
-                                  action="{{ email_save_url }}"
-                                  x-data
-                                  x-preserve-scroll-on-submit
-                                  class="px-2 py-1">
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                                <input type="hidden" name="action" value="{{ 'disable' if auto_reply_enabled else 'enable' }}" />
-                                {# Tell the backend which template to enable — the currently-displayed one. #}
-                                <input type="hidden" name="template_id" value="{{ email_template.id }}" />
-                                {{ checkbox(
-                                name="auto_reply_enabled",
-                                label=_("Send auto-reply email"),
-                                checked=auto_reply_enabled,
-                                attrs='@change="$el.form.submit()"'
-                                ) }}
-                            </form>
-                        </div>
+                        {# Send-auto-reply toggle form. Sits as a sibling of the editor's save form (nested forms
+                           are illegal HTML) and the checkbox in the section header below binds to it via the
+                           HTML5 `form="auto-reply-toggle"` attribute. The `action` field flips based on the
+                           current state, so toggling always inverts. #}
+                        <form id="auto-reply-toggle"
+                              method="post"
+                              action="{{ email_save_url }}"
+                              x-data
+                              x-preserve-scroll-on-submit
+                              style="display: none;">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                            <input type="hidden" name="action" value="{{ 'disable' if auto_reply_enabled else 'enable' }}" />
+                            <input type="hidden" name="template_id" value="{{ email_template.id }}" />
+                        </form>
 
                         {# Two-box layout mirroring the form section: editor on the left (2/3), variables reference
                            on the right (1/3, sticky). The form wraps both columns and the CTA row so the CTAs
@@ -363,6 +357,14 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             <h2 class="text-heading-lg" style="color: var(--color-headings);">
                                                 {{ _("Auto-reply email template") }}
                                             </h2>
+                                            {# Toggle lives in the section header, top-right; posts to the sibling
+                                               auto-reply-toggle form via the HTML5 form="" attribute. #}
+                                            {{ checkbox(
+                                            name="auto_reply_enabled",
+                                            label=_("Send auto-reply email"),
+                                            checked=auto_reply_enabled,
+                                            attrs='form="auto-reply-toggle" @change="$el.form.submit()"'
+                                            ) }}
                                         </div>
 
                                         <div class="space-y-4">
@@ -482,23 +484,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             {{ _("Preview and publish") }}
                         </h2>
 
-                        {# Status banner — mirrors what the modal used to show in TEST, and adds an equivalent
-                           notice for the CLOSED state where the URL now points to the closed-page redirect. #}
-                        {% if registration_status == "TEST" %}
-                            <div class="rounded-lg p-4 mb-6"
-                                 style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
-                                <p class="text-body-sm" style="color: var(--color-warning-600);">
-                                    {{ _("The form is in test mode. Submissions made via these URLs are recorded as test submissions and will not enter the selection pool.") }}
-                                </p>
-                            </div>
-                        {% elif registration_status == "CLOSED" %}
-                            <div class="rounded-lg p-4 mb-6"
-                                 style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
-                                <p class="text-body-sm" style="color: var(--color-error-600);">
-                                    {{ _("Registration is closed — visitors who follow these URLs are redirected to the closed page.") }}
-                                </p>
-                            </div>
-                        {% endif %}
+                        {# Status is shown globally above the stepper now, so no per-panel banner needed here. #}
 
                         {% if registration_page %}
                             <div class="space-y-6">

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -49,9 +49,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
                     <div>
-                        <h3 class="text-heading-md mb-2" style="color: var(--color-warning-600);">
+                        <h2 class="text-heading-md mb-2" style="color: var(--color-warning-600);">
                             {{ _("Registration page not created") }}
-                        </h3>
+                        </h2>
                         <p class="text-body-md mb-4" style="color: var(--color-warning-600);">
                             {{ _("Before you can configure the registration form, you need to create a registration page from the Details tab.") }}
                         </p>
@@ -229,7 +229,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                             @click="openImageDetailsModal(image)"
                                                             class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
                                                             style="color: var(--color-secondary-text);"
-                                                            :aria-label="'{{ _('Details for') }} ' + image.display_name">
+                                                            :aria-label="image.aria_label_details">
                                                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                             <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                                                         </svg>
@@ -239,7 +239,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                             @click="copyImageSnippet(image)"
                                                             class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
                                                             style="color: var(--color-secondary-text);"
-                                                            :aria-label="'{{ _('Copy <img> snippet for') }} ' + image.display_name">
+                                                            :aria-label="image.aria_label_copy_snippet">
                                                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                             <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                                                         </svg>
@@ -250,7 +250,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                             :disabled="imageBeingDeletedId === image.id"
                                                             class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
                                                             style="color: var(--color-secondary-text);"
-                                                            :aria-label="'{{ _('Delete') }} ' + image.display_name">
+                                                            :aria-label="image.aria_label_delete">
                                                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                             <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
                                                         </svg>
@@ -429,15 +429,20 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                         {{ variable.label }}
                                                     </label>
                                                     <div class="flex gap-2">
+                                                        {# readonly + aria-readonly: some screen readers still announce "edit text"
+                                                           for a readonly input, so we set aria-readonly explicitly. #}
                                                         <input type="text"
                                                                id="variable-{{ loop.index0 }}"
                                                                readonly
+                                                               aria-readonly="true"
                                                                value="{{ variable.expr }}"
                                                                @click="$event.target.select()"
                                                                class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
                                                                style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
                                                         <button type="button"
-                                                                @click="copyToClipboard('{{ variable.expr }}', '{{ _('Variable copied to clipboard') }}')"
+                                                                data-copy-text="{{ variable.expr }}"
+                                                                data-copy-msg="{{ _('Variable copied to clipboard') }}"
+                                                                @click="copyToClipboard($el)"
                                                                 class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
                                                                 style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
                                                                 aria-label="{{ _('Copy %(label)s variable', label=variable.label) }}">
@@ -800,8 +805,11 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                @click="$event.target.select()"
                                                class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
                                                style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        {# :data-copy-text is bound reactively so it tracks editingImage.file_name #}
                                         <button type="button"
-                                                @click="copyToClipboard(editingImage.file_name, '{{ _('File name copied to clipboard') }}')"
+                                                :data-copy-text="editingImage.file_name"
+                                                data-copy-msg="{{ _('File name copied to clipboard') }}"
+                                                @click="copyToClipboard($el)"
                                                 class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
                                                 style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
                                                 aria-label="{{ _('Copy file name') }}">
@@ -1078,10 +1086,16 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
                     },
 
-                    copyToClipboard(text, successMessage) {
+                    // Reads the text/message from data-copy-text / data-copy-msg on the triggering element.
+                    // Prefers the data-attribute pattern over passing string literals to @click because the
+                    // CSP-safe Alpine build's expression parser doesn't officially support literal arguments
+                    // in method calls (see CLAUDE.md's Alpine.js constraints).
+                    copyToClipboard($el) {
+                        const text = $el.dataset.copyText;
+                        const msg = $el.dataset.copyMsg;
                         if (!text) return;
                         navigator.clipboard.writeText(text)
-                            .then(() => this.showToast(successMessage || '{{ _("Copied to clipboard") }}', 'success'))
+                            .then(() => this.showToast(msg || '{{ _("Copied to clipboard") }}', 'success'))
                             .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
                     },
 

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -77,7 +77,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
             {"key": "preview", "label": _("Preview and publish"), "href": section_base ~ "?section=preview", "active": active_section == "preview"}
             ],
             aria_label=_("Registration setup steps"),
-            mode="tabs"
+            mode="tabs",
+            preserve_scroll=true
             ) }}
 
             {% if active_section == "form" %}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -10,6 +10,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% from "backoffice/components/modal.html" import modal %}
 {% from "backoffice/components/url_display.html" import readonly_url_display %}
+{% from "backoffice/components/stepper.html" import stepper %}
 
 {% block title %}{{ assembly.title }} - Registration{% endblock %}
 
@@ -64,283 +65,337 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </div>
             </div>
         {% else %}
+        {# Sub-navigation within the Registration tab: registration page → auto-reply email → preview & publish.
+           URL contract: ?section=form|email|preview. Panels are peers (any step reachable at any time),
+           so the stepper is rendered in tabs mode. #}
+            {% set section_base = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id) %}
+            {{ stepper(
+            id="reg-steps",
+            items=[
+            {"key": "form", "label": _("Registration page"), "href": section_base ~ "?section=form", "active": active_section == "form"},
+            {"key": "email", "label": _("Auto-reply email"), "href": section_base ~ "?section=email", "active": active_section == "email"},
+            {"key": "preview", "label": _("Preview and publish"), "href": section_base ~ "?section=preview", "active": active_section == "preview"}
+            ],
+            aria_label=_("Registration setup steps"),
+            mode="tabs"
+            ) }}
+
+            {% if active_section == "form" %}
+                <div id="reg-steps-panel-form"
+                     role="tabpanel"
+                     aria-labelledby="reg-steps-tab-form"
+                     tabindex="0">
         {# Editor (form) takes the remaining width on the left, Assets panel is a
            fixed-width column on the right. The panel sits OUTSIDE the form so
            uploading or deleting an image never submits the HTML editor — unsaved
            edits in the textarea are preserved. #}
-            <div class="flex flex-col lg:flex-row gap-6">
-                <div class="flex-1 min-w-0">
-                    <form method="post"
-                          action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
-                          x-data
-                          x-preserve-scroll-on-submit>
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                    <div class="flex flex-col lg:flex-row gap-6">
+                        <div class="flex-1 min-w-0">
+                            <form method="post"
+                                  action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
+                                  x-data
+                                  x-preserve-scroll-on-submit>
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
             {# Registration Form HTML Section #}
-                        <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                            <div class="flex items-center justify-between mb-4">
-                                <div class="flex items-center gap-3">
-                                    <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration Form HTML") }}</h2>
+                                <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                    <div class="flex items-center justify-between mb-4">
+                                        <div class="flex items-center gap-3">
+                                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration Form HTML") }}</h2>
 
                         {# Publication status indicator (tri-state). Wrapped in a fixed-min-width slot so the
                            variable badge width ("Test" / "Published" / "Closed") doesn't shift everything to
                            its right as the status changes. #}
-                                    <div class="inline-flex items-center" style="min-width: 7rem;">
-                                        {% if registration_status == "PUBLISHED" %}
-                                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                                  style="background-color: var(--color-success-100); color: var(--color-success-600);">
-                                                <span class="w-2 h-2 rounded-full" style="background-color: var(--color-success-400);"></span>
-                                                {{ _("Published") }}
-                                            </span>
-                                        {% elif registration_status == "CLOSED" %}
-                                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                                  style="background-color: var(--color-error-100); color: var(--color-error-600);">
-                                                <span class="w-2 h-2 rounded-full" style="background-color: var(--color-error-400);"></span>
-                                                {{ _("Closed") }}
-                                            </span>
-                                        {% else %}
+                                            <div class="inline-flex items-center" style="min-width: 7rem;">
+                                                {% if registration_status == "PUBLISHED" %}
+                                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
+                                                          style="background-color: var(--color-success-100); color: var(--color-success-600);">
+                                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-success-400);"></span>
+                                                        {{ _("Published") }}
+                                                    </span>
+                                                {% elif registration_status == "CLOSED" %}
+                                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
+                                                          style="background-color: var(--color-error-100); color: var(--color-error-600);">
+                                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-error-400);"></span>
+                                                        {{ _("Closed") }}
+                                                    </span>
+                                                {% else %}
                                 {# TEST status (default) #}
-                                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
-                                                  style="background-color: var(--color-warning-100); color: var(--color-warning-600);">
-                                                <span class="w-2 h-2 rounded-full" style="background-color: var(--color-warning-400);"></span>
-                                                {{ _("Test") }}
-                                            </span>
-                                        {% endif %}
-                                    </div>
+                                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-sm font-medium"
+                                                          style="background-color: var(--color-warning-100); color: var(--color-warning-600);">
+                                                        <span class="w-2 h-2 rounded-full" style="background-color: var(--color-warning-400);"></span>
+                                                        {{ _("Test") }}
+                                                    </span>
+                                                {% endif %}
+                                            </div>
 
                         {# Change status dropdown — items are named after the TARGET state, with a one-line
                            explanation of what visitors will see. Forbidden jumps (TEST↔CLOSED) are simply
                            absent from the menu. #}
-                                    {% if registration_status == "TEST" %}
-                                        {% set status_items = [
-                                        {
-                                        "text": _("Published"),
-                                        "description": _("Form goes live; submissions enter the selection pool."),
-                                        "dot_color": "var(--color-success-400)",
-                                        "attrs": 'name="action" value="publish"'
-                                        },
-                                        ] %}
-                                    {% elif registration_status == "PUBLISHED" %}
-                                        {% set status_items = [
-                                        {
-                                        "text": _("Closed for Submissions"),
-                                        "description": _("Visitors are redirected to a registration-closed page; no new submissions are accepted."),
-                                        "dot_color": "var(--color-error-400)",
-                                        "attrs": 'name="action" value="close"'
-                                        },
-                                        {
-                                        "text": _("Test"),
-                                        "description": _("Form stays public, but new submissions are flagged as test entries and skipped from the pool."),
-                                        "dot_color": "var(--color-warning-400)",
-                                        "attrs": 'name="action" value="unpublish"'
-                                        },
-                                        ] %}
-                                    {% else %}
-                                        {% set status_items = [
-                                        {
-                                        "text": _("Published"),
-                                        "description": _("Form goes live again; new submissions enter the selection pool."),
-                                        "dot_color": "var(--color-success-400)",
-                                        "attrs": 'name="action" value="reopen"'
-                                        },
-                                        ] %}
-                                    {% endif %}
-                                    {{ dropdown_button(
-                                    label=_("Change status"),
-                                    items=status_items,
-                                    variant="secondary",
-                                    id="status-control",
-                                    disabled=edit_mode,
-                                    ) }}
-                                </div>
+                                            {% if registration_status == "TEST" %}
+                                                {% set status_items = [
+                                                {
+                                                "text": _("Published"),
+                                                "description": _("Form goes live; submissions enter the selection pool."),
+                                                "dot_color": "var(--color-success-400)",
+                                                "attrs": 'name="action" value="publish"'
+                                                },
+                                                ] %}
+                                            {% elif registration_status == "PUBLISHED" %}
+                                                {% set status_items = [
+                                                {
+                                                "text": _("Closed for Submissions"),
+                                                "description": _("Visitors are redirected to a registration-closed page; no new submissions are accepted."),
+                                                "dot_color": "var(--color-error-400)",
+                                                "attrs": 'name="action" value="close"'
+                                                },
+                                                {
+                                                "text": _("Test"),
+                                                "description": _("Form stays public, but new submissions are flagged as test entries and skipped from the pool."),
+                                                "dot_color": "var(--color-warning-400)",
+                                                "attrs": 'name="action" value="unpublish"'
+                                                },
+                                                ] %}
+                                            {% else %}
+                                                {% set status_items = [
+                                                {
+                                                "text": _("Published"),
+                                                "description": _("Form goes live again; new submissions enter the selection pool."),
+                                                "dot_color": "var(--color-success-400)",
+                                                "attrs": 'name="action" value="reopen"'
+                                                },
+                                                ] %}
+                                            {% endif %}
+                                            {{ dropdown_button(
+                                            label=_("Change status"),
+                                            items=status_items,
+                                            variant="secondary",
+                                            id="status-control",
+                                            disabled=edit_mode,
+                                            ) }}
+                                        </div>
                      {# Header right: editorial helper only (status controls live on the left next to the badge) #}
-                                <div class="flex items-center gap-2">
-                                    {% set code_icon %}
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-                                        </svg>
-                                    {% endset %}
-                                    {{ button(
-                                    _("Show Form Skeleton"),
-                                    variant="tertiary",
-                                    leading_icon=code_icon,
-                                    attrs='@click="fetchSkeleton()" :disabled="skeletonLoading"'
-                                    ) }}
-                                </div>
-                            </div>
+                                        <div class="flex items-center gap-2">
+                                            {% set code_icon %}
+                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                                                </svg>
+                                            {% endset %}
+                                            {{ button(
+                                            _("Show Form Skeleton"),
+                                            variant="tertiary",
+                                            leading_icon=code_icon,
+                                            attrs='@click="fetchSkeleton()" :disabled="skeletonLoading"'
+                                            ) }}
+                                        </div>
+                                    </div>
 
-                            <div class="space-y-4">
-                                <p class="text-body-sm" style="color: var(--color-secondary-text);">
-                                    {{ _("Paste your HTML form code below. The only required placeholders are {{ form_action }} for the form's action attribute and {{ csrf_form_element }} for CSRF protection.") }}
-                                </p>
+                                    <div class="space-y-4">
+                                        <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                                            {{ _("Paste your HTML form code below. The only required placeholders are {{ form_action }} for the form's action attribute and {{ csrf_form_element }} for CSRF protection.") }}
+                                        </p>
 
                     {# HTML Textarea with monospace font. `readonly` is the default;
                        ?edit=1 unlocks it via the Edit CTA below. #}
-                                {% set textarea_attrs %}
-                                    {% if not edit_mode %}readonly aria-readonly="true" {% endif %}style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;{% if not edit_mode %} background-color: var(--color-subtle-background-panels); cursor: default;{% endif %}"
-                                {% endset %}
-                                {{ textarea(
-                                name="html_content",
-                                label="",
-                                value=html_content,
-                                placeholder="<form action=\"{{ form_action }}\" method=\"POST\">\n  {{ csrf_form_element }}\n  <div>\n    <label for=\"first_name\">First Name</label>\n    <input type=\"text\" id=\"first_name\" name=\"first_name\" required />\n  </div>\n  <!-- Add more fields here -->\n  <button type=\"submit\">Register</button>\n</form>",
-                                rows=25,
-                                attrs=textarea_attrs|trim
-                                ) }}
+                                        {% set textarea_attrs %}
+                                            {% if not edit_mode %}readonly aria-readonly="true" {% endif %}style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;{% if not edit_mode %} background-color: var(--color-subtle-background-panels); cursor: default;{% endif %}"
+                                        {% endset %}
+                                        {{ textarea(
+                                        name="html_content",
+                                        label="",
+                                        value=html_content,
+                                        placeholder="<form action=\"{{ form_action }}\" method=\"POST\">\n  {{ csrf_form_element }}\n  <div>\n    <label for=\"first_name\">First Name</label>\n    <input type=\"text\" id=\"first_name\" name=\"first_name\" required />\n  </div>\n  <!-- Add more fields here -->\n  <button type=\"submit\">Register</button>\n</form>",
+                                        rows=25,
+                                        attrs=textarea_attrs|trim
+                                        ) }}
 
                     {# Footer: review the form + save edits. Status transitions live in the header dropdown.
                        The primary action slot toggles between Edit (read-only, default) and Save/Cancel (edit_mode). #}
-                                <div class="flex justify-end gap-3">
-                                    {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, edit="1") %}
-                                    {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id) %}
+                                        <div class="flex justify-end gap-3">
+                                            {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, edit="1") %}
+                                            {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id) %}
                         {# Preview / Share lives next to Save — "view what you just edited" pairs with "save it" #}
-                                    {% if registration_status == "TEST" %}
-                                        {% set eye_icon %}
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                                            </svg>
-                                        {% endset %}
-                                        {{ button(
-                                        _("Preview and Test Responses"),
-                                        variant="tertiary",
-                                        leading_icon=eye_icon,
-                                        attrs='@click="openPreviewModal()"'
-                                        ) }}
-                                        {% if edit_mode %}
-                                            {{ button(_("Cancel"), variant="secondary", href=view_url) }}
-                                            {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
-                                        {% else %}
-                                            {{ button(_("Edit"), variant="primary", href=edit_url) }}
-                                        {% endif %}
-                                    {% else %}
-                                        {% set link_icon %}
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                                            </svg>
-                                        {% endset %}
-                                        {% if registration_status == "PUBLISHED" %}
-                                            {{ button(
-                                            _("Share Form"),
-                                            variant="tertiary",
-                                            leading_icon=link_icon,
-                                            attrs='@click="openPreviewModal()"'
-                                            ) }}
-                                            {% if edit_mode %}
-                                                {{ button(_("Cancel"), variant="secondary", href=view_url) }}
-                                                {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                            {% if registration_status == "TEST" %}
+                                                {% set eye_icon %}
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                                    </svg>
+                                                {% endset %}
+                                                {{ button(
+                                                _("Preview and Test Responses"),
+                                                variant="tertiary",
+                                                leading_icon=eye_icon,
+                                                attrs='@click="openPreviewModal()"'
+                                                ) }}
+                                                {% if edit_mode %}
+                                                    {{ button(_("Cancel"), variant="secondary", href=view_url) }}
+                                                    {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                                {% else %}
+                                                    {{ button(_("Edit"), variant="primary", href=edit_url) }}
+                                                {% endif %}
                                             {% else %}
-                                                {{ button(_("Edit"), variant="primary", href=edit_url) }}
-                                            {% endif %}
-                                        {% else %}
+                                                {% set link_icon %}
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                                                    </svg>
+                                                {% endset %}
+                                                {% if registration_status == "PUBLISHED" %}
+                                                    {{ button(
+                                                    _("Share Form"),
+                                                    variant="tertiary",
+                                                    leading_icon=link_icon,
+                                                    attrs='@click="openPreviewModal()"'
+                                                    ) }}
+                                                    {% if edit_mode %}
+                                                        {{ button(_("Cancel"), variant="secondary", href=view_url) }}
+                                                        {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                                    {% else %}
+                                                        {{ button(_("Edit"), variant="primary", href=edit_url) }}
+                                                    {% endif %}
+                                                {% else %}
                                 {# CLOSED: no save (form is redirecting) and no Edit — admins must reopen first. #}
-                                            {{ button(
-                                            _("Share Form"),
-                                            variant="tertiary",
-                                            leading_icon=link_icon,
-                                            disabled=true,
-                                            aria_label=_("Registration is closed — the form URL redirects to the closed page"),
-                                            attrs='title="' ~ _("Registration is closed — the form URL redirects to the closed page") ~ '"'
-                                            ) }}
-                                        {% endif %}
-                                    {% endif %}
-                                </div>
-                            </div>
-                        </section>
-                    </form>
-                </div>
+                                                    {{ button(
+                                                    _("Share Form"),
+                                                    variant="tertiary",
+                                                    leading_icon=link_icon,
+                                                    disabled=true,
+                                                    aria_label=_("Registration is closed — the form URL redirects to the closed page"),
+                                                    attrs='title="' ~ _("Registration is closed — the form URL redirects to the closed page") ~ '"'
+                                                    ) }}
+                                                {% endif %}
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                </section>
+                            </form>
+                        </div>
 
             {# Assets panel (image library). Lives outside the editor form so its
                buttons never submit the HTML editor. Initial list is rendered
                server-side; uploads/deletes mutate the Alpine `images` array in
                place, no page reload required. #}
-                <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
-                    <section class="rounded-lg p-6 sticky top-4 w-full"
-                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                        <div class="flex items-center justify-between mb-4">
-                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
-                            {% set upload_icon %}
-                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
-                                </svg>
-                            {% endset %}
-                            {{ button(
-                            _("Upload"),
-                            variant="tertiary",
-                            leading_icon=upload_icon,
-                            attrs='type="button" @click="openImageUploadModal()"'
-                            ) }}
-                        </div>
+                        <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
+                            <section class="rounded-lg p-6 sticky top-4 w-full"
+                                     style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                <div class="flex items-center justify-between mb-4">
+                                    <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
+                                    {% set upload_icon %}
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
+                                        </svg>
+                                    {% endset %}
+                                    {{ button(
+                                    _("Upload"),
+                                    variant="tertiary",
+                                    leading_icon=upload_icon,
+                                    attrs='type="button" @click="openImageUploadModal()"'
+                                    ) }}
+                                </div>
 
                     {# Format / size hint #}
-                        <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
-                             style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                            <p class="text-body-sm" style="color: var(--color-info-700);">
-                                {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
-                            </p>
-                        </div>
+                                <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
+                                     style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                    </svg>
+                                    <p class="text-body-sm" style="color: var(--color-info-700);">
+                                        {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
+                                    </p>
+                                </div>
 
                     {# Empty state #}
-                        <template x-if="!images.length">
-                            <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
-                                {{ _("No images uploaded yet.") }}
-                            </p>
-                        </template>
+                                <template x-if="!images.length">
+                                    <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
+                                        {{ _("No images uploaded yet.") }}
+                                    </p>
+                                </template>
 
                     {# Image list #}
-                        <ul class="space-y-2" x-show="images.length" x-cloak>
-                            <template x-for="image in images" :key="image.id">
-                                <li class="rounded-md px-3 py-2 flex items-center justify-between"
-                                    style="background-color: var(--color-subtle-background-panels);">
-                                    <a :href="image.public_url"
-                                       :title="image.alt || image.file_name"
-                                       target="_blank"
-                                       rel="noopener"
-                                       class="text-body-sm truncate flex-1 mr-2"
-                                       style="color: var(--color-body-text);"
-                                       x-text="image.display_name"></a>
-                                    <div class="flex items-center gap-1 flex-shrink-0">
+                                <ul class="space-y-2" x-show="images.length" x-cloak>
+                                    <template x-for="image in images" :key="image.id">
+                                        <li class="rounded-md px-3 py-2 flex items-center justify-between"
+                                            style="background-color: var(--color-subtle-background-panels);">
+                                            <a :href="image.public_url"
+                                               :title="image.alt || image.file_name"
+                                               target="_blank"
+                                               rel="noopener"
+                                               class="text-body-sm truncate flex-1 mr-2"
+                                               style="color: var(--color-body-text);"
+                                               x-text="image.display_name"></a>
+                                            <div class="flex items-center gap-1 flex-shrink-0">
                                     {# Image details / edit alt text #}
-                                        <button type="button"
-                                                @click="openImageDetailsModal(image)"
-                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                style="color: var(--color-secondary-text);"
-                                                :aria-label="'{{ _('Details for') }} ' + image.display_name">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                            </svg>
-                                        </button>
+                                                <button type="button"
+                                                        @click="openImageDetailsModal(image)"
+                                                        class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                        style="color: var(--color-secondary-text);"
+                                                        :aria-label="'{{ _('Details for') }} ' + image.display_name">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                    </svg>
+                                                </button>
                                     {# Copy <img> snippet to clipboard #}
-                                        <button type="button"
-                                                @click="copyImageSnippet(image)"
-                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                style="color: var(--color-secondary-text);"
-                                                :aria-label="'{{ _('Copy <img> snippet for') }} ' + image.display_name">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
+                                                <button type="button"
+                                                        @click="copyImageSnippet(image)"
+                                                        class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                        style="color: var(--color-secondary-text);"
+                                                        :aria-label="'{{ _('Copy <img> snippet for') }} ' + image.display_name">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                    </svg>
+                                                </button>
                                     {# Delete #}
-                                        <button type="button"
-                                                @click="deleteImage(image)"
-                                                :disabled="imageBeingDeletedId === image.id"
-                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                style="color: var(--color-secondary-text);"
-                                                :aria-label="'{{ _('Delete') }} ' + image.display_name">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </li>
-                            </template>
-                        </ul>
-                    </section>
-                </aside>
-            </div>
+                                                <button type="button"
+                                                        @click="deleteImage(image)"
+                                                        :disabled="imageBeingDeletedId === image.id"
+                                                        class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                        style="color: var(--color-secondary-text);"
+                                                        :aria-label="'{{ _('Delete') }} ' + image.display_name">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                                                    </svg>
+                                                </button>
+                                            </div>
+                                        </li>
+                                    </template>
+                                </ul>
+                            </section>
+                        </aside>
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if active_section == "email" %}
+                <div id="reg-steps-panel-email"
+                     role="tabpanel"
+                     aria-labelledby="reg-steps-tab-email"
+                     tabindex="0"
+                     class="rounded-lg p-6"
+                     style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                    <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">
+                        {{ _("Auto-reply email") }}
+                    </h2>
+                    <p class="text-body-md" style="color: var(--color-secondary-text);">
+                        {{ _("Coming soon — you will be able to edit the email respondents receive after registering.") }}
+                    </p>
+                </div>
+            {% endif %}
+
+            {% if active_section == "preview" %}
+                <div id="reg-steps-panel-preview"
+                     role="tabpanel"
+                     aria-labelledby="reg-steps-tab-preview"
+                     tabindex="0"
+                     class="rounded-lg p-6"
+                     style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                    <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">
+                        {{ _("Preview and publish") }}
+                    </h2>
+                    <p class="text-body-md" style="color: var(--color-secondary-text);">
+                        {{ _("Coming soon — a combined preview of the registration form and the auto-reply email, together with the publish controls.") }}
+                    </p>
+                </div>
+            {% endif %}
         {% endif %}
 
         {# Form Skeleton Modal - only shown when registration page exists #}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -5,7 +5,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 {% extends "backoffice/base_page.html" %}
 {% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 {% from "backoffice/components/button.html" import button %}
-{% from "backoffice/components/dropdown_button.html" import dropdown_button %}
 {% from "backoffice/components/input.html" import checkbox, input, switch, textarea %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% from "backoffice/components/modal.html" import modal %}
@@ -130,50 +129,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                 {% endif %}
                                             </div>
 
-                        {# Change status dropdown — items are named after the TARGET state, with a one-line
-                           explanation of what visitors will see. Forbidden jumps (TEST↔CLOSED) are simply
-                           absent from the menu. #}
-                                            {% if registration_status == "TEST" %}
-                                                {% set status_items = [
-                                                {
-                                                "text": _("Published"),
-                                                "description": _("Form goes live; submissions enter the selection pool."),
-                                                "dot_color": "var(--color-success-400)",
-                                                "attrs": 'name="action" value="publish"'
-                                                },
-                                                ] %}
-                                            {% elif registration_status == "PUBLISHED" %}
-                                                {% set status_items = [
-                                                {
-                                                "text": _("Closed for Submissions"),
-                                                "description": _("Visitors are redirected to a registration-closed page; no new submissions are accepted."),
-                                                "dot_color": "var(--color-error-400)",
-                                                "attrs": 'name="action" value="close"'
-                                                },
-                                                {
-                                                "text": _("Test"),
-                                                "description": _("Form stays public, but new submissions are flagged as test entries and skipped from the pool."),
-                                                "dot_color": "var(--color-warning-400)",
-                                                "attrs": 'name="action" value="unpublish"'
-                                                },
-                                                ] %}
-                                            {% else %}
-                                                {% set status_items = [
-                                                {
-                                                "text": _("Published"),
-                                                "description": _("Form goes live again; new submissions enter the selection pool."),
-                                                "dot_color": "var(--color-success-400)",
-                                                "attrs": 'name="action" value="reopen"'
-                                                },
-                                                ] %}
-                                            {% endif %}
-                                            {{ dropdown_button(
-                                            label=_("Change status"),
-                                            items=status_items,
-                                            variant="secondary",
-                                            id="status-control",
-                                            disabled=edit_mode,
-                                            ) }}
                                         </div>
                      {# Header right: editorial helper only (status controls live on the left next to the badge) #}
                                         <div class="flex items-center gap-2">
@@ -210,33 +165,28 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                         attrs=textarea_attrs|trim
                                         ) }}
 
-                    {# Footer: review the form + save edits. Status transitions live in the header dropdown.
-                       The primary action slot toggles between Edit (read-only, default) and Save/Cancel (edit_mode).
-                       Share/Preview lives on the Preview-and-publish step of the stepper, not next to Save. #}
-                                        {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, edit="1") %}
-                                        {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id) %}
-                                        {% if registration_status == "TEST" %}
-                                            <div class="flex justify-end gap-3">
-                                                {% if edit_mode %}
-                                                    {{ button(_("Cancel"), variant="secondary", href=view_url) }}
-                                                    {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
-                                                {% else %}
-                                                    {{ button(_("Edit"), variant="primary", href=edit_url) }}
-                                                {% endif %}
-                                            </div>
-                                        {% elif registration_status == "PUBLISHED" %}
-                                            <div class="flex justify-end gap-3">
-                                                {% if edit_mode %}
-                                                    {{ button(_("Cancel"), variant="secondary", href=view_url) }}
-                                                    {{ button(_("Save and Republish"), type="submit", variant="primary", attrs='name="action" value="save"') }}
-                                                {% else %}
-                                                    {{ button(_("Edit"), variant="primary", href=edit_url) }}
-                                                {% endif %}
-                                            </div>
-                                        {% endif %}
-                                        {# CLOSED: no save (form is redirecting) and no Edit — admins must reopen first. #}
                                     </div>
                                 </section>
+
+                    {# Bottom CTAs — outside the editor box, right-aligned. Same shape across all three steps:
+                       Read = Edit + Next, Edit = Cancel + Save + Save and next. Primary is the forward action. #}
+                                {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form", edit="1") %}
+                                {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form") %}
+                                {% set next_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="email") %}
+                                {% set save_label = _("Save and Republish") if registration_status == "PUBLISHED" else _("Save") %}
+                                {% set save_next_label = _("Save and Republish and next →") if registration_status == "PUBLISHED" else _("Save and next →") %}
+                                <div class="flex justify-end gap-3 mt-4">
+                                    {% if edit_mode %}
+                                        {{ button(_("Cancel"), variant="secondary", href=view_url) }}
+                                        {{ button(save_label, type="submit", variant="secondary", attrs='name="action" value="save"') }}
+                                        {{ button(save_next_label, type="submit", variant="primary", attrs='name="action" value="save_and_next"') }}
+                                    {% else %}
+                                        {% if registration_status != "CLOSED" %}
+                                            {{ button(_("Edit"), variant="secondary", href=edit_url) }}
+                                        {% endif %}
+                                        {{ button(_("Next →"), variant="primary", href=next_url) }}
+                                    {% endif %}
+                                </div>
                             </form>
                         </div>
 
@@ -441,18 +391,23 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             attrs=body_attrs|trim
                                             ) }}
 
-                                            <div class="flex justify-end gap-3">
-                                                {% set email_edit_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email', edit='1') %}
-                                                {% set email_view_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
-                                                {% if edit_mode %}
-                                                    {{ button(_("Cancel"), variant="secondary", href=email_view_url) }}
-                                                    {{ button(_("Save"), type="submit", variant="primary") }}
-                                                {% else %}
-                                                    {{ button(_("Edit"), variant="primary", href=email_edit_url) }}
-                                                {% endif %}
-                                            </div>
                                         </div>
                                     </section>
+
+                    {# Bottom CTAs — mirror the S1 pattern: outside the editor box, right-aligned. #}
+                                    {% set email_edit_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email', edit='1') %}
+                                    {% set email_view_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
+                                    {% set preview_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='preview') %}
+                                    <div class="flex justify-end gap-3 mt-4">
+                                        {% if edit_mode %}
+                                            {{ button(_("Cancel"), variant="secondary", href=email_view_url) }}
+                                            {{ button(_("Save"), type="submit", variant="secondary", attrs='name="action" value="save"') }}
+                                            {{ button(_("Save and next →"), type="submit", variant="primary", attrs='name="action" value="save_and_next"') }}
+                                        {% else %}
+                                            {{ button(_("Edit"), variant="secondary", href=email_edit_url) }}
+                                            {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                                        {% endif %}
+                                    </div>
                                 </form>
                             </div>
 
@@ -593,6 +548,21 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             </div>
                         {% endif %}
                     </section>
+
+                    {# Bottom CTA — Publish is the primary happy-path action in TEST. Once PUBLISHED the badge on
+                       step 1 conveys the state; CLOSED is terminal (no Reopen in the UI). #}
+                    {% if registration_status == "TEST" and registration_page %}
+                        <div class="flex justify-end gap-3 mt-4">
+                            <form method="post"
+                                  action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
+                                  x-data
+                                  x-preserve-scroll-on-submit>
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                <input type="hidden" name="action" value="publish" />
+                                {{ button(_("Publish"), type="submit", variant="primary") }}
+                            </form>
+                        </div>
+                    {% endif %}
                 </div>
             {% endif %}
         {% endif %}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -6,7 +6,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 {% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/dropdown_button.html" import dropdown_button %}
-{% from "backoffice/components/input.html" import input, switch, textarea %}
+{% from "backoffice/components/input.html" import checkbox, input, switch, textarea %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% from "backoffice/components/modal.html" import modal %}
 {% from "backoffice/components/url_display.html" import readonly_url_display %}
@@ -371,14 +371,167 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                      role="tabpanel"
                      aria-labelledby="reg-steps-tab-email"
                      tabindex="0"
-                     class="rounded-lg p-6"
-                     style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                    <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">
-                        {{ _("Auto-reply email") }}
-                    </h2>
-                    <p class="text-body-md" style="color: var(--color-secondary-text);">
-                        {{ _("Coming soon — you will be able to edit the email respondents receive after registering.") }}
-                    </p>
+                     class="space-y-4">
+                    {% set email_save_url = url_for('backoffice_registration.save_assembly_registration_email', assembly_id=assembly.id) %}
+
+                    {# Readiness banner — surfaces problems that would stop the auto-reply from actually being delivered #}
+                    {% for problem in email_readiness_problems %}
+                        {% set is_error = problem.severity == "error" %}
+                        <div class="rounded-lg p-4"
+                             role="alert"
+                             style="background-color: var({{ '--color-error-100' if is_error else '--color-warning-100' }}); border: 1px solid var({{ '--color-error-400' if is_error else '--color-warning-400' }}); color: var({{ '--color-error-600' if is_error else '--color-warning-600' }});">
+                            <p class="text-body-md">
+                                <span class="font-semibold">{% if is_error %}⛔ {{ _("Auto-reply cannot be sent") }}:{% else %}⚠️ {{ _("Heads up") }}:{% endif %}</span>
+                                {{ problem.message }}
+                            </p>
+                        </div>
+                    {% endfor %}
+
+                    {% if not email_template %}
+                        {# Empty state — no template exists yet. One button to create + assign + enter edit mode. #}
+                        <section class="rounded-lg p-6"
+                                 style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                            <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">
+                                {{ _("Auto-reply email") }}
+                            </h2>
+                            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                                {{ _("Automatically send a confirmation email to people after they register. Templates support variables like the respondent's first name and the assembly title.") }}
+                            </p>
+                            <form method="post" action="{{ email_save_url }}" x-data x-preserve-scroll-on-submit>
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                <input type="hidden" name="action" value="create" />
+                                {{ button(_("Set up auto-reply email"), type="submit", variant="primary") }}
+                            </form>
+                        </section>
+                    {% else %}
+                        {# Send-auto-reply toggle: outside both boxes, top-right, auto-submits on change so it feels
+                           like a proper toggle. The `action` field flips based on the current state, so the checkbox
+                           value doesn't need to be read; toggling always inverts the state. #}
+                        <div class="flex justify-end mb-4">
+                            <form method="post"
+                                  action="{{ email_save_url }}"
+                                  x-data
+                                  x-preserve-scroll-on-submit
+                                  class="px-2 py-1">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                <input type="hidden" name="action" value="{{ 'disable' if auto_reply_enabled else 'enable' }}" />
+                                {# Tell the backend which template to enable — the currently-displayed one. #}
+                                <input type="hidden" name="template_id" value="{{ email_template.id }}" />
+                                {{ checkbox(
+                                name="auto_reply_enabled",
+                                label=_("Send auto-reply email"),
+                                checked=auto_reply_enabled,
+                                attrs='@change="$el.form.submit()"'
+                                ) }}
+                            </form>
+                        </div>
+
+                        {# Two-box layout mirroring the form section: editor on the left (2/3), variables reference
+                           on the right (1/3, sticky). The two panels start at the same vertical offset, which is
+                           pushed down together by the send toggle above. #}
+                        <div class="flex flex-col lg:flex-row gap-6">
+                            <div class="flex-1 min-w-0">
+                                <form method="post"
+                                      action="{{ email_save_url }}"
+                                      x-data
+                                      x-preserve-scroll-on-submit>
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                    <input type="hidden" name="action" value="save" />
+
+                                    <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                        <div class="flex items-center justify-between mb-4 gap-4">
+                                            <h2 class="text-heading-lg" style="color: var(--color-headings);">
+                                                {{ _("Auto-reply email template") }}
+                                            </h2>
+                                        </div>
+
+                                        <div class="space-y-4">
+                                            {% set common_input_attrs %}{% if not edit_mode %}readonly aria-readonly="true" style="background-color: var(--color-subtle-background-panels); cursor: default;"{% endif %}{% endset %}
+
+                                            {# Template name is not exposed yet — one template per page, always called "Registration
+                                               auto-reply". When multi-template support ships this becomes a visible input. #}
+
+                                            {{ input(
+                                            name="template_subject",
+                                            label=_("Email subject"),
+                                            value=email_template.subject,
+                                            hint=_("Jinja variables allowed, e.g. {{ assembly.title }}."),
+                                            required=true,
+                                            attrs=common_input_attrs|trim
+                                            ) }}
+
+                                            {% set body_attrs %}
+                                                {% if not edit_mode %}readonly aria-readonly="true" {% endif %}style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;{% if not edit_mode %} background-color: var(--color-subtle-background-panels); cursor: default;{% endif %}"
+                                            {% endset %}
+                                            {{ textarea(
+                                            name="template_body_html",
+                                            label=_("HTML body"),
+                                            value=email_template.body_html,
+                                            hint=_("Jinja + HTML. A plain-text version is generated automatically for email clients that need it."),
+                                            required=true,
+                                            rows=18,
+                                            attrs=body_attrs|trim
+                                            ) }}
+
+                                            <div class="flex justify-end gap-3">
+                                                {% set email_edit_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email', edit='1') %}
+                                                {% set email_view_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
+                                                {% if edit_mode %}
+                                                    {{ button(_("Cancel"), variant="secondary", href=email_view_url) }}
+                                                    {{ button(_("Save"), type="submit", variant="primary") }}
+                                                {% else %}
+                                                    {{ button(_("Edit"), variant="primary", href=email_edit_url) }}
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                    </section>
+                                </form>
+                            </div>
+
+                            {# Variables reference sidebar — styled like the Assets panel from the form section. #}
+                            <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
+                                <section class="rounded-lg p-6 sticky top-4 w-full"
+                                         style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                    <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
+                                        {{ _("Available variables") }}
+                                    </h2>
+                                    <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                        {{ _("Paste any of these into the subject or body. Missing values render as an empty string.") }}
+                                    </p>
+                                    <dl class="text-body-sm space-y-3" style="color: var(--color-body-text);">
+                                        <div>
+                                            <dt class="font-mono">{{ '{{ assembly.title }}' }}</dt>
+                                            <dd style="color: var(--color-secondary-text);">{{ _("Assembly title") }}</dd>
+                                        </div>
+                                        <div>
+                                            <dt class="font-mono">{{ '{{ assembly.question }}' }}</dt>
+                                            <dd style="color: var(--color-secondary-text);">{{ _("Assembly question") }}</dd>
+                                        </div>
+                                        <div>
+                                            <dt class="font-mono">{{ '{{ assembly.first_assembly_date }}' }}</dt>
+                                            <dd style="color: var(--color-secondary-text);">{{ _("First assembly date (ISO)") }}</dd>
+                                        </div>
+                                        <div>
+                                            <dt class="font-mono">{{ '{{ respondent.first_name }}' }}</dt>
+                                            <dd style="color: var(--color-secondary-text);">{{ _("Respondent first name") }}</dd>
+                                        </div>
+                                        <div>
+                                            <dt class="font-mono">{{ '{{ respondent.first_name_or_friend }}' }}</dt>
+                                            <dd style="color: var(--color-secondary-text);">{{ _("First name, or 'Friend' as a fallback") }}</dd>
+                                        </div>
+                                        <div>
+                                            <dt class="font-mono">{{ '{{ respondent.full_name }}' }}</dt>
+                                            <dd style="color: var(--color-secondary-text);">{{ _("Respondent full name") }}</dd>
+                                        </div>
+                                        <div>
+                                            <dt class="font-mono">{{ '{{ respondent.email }}' }}</dt>
+                                            <dd style="color: var(--color-secondary-text);">{{ _("Respondent email address") }}</dd>
+                                        </div>
+                                    </dl>
+                                </section>
+                            </aside>
+                        </div>
+                    {% endif %}
                 </div>
             {% endif %}
 

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -169,12 +169,14 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 </section>
                             </div>
 
-            {# Assets panel (image library). Buttons all use type="button" so they never
-               submit the parent editor form. Initial list is rendered server-side; uploads
-               and deletes mutate the Alpine `images` array in place, no page reload required. #}
-                            <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
-                                <section class="rounded-lg p-6 sticky top-4 w-full"
-                                         style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+            {# Assets panel (image library). The aside carries the visual box (border/bg) so it
+               stretches to match the left column's height (align-items: stretch is the flex default),
+               and only the inner content sticks to the top on scroll. That way the box's bottom lines
+               up with the editor's bottom instead of leaving the CTAs disconnected. Buttons all use
+               type="button" so they never submit the parent editor form. #}
+                            <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
+                                   style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                <div class="p-6 sticky top-4 w-full">
                                     <div class="flex items-center justify-between mb-4">
                                         <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
                                         {% set upload_icon %}
@@ -256,7 +258,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             </li>
                                         </template>
                                     </ul>
-                                </section>
+                                </div>
                             </aside>
                         </div>
 
@@ -395,10 +397,12 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     </section>
                                 </div>
 
-                                {# Variables reference sidebar — styled like the Assets panel from the form section. #}
-                                <aside class="lg:flex-shrink-0 w-full lg:w-[400px]">
-                                    <section class="rounded-lg p-6 sticky top-4 w-full"
-                                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                {# Variables reference sidebar — the aside carries the visual box so it stretches
+                                   to match the editor's height, and only the inner content sticks on scroll
+                                   (same trick as the S1 Assets panel). #}
+                                <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
+                                       style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                    <div class="p-6 sticky top-4 w-full">
                                         <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
                                             {{ _("Available variables") }}
                                         </h2>
@@ -443,7 +447,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                 </li>
                                             {% endfor %}
                                         </ul>
-                                    </section>
+                                    </div>
                                 </aside>
                             </div>
 

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -404,10 +404,10 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             </form>
                         </section>
                     {% else %}
-                        {# Send-auto-reply toggle: outside both boxes, top-right, auto-submits on change so it feels
+                        {# Send-auto-reply toggle: outside both boxes, top-left, auto-submits on change so it feels
                            like a proper toggle. The `action` field flips based on the current state, so the checkbox
                            value doesn't need to be read; toggling always inverts the state. #}
-                        <div class="flex justify-end mb-4">
+                        <div class="flex justify-start mb-4">
                             <form method="post"
                                   action="{{ email_save_url }}"
                                   x-data

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -344,12 +344,14 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                            on the right (1/3, sticky). The form wraps both columns and the CTA row so the CTAs
                            align to the far right of the whole layout and the sticky aside unsticks at the
                            flex-row's bottom. #}
+                        {# The action name comes from the clicked submit button (Save / Save and next).
+                           A hidden <input name="action"> here would be sent as a duplicate and would win
+                           over the button value because request.form.get() returns the first entry. #}
                         <form method="post"
                               action="{{ email_save_url }}"
                               x-data
                               x-preserve-scroll-on-submit>
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                            <input type="hidden" name="action" value="save" />
                             <div class="flex flex-col lg:flex-row gap-6">
                                 <div class="flex-1 min-w-0">
                                     <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">

--- a/backend/templates/backoffice/components/stepper.html
+++ b/backend/templates/backoffice/components/stepper.html
@@ -86,6 +86,13 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                                 {% endif %}
                             </span>
                             <span class="stepper-label">{{ item.label }}</span>
+                            {# Visually-hidden state so screen readers announce done/error steps.
+                               Active is already announced via aria-selected / aria-current. #}
+                            {% if state == "done" %}
+                                <span class="sr-only"> ({{ _("completed") }})</span>
+                            {% elif state == "error" %}
+                                <span class="sr-only"> ({{ _("has errors") }})</span>
+                            {% endif %}
                         </span>
                     {% else %}
                         <a href="{{ item.href }}"
@@ -108,6 +115,13 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                                 {% endif %}
                             </span>
                             <span class="stepper-label">{{ item.label }}</span>
+                            {# Visually-hidden state so screen readers announce done/error steps.
+                               Active is already announced via aria-selected / aria-current. #}
+                            {% if state == "done" %}
+                                <span class="sr-only"> ({{ _("completed") }})</span>
+                            {% elif state == "error" %}
+                                <span class="sr-only"> ({{ _("has errors") }})</span>
+                            {% endif %}
                         </a>
                     {% endif %}
                 </li>

--- a/backend/templates/backoffice/components/stepper.html
+++ b/backend/templates/backoffice/components/stepper.html
@@ -59,11 +59,13 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                 {% set is_disabled = item.disabled and is_wizard %}
                 {% set step_role = "step" if is_wizard else "tab" %}
 
-                {# Pass-through attributes for anything not consumed above #}
+                {# Pass-through attributes for anything not consumed above.
+                   Value is HTML-escaped; the surrounding = and " are marked safe so Jinja
+                   doesn't re-escape them when concatenating with the escaped Markup value. #}
                 {% set extra_attrs = [] %}
                 {% for key, value in item.items() %}
                     {% if key not in ["label", "href", "active", "disabled", "key", "state"] %}
-                        {% set _ = extra_attrs.append(key ~ '="' ~ value ~ '"') %}
+                        {% set _ = extra_attrs.append(key ~ ('="' | safe) ~ (value | e) ~ ('"' | safe)) %}
                     {% endif %}
                 {% endfor %}
 

--- a/backend/templates/backoffice/components/stepper.html
+++ b/backend/templates/backoffice/components/stepper.html
@@ -27,6 +27,10 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                   be disabled via `disabled: true`. Use when steps must be
                   completed in order.
     preserve_scroll: whether to preserve scroll position on navigation (default false)
+                     When true, requires the `x-scroll-preserve-links` Alpine directive
+                     (registered in `static/js/alpine-scroll-manager.js`, loaded by
+                     `backoffice/base.html`). Silently no-ops if used from a base
+                     template that doesn't load that script.
 
     Panel convention (same as tabs macro):
         <div id="{{ id }}-panel-{{ key }}" role="tabpanel"
@@ -45,7 +49,9 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
     #}
     {% set is_wizard = mode == "wizard" %}
     {% set list_role = "list" if is_wizard else "tablist" %}
-    <nav class="mb-8" aria-label="{{ aria_label }}" {% if preserve_scroll %}x-data x-scroll-preserve-links{% endif %}>
+    {# aria_label goes on the inner <ol> (the actual tab/step list); repeating it on the
+       outer <nav> landmark just doubles the announcement without adding meaning. #}
+    <nav class="mb-8" {% if preserve_scroll %}x-data x-scroll-preserve-links{% endif %}>
         <ol class="stepper"
             role="{{ list_role }}"
             aria-label="{{ aria_label }}"
@@ -82,7 +88,7 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                                 {% if state == "done" %}
                                     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 10 8 14 16 6"></polyline></svg>
                                 {% elif state == "error" %}
-                                    !
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3 L18 17 L2 17 Z"></path><line x1="10" y1="9" x2="10" y2="12"></line><line x1="10" y1="15" x2="10.01" y2="15"></line></svg>
                                 {% else %}
                                     {{ loop.index }}
                                 {% endif %}
@@ -111,7 +117,7 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                                 {% if state == "done" %}
                                     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 10 8 14 16 6"></polyline></svg>
                                 {% elif state == "error" %}
-                                    !
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3 L18 17 L2 17 Z"></path><line x1="10" y1="9" x2="10" y2="12"></line><line x1="10" y1="15" x2="10.01" y2="15"></line></svg>
                                 {% else %}
                                     {{ loop.index }}
                                 {% endif %}

--- a/backend/templates/backoffice/components/stepper.html
+++ b/backend/templates/backoffice/components/stepper.html
@@ -1,0 +1,117 @@
+{#
+ABOUTME: Stepper component macro — numbered step navigation with tabs or wizard semantics
+ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="step"
+#}
+{% macro stepper(items=[], aria_label="", id="", mode="tabs", preserve_scroll=false) %}
+    {#
+    Numbered step navigation with two semantic modes.
+
+    items: list of step dicts, each with:
+        - key: unique identifier (REQUIRED — used for tab/panel ids and aria-controls)
+        - label: display text (REQUIRED)
+        - href: link URL (REQUIRED)
+        - state: one of "active" | "inactive" | "done" | "error"
+                 optional — if omitted, derived from `active` bool
+                            (active=true → "active", else "inactive")
+        - active: bool (optional, mirrors tabs macro)
+        - disabled: bool (optional, only meaningful in wizard mode)
+        - Any additional attributes pass through to the anchor element
+
+    aria_label: accessible label for the step navigation (REQUIRED)
+    id: base id for tab/panel ids and focus preservation (REQUIRED)
+    mode: "tabs" (default) or "wizard"
+        - tabs: role="tablist" + role="tab", all steps clickable, arrow-key nav,
+                aria-selected on active step. Use when panels are peer views of
+                related content.
+        - wizard: role="list" + aria-current="step" on active, later steps may
+                  be disabled via `disabled: true`. Use when steps must be
+                  completed in order.
+    preserve_scroll: whether to preserve scroll position on navigation (default false)
+
+    Panel convention (same as tabs macro):
+        <div id="{{ id }}-panel-{{ key }}" role="tabpanel"
+             aria-labelledby="{{ id }}-tab-{{ key }}" tabindex="0">...</div>
+
+    Example (tabs mode):
+        {{ stepper(
+            id="reg-steps",
+            items=[
+                {"key": "form", "label": "Registration page", "href": "?section=form", "state": "done"},
+                {"key": "email", "label": "Auto-reply email", "href": "?section=email", "active": true},
+                {"key": "preview", "label": "Preview and publish", "href": "?section=preview"}
+            ],
+            aria_label=_("Registration setup steps")
+        ) }}
+    #}
+    {% set is_wizard = mode == "wizard" %}
+    {% set list_role = "list" if is_wizard else "tablist" %}
+    <nav class="mb-8" aria-label="{{ aria_label }}" {% if preserve_scroll %}x-data x-scroll-preserve-links{% endif %}>
+        <ol class="stepper"
+            role="{{ list_role }}"
+            aria-label="{{ aria_label }}"
+            {% if not is_wizard %}x-data="tabsKeyboard({ activation: 'manual' })" @keydown="handleKeydown($event)"{% endif %}>
+            {% for item in items %}
+                {% set item_key = item.key %}
+                {% set tab_id = id ~ "-tab-" ~ item_key %}
+                {% set panel_id = id ~ "-panel-" ~ item_key %}
+                {% set is_active = item.active or item.state == "active" %}
+                {% set state = item.state | default("active" if is_active else "inactive") %}
+                {% set is_disabled = item.disabled and is_wizard %}
+                {% set step_role = "step" if is_wizard else "tab" %}
+
+                {# Pass-through attributes for anything not consumed above #}
+                {% set extra_attrs = [] %}
+                {% for key, value in item.items() %}
+                    {% if key not in ["label", "href", "active", "disabled", "key", "state"] %}
+                        {% set _ = extra_attrs.append(key ~ '="' ~ value ~ '"') %}
+                    {% endif %}
+                {% endfor %}
+
+                <li class="stepper-item stepper-item-{{ state }}"
+                    {% if is_wizard %}role="listitem"{% else %}role="presentation"{% endif %}>
+                    {% if is_disabled %}
+                        <span class="stepper-link"
+                              role="{{ step_role }}"
+                              id="{{ tab_id }}"
+                              aria-disabled="true"
+                              {% if not is_wizard %}aria-controls="{{ panel_id }}" tabindex="-1"{% endif %}
+                              {{ extra_attrs | join(" ") | safe }}>
+                            <span class="stepper-number" aria-hidden="true">
+                                {% if state == "done" %}
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 10 8 14 16 6"></polyline></svg>
+                                {% elif state == "error" %}
+                                    !
+                                {% else %}
+                                    {{ loop.index }}
+                                {% endif %}
+                            </span>
+                            <span class="stepper-label">{{ item.label }}</span>
+                        </span>
+                    {% else %}
+                        <a href="{{ item.href }}"
+                           class="stepper-link"
+                           role="{{ step_role }}"
+                           id="{{ tab_id }}"
+                           {% if not is_wizard %}aria-controls="{{ panel_id }}" aria-selected="{{ 'true' if is_active else 'false' }}" tabindex="{{ '0' if is_active else '-1' }}"{% endif %}
+                           {% if is_wizard and is_active %}aria-current="step"{% endif %}
+                           data-focus-id="{{ tab_id }}"
+                           x-data
+                           x-focus-preserve
+                           {{ extra_attrs | join(" ") | safe }}>
+                            <span class="stepper-number" aria-hidden="true">
+                                {% if state == "done" %}
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 10 8 14 16 6"></polyline></svg>
+                                {% elif state == "error" %}
+                                    !
+                                {% else %}
+                                    {{ loop.index }}
+                                {% endif %}
+                            </span>
+                            <span class="stepper-label">{{ item.label }}</span>
+                        </a>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ol>
+    </nav>
+{% endmacro %}

--- a/backend/templates/backoffice/patterns.html
+++ b/backend/templates/backoffice/patterns.html
@@ -49,7 +49,8 @@ ABOUTME: Documents Alpine.js patterns, form handling, and AJAX with live example
         {"key": "scroll", "label": _("Scroll"), "href": url_for('dev.patterns', tab='scroll'), "active": active_tab == 'scroll'},
         {"key": "focus", "label": _("Focus"), "href": url_for('dev.patterns', tab='focus'), "active": active_tab == 'focus'},
         {"key": "floating-alerts", "label": _("Floating Alerts"), "href": url_for('dev.patterns', tab='floating-alerts'), "active": active_tab == 'floating-alerts'},
-        {"key": "custom", "label": _("Custom Components"), "href": url_for('dev.patterns', tab='custom'), "active": active_tab == 'custom'}
+        {"key": "custom", "label": _("Custom Components"), "href": url_for('dev.patterns', tab='custom'), "active": active_tab == 'custom'},
+        {"key": "stepper", "label": _("Stepper"), "href": url_for('dev.patterns', tab='stepper'), "active": active_tab == 'stepper'}
         ],
         aria_label=_("Pattern categories"),
         preserve_scroll=true
@@ -94,6 +95,10 @@ ABOUTME: Documents Alpine.js patterns, form handling, and AJAX with live example
 
         {% if active_tab == 'custom' %}
             {% include "backoffice/patterns/_custom.html" %}
+        {% endif %}
+
+        {% if active_tab == 'stepper' %}
+            {% include "backoffice/patterns/_stepper.html" %}
         {% endif %}
 
         {# Toast Notification #}

--- a/backend/templates/backoffice/patterns/_stepper.html
+++ b/backend/templates/backoffice/patterns/_stepper.html
@@ -30,7 +30,8 @@ ABOUTME: Documents states (active/inactive/done/error), URL contract, and panel 
                 {"key": "three", "label": _("Preview and publish"), "href": "?tab=stepper&mode=tabs&step=three"}
                 ],
                 aria_label=_("Example stepper (tabs mode)"),
-                mode="tabs"
+                mode="tabs",
+                preserve_scroll=true
                 ) }}
             </div>
 
@@ -67,7 +68,8 @@ ABOUTME: Documents states (active/inactive/done/error), URL contract, and panel 
                 {"key": "three", "label": _("Choose a plan"), "href": "?tab=stepper&mode=wizard&step=three", "disabled": true}
                 ],
                 aria_label=_("Example stepper (wizard mode)"),
-                mode="wizard"
+                mode="wizard",
+                preserve_scroll=true
                 ) }}
             </div>
 

--- a/backend/templates/backoffice/patterns/_stepper.html
+++ b/backend/templates/backoffice/patterns/_stepper.html
@@ -1,0 +1,165 @@
+{#
+ABOUTME: Showcase for the stepper() macro — tabs mode + wizard mode live examples
+ABOUTME: Documents states (active/inactive/done/error), URL contract, and panel convention
+#}
+{% from "backoffice/components/card.html" import card, card_body %}
+{% from "backoffice/components/stepper.html" import stepper %}
+
+<div class="space-y-6">
+    <div class="rounded-lg p-4 mb-4"
+         style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400); color: var(--color-info-600);">
+        <p class="text-body-md">
+            <span class="font-semibold">🪜 {{ _("Stepper") }}:</span>
+            {{ _("Numbered step navigation with two semantic modes. Use tabs mode when the panels are peer views of the same content; use wizard mode when steps must be completed in order.") }}
+        </p>
+    </div>
+
+    {# ===== tabs mode ===== #}
+    {% call card(title="Tabs mode (default)", composed=true) %}
+        {% call card_body() %}
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("All steps are always clickable, arrow-key navigation moves focus between steps, and the active step is announced with aria-selected. Under the hood this is a tablist — use it when the panels are peers.") }}
+            </p>
+
+            <div class="mb-6">
+                {{ stepper(
+                id="showcase-tabs",
+                items=[
+                {"key": "one", "label": _("Registration page"), "href": "?tab=stepper&mode=tabs&step=one", "state": "done"},
+                {"key": "two", "label": _("Auto-reply email"), "href": "?tab=stepper&mode=tabs&step=two", "active": true},
+                {"key": "three", "label": _("Preview and publish"), "href": "?tab=stepper&mode=tabs&step=three"}
+                ],
+                aria_label=_("Example stepper (tabs mode)"),
+                mode="tabs"
+                ) }}
+            </div>
+
+            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Code") }}</h4>
+            <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto"
+                 style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{% raw %}{% from "backoffice/components/stepper.html" import stepper %}
+
+{{ stepper(
+    id="reg-steps",
+    items=[
+        {"key": "form",    "label": "Registration page",   "href": "?section=form",    "state": "done"},
+        {"key": "email",   "label": "Auto-reply email",    "href": "?section=email",   "active": true},
+        {"key": "preview", "label": "Preview and publish", "href": "?section=preview"}
+    ],
+    aria_label="Registration setup steps",
+    mode="tabs"
+) }}{% endraw %}</pre>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== wizard mode ===== #}
+    {% call card(title="Wizard mode", composed=true) %}
+        {% call card_body() %}
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Later steps can be disabled until earlier ones are complete. The active step is marked with aria-current='step' and disabled steps render as non-focusable spans. Use this when there is a genuine linear dependency.") }}
+            </p>
+
+            <div class="mb-6">
+                {{ stepper(
+                id="showcase-wizard",
+                items=[
+                {"key": "one", "label": _("Sign the agreement"), "href": "?tab=stepper&mode=wizard&step=one", "state": "done"},
+                {"key": "two", "label": _("Verify your email"), "href": "?tab=stepper&mode=wizard&step=two", "active": true},
+                {"key": "three", "label": _("Choose a plan"), "href": "?tab=stepper&mode=wizard&step=three", "disabled": true}
+                ],
+                aria_label=_("Example stepper (wizard mode)"),
+                mode="wizard"
+                ) }}
+            </div>
+
+            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Code") }}</h4>
+            <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto"
+                 style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{% raw %}{{ stepper(
+    id="signup-wizard",
+    items=[
+        {"key": "agree",  "label": "Sign the agreement", "href": "?step=agree",  "state": "done"},
+        {"key": "verify", "label": "Verify your email", "href": "?step=verify", "active": true},
+        {"key": "plan",   "label": "Choose a plan",     "href": "?step=plan",   "disabled": true}
+    ],
+    aria_label="Sign-up wizard",
+    mode="wizard"
+) }}{% endraw %}</pre>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== State reference ===== #}
+    {% call card(title="States", composed=true) %}
+        {% call card_body() %}
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Set per item via the `state` key, or let it default from the `active` bool. Each state has its own colour treatment.") }}
+            </p>
+
+            <div class="mb-4">
+                <p class="text-body-sm mb-2" style="color: var(--color-secondary-text);">state: "active"</p>
+                {{ stepper(
+                id="showcase-active",
+                items=[{"key": "a", "label": _("Active step"), "href": "#", "state": "active"}],
+                aria_label=_("Active state"),
+                mode="wizard"
+                ) }}
+            </div>
+
+            <div class="mb-4">
+                <p class="text-body-sm mb-2" style="color: var(--color-secondary-text);">state: "inactive" (default)</p>
+                {{ stepper(
+                id="showcase-inactive",
+                items=[{"key": "a", "label": _("Inactive step"), "href": "#", "state": "inactive"}],
+                aria_label=_("Inactive state"),
+                mode="wizard"
+                ) }}
+            </div>
+
+            <div class="mb-4">
+                <p class="text-body-sm mb-2" style="color: var(--color-secondary-text);">state: "done"</p>
+                {{ stepper(
+                id="showcase-done",
+                items=[{"key": "a", "label": _("Completed step"), "href": "#", "state": "done"}],
+                aria_label=_("Done state"),
+                mode="wizard"
+                ) }}
+            </div>
+
+            <div>
+                <p class="text-body-sm mb-2" style="color: var(--color-secondary-text);">state: "error"</p>
+                {{ stepper(
+                id="showcase-error",
+                items=[{"key": "a", "label": _("Step with an error"), "href": "#", "state": "error"}],
+                aria_label=_("Error state"),
+                mode="wizard"
+                ) }}
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== API reference ===== #}
+    {% call card(title="API", composed=true) %}
+        {% call card_body() %}
+            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Signature") }}</h4>
+            <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto mb-4"
+                 style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">stepper(items=[], aria_label="", id="", mode="tabs", preserve_scroll=false)</pre>
+
+            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Item keys") }}</h4>
+            <ul class="text-body-sm font-mono mb-4" style="color: var(--color-body-text);">
+                <li>key: str ✅ ({{ _("unique per stepper — used for tab/panel ids") }})</li>
+                <li>label: str ✅</li>
+                <li>href: str ✅</li>
+                <li>state: "active" | "inactive" | "done" | "error" ❌ ({{ _("derived from `active` if omitted") }})</li>
+                <li>active: bool ❌ ({{ _("shortcut for state='active'") }})</li>
+                <li>disabled: bool ❌ ({{ _("only meaningful in wizard mode") }})</li>
+            </ul>
+
+            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Panel convention (same as tabs macro)") }}</h4>
+            <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto"
+                 style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">&lt;div id="{id}-panel-{key}"
+                role="tabpanel"
+                aria-labelledby="{id}-tab-{key}"
+                tabindex="0"&gt;
+                …
+                &lt;/div&gt;</pre>
+        {% endcall %}
+    {% endcall %}
+</div>

--- a/backend/templates/backoffice/service_docs.html
+++ b/backend/templates/backoffice/service_docs.html
@@ -45,7 +45,8 @@ ABOUTME: Provides testing console with code references, sample data, and executi
         {"key": "targets", "label": _("Targets"), "href": url_for('dev.service_docs', tab='targets'), "active": active_tab == 'targets'},
         {"key": "config", "label": _("CSV Config"), "href": url_for('dev.service_docs', tab='config'), "active": active_tab == 'config'},
         {"key": "selection", "label": _("Selection"), "href": url_for('dev.service_docs', tab='selection'), "active": active_tab == 'selection'},
-        {"key": "images", "label": _("Images"), "href": url_for('dev.service_docs', tab='images'), "active": active_tab == 'images'}
+        {"key": "images", "label": _("Images"), "href": url_for('dev.service_docs', tab='images'), "active": active_tab == 'images'},
+        {"key": "emails", "label": _("Emails"), "href": url_for('dev.service_docs', tab='emails'), "active": active_tab == 'emails'}
         ],
         aria_label=_("Service categories"),
         preserve_scroll=true
@@ -82,6 +83,10 @@ ABOUTME: Provides testing console with code references, sample data, and executi
 
         {% if active_tab == 'images' %}
             {% include "backoffice/service_docs/_images.html" %}
+        {% endif %}
+
+        {% if active_tab == 'emails' %}
+            {% include "backoffice/service_docs/_emails.html" %}
         {% endif %}
 
         {# Toast Notification #}
@@ -171,6 +176,22 @@ ABOUTME: Provides testing console with code references, sample data, and executi
                 submitRegistrationFormData: '{}',
                 submitRegistrationIsTest: false,
 
+                // Email template / send form properties
+                createTemplateAssemblyId: '',
+                createTemplateName: '',
+                createTemplateSubject: '',
+                createTemplateBodyHtml: '',
+                listTemplatesAssemblyId: '',
+                getTemplateId: '',
+                updateTemplateId: '',
+                updateTemplateName: '',
+                updateTemplateSubject: '',
+                updateTemplateBodyHtml: '',
+                deleteTemplateId: '',
+                assignAutoReplyAssemblyId: '',
+                assignAutoReplyTemplateId: '',
+                autoReplyReadinessAssemblyId: '',
+
                 // Loading state for each service
                 loading: {
                     import_respondents: false,
@@ -198,7 +219,14 @@ ABOUTME: Provides testing console with code references, sample data, and executi
                     delete_image: false,
                     set_image_alt: false,
                     list_snippets: false,
-                    serve_image: false
+                    serve_image: false,
+                    create_email_template: false,
+                    list_email_templates: false,
+                    get_email_template: false,
+                    update_email_template: false,
+                    delete_email_template: false,
+                    assign_auto_reply_template: false,
+                    auto_reply_readiness: false
                 },
 
                 // Response data for each service
@@ -228,7 +256,14 @@ ABOUTME: Provides testing console with code references, sample data, and executi
                     delete_image: null,
                     set_image_alt: null,
                     list_snippets: null,
-                    serve_image: null
+                    serve_image: null,
+                    create_email_template: null,
+                    list_email_templates: null,
+                    get_email_template: null,
+                    update_email_template: null,
+                    delete_email_template: null,
+                    assign_auto_reply_template: null,
+                    auto_reply_readiness: null
                 },
 
                 // Sample data for each service
@@ -252,7 +287,12 @@ Age,51+,2,5,1,1`,
     <input type="text" id="first_name" name="first_name" required />
   </div>
   <button type="submit">Register</button>
-</form>`
+</form>`,
+                    email_subject: `Thanks for registering, {{ '{{' }} respondent.first_name_or_friend {{ '}}' }}!`,
+                    email_body: `<p>Hi {{ '{{' }} respondent.first_name_or_friend {{ '}}' }},</p>
+<p>Thanks for registering for <strong>{{ '{{' }} assembly.title {{ '}}' }}</strong>.</p>
+<p>We will get back to you about the assembly on {{ '{{' }} assembly.first_assembly_date {{ '}}' }}.</p>
+<p>Best wishes,<br>The team</p>`
                 },
 
                 async executeService(serviceName, params) {
@@ -283,7 +323,14 @@ Age,51+,2,5,1,1`,
                         'delete_registration_image': 'delete_image',
                         'set_registration_image_alt': 'set_image_alt',
                         'list_image_snippets': 'list_snippets',
-                        'get_registration_image_for_serving': 'serve_image'
+                        'get_registration_image_for_serving': 'serve_image',
+                        'create_email_template': 'create_email_template',
+                        'list_email_templates': 'list_email_templates',
+                        'get_email_template': 'get_email_template',
+                        'update_email_template': 'update_email_template',
+                        'delete_email_template': 'delete_email_template',
+                        'assign_auto_reply_template': 'assign_auto_reply_template',
+                        'auto_reply_readiness_problems': 'auto_reply_readiness'
                     };
                     const key = keyMap[serviceName];
 
@@ -541,6 +588,56 @@ Age,51+,2,5,1,1`,
                         url_slug: this.serveImageUrlSlug,
                         image_name: this.serveImageImageName
                     });
+                },
+
+                // ===== Email template / send service execute methods =====
+                executeCreateEmailTemplate() {
+                    this.executeService('create_email_template', {
+                        assembly_id: this.createTemplateAssemblyId,
+                        name: this.createTemplateName,
+                        subject: this.createTemplateSubject,
+                        body_html: this.createTemplateBodyHtml
+                    });
+                },
+                executeListEmailTemplates() {
+                    this.executeService('list_email_templates', {
+                        assembly_id: this.listTemplatesAssemblyId
+                    });
+                },
+                executeGetEmailTemplate() {
+                    this.executeService('get_email_template', {
+                        template_id: this.getTemplateId
+                    });
+                },
+                executeUpdateEmailTemplate() {
+                    // Only send fields that were entered (so callers can update one at a time)
+                    const params = { template_id: this.updateTemplateId };
+                    if (this.updateTemplateName) params.name = this.updateTemplateName;
+                    if (this.updateTemplateSubject) params.subject = this.updateTemplateSubject;
+                    if (this.updateTemplateBodyHtml) params.body_html = this.updateTemplateBodyHtml;
+                    this.executeService('update_email_template', params);
+                },
+                executeDeleteEmailTemplate() {
+                    this.executeService('delete_email_template', {
+                        template_id: this.deleteTemplateId
+                    });
+                },
+                executeAssignAutoReplyTemplate() {
+                    this.executeService('assign_auto_reply_template', {
+                        assembly_id: this.assignAutoReplyAssemblyId,
+                        template_id: this.assignAutoReplyTemplateId || null
+                    });
+                },
+                executeAutoReplyReadinessProblems() {
+                    this.executeService('auto_reply_readiness_problems', {
+                        assembly_id: this.autoReplyReadinessAssemblyId
+                    });
+                },
+                loadEmailSubjectSample() {
+                    this.createTemplateSubject = this.sampleData.email_subject;
+                },
+                loadEmailBodySample() {
+                    this.createTemplateBodyHtml = this.sampleData.email_body;
                 },
 
                 // ===== Reset methods =====

--- a/backend/templates/backoffice/service_docs/_emails.html
+++ b/backend/templates/backoffice/service_docs/_emails.html
@@ -1,0 +1,644 @@
+{#
+ABOUTME: Service documentation for assembly-scoped email templates and templated email sending
+ABOUTME: Documents CRUD on EmailTemplate, auto-reply assignment, readiness checks, and the send path
+#}
+<div class="space-y-6">
+
+    <div class="rounded-lg p-4 mb-4"
+         style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400); color: var(--color-info-600);">
+        <p class="text-body-md">
+            <span class="font-semibold">📧 {{ _("Templated emails") }}:</span>
+            {{ _("Assembly-scoped email templates with a Jinja subject and HTML body. Used to send the registration auto-reply and (in future) other respondent emails.") }}
+        </p>
+        <p class="text-body-sm mt-2">
+            {{ _("Template variables: ") }}
+            <code>assembly.title</code>, <code>assembly.question</code>, <code>assembly.first_assembly_date</code>,
+            <code>assembly.number_to_select</code>, <code>respondent.email</code>,
+            <code>respondent.first_name</code>, <code>respondent.last_name</code>, <code>respondent.full_name</code>,
+            <code>respondent.first_name_or_friend</code>, <code>respondent.attributes</code>.
+        </p>
+    </div>
+
+    {# ===== INTERACTIVE: create_email_template ===== #}
+    {% call card(title="create_email_template()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_template_service.py:109
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100); color: var(--color-warning-600)">🔒 can_manage_assembly()</span>
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-success-100); color: var(--color-success-600)">🧪 Interactive</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Create an assembly-scoped email template. Validates name/subject/body presence, Jinja syntax and body size (configurable via EMAIL_TEMPLATE_BODY_MAX_BYTES).") }}
+            </p>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                    <li>assembly_id: UUID ✅</li>
+                    <li>name: str ✅ ({{ _("manager-facing label") }})</li>
+                    <li>subject: str ✅ ({{ _("Jinja template") }})</li>
+                    <li>body_html: str ✅ ({{ _("HTML body, Jinja template; auto-converted to text") }})</li>
+                </ul>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm">EmailTemplate</code>
+                <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                    {{ _("Raises EmailTemplateInvalid with a list of problems on bad input.") }}
+                </p>
+            </div>
+            {# Try It Section #}
+            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                    <span class="mr-2">🧪</span>{{ _("Try It") }}
+                </h4>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Assembly") }}</label>
+                    <select x-model="createTemplateAssemblyId" class="w-full px-3 py-2 rounded-lg text-body-md"
+                            style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                        <option value="">{{ _("Select an assembly...") }}</option>
+                        {% for assembly in assemblies %}<option value="{{ assembly.id }}">{{ assembly.title }}</option>{% endfor %}
+                    </select>
+                </div>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Name") }}</label>
+                    <input type="text" x-model="createTemplateName" placeholder="e.g., Registration auto-reply"
+                           class="w-full px-3 py-2 rounded-lg text-body-md"
+                           style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                </div>
+                <div class="mb-4">
+                    <div class="flex items-center justify-between mb-1">
+                        <label class="text-label-md" style="color: var(--color-headings)">{{ _("Subject (Jinja)") }}</label>
+                        <button @click="loadEmailSubjectSample()" type="button"
+                                class="text-body-sm px-2 py-1 rounded"
+                                style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600);">📥 {{ _("Load sample") }}</button>
+                    </div>
+                    <input type="text" x-model="createTemplateSubject"
+                           class="w-full px-3 py-2 rounded-lg text-body-md"
+                           style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                </div>
+                <div class="mb-4">
+                    <div class="flex items-center justify-between mb-1">
+                        <label class="text-label-md" style="color: var(--color-headings)">{{ _("Body HTML (Jinja)") }}</label>
+                        <button @click="loadEmailBodySample()" type="button"
+                                class="text-body-sm px-2 py-1 rounded"
+                                style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600);">📥 {{ _("Load sample") }}</button>
+                    </div>
+                    <textarea x-model="createTemplateBodyHtml" rows="8"
+                              class="w-full px-3 py-2 rounded-lg text-body-md font-mono"
+                              style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)"></textarea>
+                </div>
+                <div class="flex gap-2 mb-4">
+                    <button @click="executeCreateEmailTemplate()" :disabled="loading.create_email_template"
+                            class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                            style="background-color: var(--color-primary-action); color: var(--color-page-background)">
+                        <span x-show="!loading.create_email_template">▶️ {{ _("Execute") }}</span>
+                        <span x-cloak x-show="loading.create_email_template">⏳ {{ _("Running...") }}</span>
+                    </button>
+                </div>
+                <template x-if="responses.create_email_template">
+                    <div class="rounded-lg p-4"
+                         :style="responses.create_email_template.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                        <div class="flex items-center justify-between mb-2">
+                            <span class="text-heading-sm"
+                                  :style="responses.create_email_template.status === 'success' ? 'color: var(--color-success-600);' : 'color: var(--color-error-600);'">
+                                <span x-text="responses.create_email_template.status === 'success' ? '✅ Success' : '❌ Error'"></span>
+                            </span>
+                        </div>
+                        <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap"
+                             style="color: var(--color-body-text)"
+                             x-text="formatResponse('create_email_template')"></pre>
+                    </div>
+                </template>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== INTERACTIVE: list_email_templates ===== #}
+    {% call card(title="list_email_templates()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_template_service.py:161
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-info-100); color: var(--color-info-600)">🔍 can_view_assembly()</span>
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-success-100); color: var(--color-success-600)">🧪 Interactive</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("List all email templates for an assembly the user may view, oldest first.") }}
+            </p>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                    <li>assembly_id: UUID ✅</li>
+                </ul>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm">list[EmailTemplate]</code>
+            </div>
+            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                    <span class="mr-2">🧪</span>{{ _("Try It") }}
+                </h4>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Assembly") }}</label>
+                    <select x-model="listTemplatesAssemblyId" class="w-full px-3 py-2 rounded-lg text-body-md"
+                            style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                        <option value="">{{ _("Select an assembly...") }}</option>
+                        {% for assembly in assemblies %}<option value="{{ assembly.id }}">{{ assembly.title }}</option>{% endfor %}
+                    </select>
+                </div>
+                <div class="flex gap-2 mb-4">
+                    <button @click="executeListEmailTemplates()" :disabled="loading.list_email_templates"
+                            class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                            style="background-color: var(--color-primary-action); color: var(--color-page-background)">
+                        <span x-show="!loading.list_email_templates">▶️ {{ _("Execute") }}</span>
+                        <span x-cloak x-show="loading.list_email_templates">⏳ {{ _("Running...") }}</span>
+                    </button>
+                </div>
+                <template x-if="responses.list_email_templates">
+                    <div class="rounded-lg p-4"
+                         :style="responses.list_email_templates.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                        <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap"
+                             style="color: var(--color-body-text)"
+                             x-text="formatResponse('list_email_templates')"></pre>
+                    </div>
+                </template>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== INTERACTIVE: get_email_template ===== #}
+    {% call card(title="get_email_template()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_template_service.py:151
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-info-100); color: var(--color-info-600)">🔍 can_view_assembly()</span>
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-success-100); color: var(--color-success-600)">🧪 Interactive</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Get a single email template by id. The user must have view permissions on its assembly.") }}
+            </p>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                    <li>template_id: UUID ✅</li>
+                </ul>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm">EmailTemplate</code>
+                <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                    {{ _("Raises EmailTemplateNotFoundError when not found.") }}
+                </p>
+            </div>
+            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                    <span class="mr-2">🧪</span>{{ _("Try It") }}
+                </h4>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Template ID") }}</label>
+                    <input type="text" x-model="getTemplateId" placeholder="UUID"
+                           class="w-full px-3 py-2 rounded-lg text-body-md font-mono"
+                           style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                </div>
+                <div class="flex gap-2 mb-4">
+                    <button @click="executeGetEmailTemplate()" :disabled="loading.get_email_template"
+                            class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                            style="background-color: var(--color-primary-action); color: var(--color-page-background)">
+                        <span x-show="!loading.get_email_template">▶️ {{ _("Execute") }}</span>
+                        <span x-cloak x-show="loading.get_email_template">⏳ {{ _("Running...") }}</span>
+                    </button>
+                </div>
+                <template x-if="responses.get_email_template">
+                    <div class="rounded-lg p-4"
+                         :style="responses.get_email_template.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                        <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap"
+                             style="color: var(--color-body-text)"
+                             x-text="formatResponse('get_email_template')"></pre>
+                    </div>
+                </template>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== INTERACTIVE: update_email_template ===== #}
+    {% call card(title="update_email_template()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_template_service.py:130
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100); color: var(--color-warning-600)">🔒 can_manage_assembly()</span>
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-success-100); color: var(--color-success-600)">🧪 Interactive</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Update one or more of the name, subject and body. Leave a field blank to leave it unchanged. Re-validates the template after the change.") }}
+            </p>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                    <li>template_id: UUID ✅</li>
+                    <li>name: str | None ❌</li>
+                    <li>subject: str | None ❌</li>
+                    <li>body_html: str | None ❌</li>
+                </ul>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm">EmailTemplate</code>
+            </div>
+            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                    <span class="mr-2">🧪</span>{{ _("Try It") }}
+                </h4>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Template ID") }}</label>
+                    <input type="text" x-model="updateTemplateId" placeholder="UUID"
+                           class="w-full px-3 py-2 rounded-lg text-body-md font-mono"
+                           style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                </div>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("New name (blank = leave alone)") }}</label>
+                    <input type="text" x-model="updateTemplateName"
+                           class="w-full px-3 py-2 rounded-lg text-body-md"
+                           style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                </div>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("New subject (blank = leave alone)") }}</label>
+                    <input type="text" x-model="updateTemplateSubject"
+                           class="w-full px-3 py-2 rounded-lg text-body-md"
+                           style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                </div>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("New body HTML (blank = leave alone)") }}</label>
+                    <textarea x-model="updateTemplateBodyHtml" rows="6"
+                              class="w-full px-3 py-2 rounded-lg text-body-md font-mono"
+                              style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)"></textarea>
+                </div>
+                <div class="flex gap-2 mb-4">
+                    <button @click="executeUpdateEmailTemplate()" :disabled="loading.update_email_template"
+                            class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                            style="background-color: var(--color-primary-action); color: var(--color-page-background)">
+                        <span x-show="!loading.update_email_template">▶️ {{ _("Execute") }}</span>
+                        <span x-cloak x-show="loading.update_email_template">⏳ {{ _("Running...") }}</span>
+                    </button>
+                </div>
+                <template x-if="responses.update_email_template">
+                    <div class="rounded-lg p-4"
+                         :style="responses.update_email_template.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                        <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap"
+                             style="color: var(--color-body-text)"
+                             x-text="formatResponse('update_email_template')"></pre>
+                    </div>
+                </template>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== INTERACTIVE: delete_email_template ===== #}
+    {% call card(title="delete_email_template()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_template_service.py:170
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100); color: var(--color-warning-600)">🔒 can_manage_assembly()</span>
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-success-100); color: var(--color-success-600)">🧪 Interactive</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Delete an email template. The registration page's auto_reply_email_template_id FK is cleared by ON DELETE SET NULL.") }}
+            </p>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                    <li>template_id: UUID ✅</li>
+                </ul>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm">None</code>
+            </div>
+            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                    <span class="mr-2">🧪</span>{{ _("Try It") }}
+                </h4>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Template ID") }}</label>
+                    <input type="text" x-model="deleteTemplateId" placeholder="UUID"
+                           class="w-full px-3 py-2 rounded-lg text-body-md font-mono"
+                           style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                </div>
+                <div class="flex gap-2 mb-4">
+                    <button @click="executeDeleteEmailTemplate()" :disabled="loading.delete_email_template"
+                            class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                            style="background-color: var(--color-error-600); color: var(--color-page-background)">
+                        <span x-show="!loading.delete_email_template">🗑️ {{ _("Delete") }}</span>
+                        <span x-cloak x-show="loading.delete_email_template">⏳ {{ _("Running...") }}</span>
+                    </button>
+                </div>
+                <template x-if="responses.delete_email_template">
+                    <div class="rounded-lg p-4"
+                         :style="responses.delete_email_template.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                        <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap"
+                             style="color: var(--color-body-text)"
+                             x-text="formatResponse('delete_email_template')"></pre>
+                    </div>
+                </template>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== INTERACTIVE: assign_auto_reply_template ===== #}
+    {% call card(title="assign_auto_reply_template()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_template_service.py:181
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-warning-100); color: var(--color-warning-600)">🔒 can_manage_assembly()</span>
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-success-100); color: var(--color-success-600)">🧪 Interactive</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Set the registration page's auto-reply template, or clear it by passing an empty template id. Readiness problems (no email field, optional email) are logged but never block this call.") }}
+            </p>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                    <li>assembly_id: UUID ✅</li>
+                    <li>template_id: UUID | None ✅ ({{ _("None or empty clears the assignment") }})</li>
+                </ul>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm">None</code>
+                <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                    {{ _("Raises RegistrationPageNotFoundError if the assembly has no page; EmailTemplateNotFoundError if the template id is not on this assembly.") }}
+                </p>
+            </div>
+            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                    <span class="mr-2">🧪</span>{{ _("Try It") }}
+                </h4>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Assembly") }}</label>
+                    <select x-model="assignAutoReplyAssemblyId" class="w-full px-3 py-2 rounded-lg text-body-md"
+                            style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                        <option value="">{{ _("Select an assembly...") }}</option>
+                        {% for assembly in assemblies %}<option value="{{ assembly.id }}">{{ assembly.title }}</option>{% endfor %}
+                    </select>
+                </div>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Template ID (blank = clear)") }}</label>
+                    <input type="text" x-model="assignAutoReplyTemplateId" placeholder="UUID or blank"
+                           class="w-full px-3 py-2 rounded-lg text-body-md font-mono"
+                           style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                </div>
+                <div class="flex gap-2 mb-4">
+                    <button @click="executeAssignAutoReplyTemplate()" :disabled="loading.assign_auto_reply_template"
+                            class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                            style="background-color: var(--color-primary-action); color: var(--color-page-background)">
+                        <span x-show="!loading.assign_auto_reply_template">▶️ {{ _("Execute") }}</span>
+                        <span x-cloak x-show="loading.assign_auto_reply_template">⏳ {{ _("Running...") }}</span>
+                    </button>
+                </div>
+                <template x-if="responses.assign_auto_reply_template">
+                    <div class="rounded-lg p-4"
+                         :style="responses.assign_auto_reply_template.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                        <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap"
+                             style="color: var(--color-body-text)"
+                             x-text="formatResponse('assign_auto_reply_template')"></pre>
+                    </div>
+                </template>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== INTERACTIVE: auto_reply_readiness_problems ===== #}
+    {% call card(title="auto_reply_readiness_problems()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded"
+                      style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_template_service.py:73
+                </code>
+                <div class="flex gap-2">
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-secondary-text); color: var(--color-page-background)">⚙️ No permission check</span>
+                    <span class="text-body-sm px-2 py-1 rounded"
+                          style="background-color: var(--color-success-100); color: var(--color-success-600)">🧪 Interactive</span>
+                </div>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Inspect whether the assembly's registration page is configured to actually deliver an auto-reply. Returns an ERROR if no email is collected, a WARNING if email is optional, or an empty list if email is required.") }}
+            </p>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                    <li>assembly_id: UUID ✅</li>
+                </ul>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                <code class="text-body-sm">list[AutoReplyReadinessProblem]</code>
+            </div>
+            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers)">
+                <h4 class="text-heading-sm mb-4" style="color: var(--color-headings);">
+                    <span class="mr-2">🧪</span>{{ _("Try It") }}
+                </h4>
+                <div class="mb-4">
+                    <label class="text-label-md block mb-1" style="color: var(--color-headings)">{{ _("Assembly") }}</label>
+                    <select x-model="autoReplyReadinessAssemblyId" class="w-full px-3 py-2 rounded-lg text-body-md"
+                            style="background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers); color: var(--color-body-text)">
+                        <option value="">{{ _("Select an assembly...") }}</option>
+                        {% for assembly in assemblies %}<option value="{{ assembly.id }}">{{ assembly.title }}</option>{% endfor %}
+                    </select>
+                </div>
+                <div class="flex gap-2 mb-4">
+                    <button @click="executeAutoReplyReadinessProblems()" :disabled="loading.auto_reply_readiness"
+                            class="px-4 py-2 rounded-lg text-button-lg transition-all"
+                            style="background-color: var(--color-primary-action); color: var(--color-page-background)">
+                        <span x-show="!loading.auto_reply_readiness">▶️ {{ _("Execute") }}</span>
+                        <span x-cloak x-show="loading.auto_reply_readiness">⏳ {{ _("Running...") }}</span>
+                    </button>
+                </div>
+                <template x-if="responses.auto_reply_readiness">
+                    <div class="rounded-lg p-4"
+                         :style="responses.auto_reply_readiness.status === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400);'">
+                        <pre class="text-body-sm font-mono overflow-x-auto whitespace-pre-wrap"
+                             style="color: var(--color-body-text)"
+                             x-text="formatResponse('auto_reply_readiness')"></pre>
+                    </div>
+                </template>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# ===== STATIC DOCUMENTATION ===== #}
+    <div class="pt-4">
+        <h2 class="text-display-sm mb-4" style="color: var(--color-headings);">{{ _("Send path (not interactive)") }}</h2>
+        <p class="text-body-md mb-6" style="color: var(--color-secondary-text);">
+            {{ _("These functions take live domain aggregates (Assembly, Respondent) and the EmailAdapter, and are wired into the registration submit flow. Listed here for reference.") }}
+        </p>
+    </div>
+
+    {# send_registration_auto_reply #}
+    {% call card(title="send_registration_auto_reply()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_send_service.py:81
+                </code>
+                <span class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-secondary-text); color: var(--color-page-background)">⚙️ Called from registration submit</span>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Send the configured auto-reply to a newly registered respondent. Skips silently when no auto-reply is configured. Logs a warning when configured but the respondent has no email. Never raises on send failure - the failure is recorded as a RespondentEmailSendRecord with outcome=FAILED.") }}
+            </p>
+            <div class="grid grid-cols-2 gap-4">
+                <div>
+                    <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                    <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                        <li>uow: AbstractUnitOfWork ✅</li>
+                        <li>email_adapter: EmailAdapter ✅</li>
+                        <li>respondent: Respondent ✅ (kw-only)</li>
+                        <li>assembly_id: UUID ✅ (kw-only)</li>
+                    </ul>
+                </div>
+                <div>
+                    <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                    <code class="text-body-sm">RespondentEmailSendRecord | None</code>
+                    <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">{{ _("None when the send was skipped (no template, no email).") }}</p>
+                </div>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# send_templated_email #}
+    {% call card(title="send_templated_email()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_send_service.py:66
+                </code>
+                <span class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-secondary-text); color: var(--color-page-background)">⚙️ Internal building block</span>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Render a template against an assembly+respondent context and send it via the adapter, writing a RespondentEmailSendRecord either way. Never raises on send failure.") }}
+            </p>
+            <div class="grid grid-cols-2 gap-4">
+                <div>
+                    <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Parameters") }}</h4>
+                    <ul class="text-body-sm font-mono" style="color: var(--color-body-text);">
+                        <li>uow: AbstractUnitOfWork ✅</li>
+                        <li>email_adapter: EmailAdapter ✅</li>
+                        <li>template: EmailTemplate ✅ (kw-only)</li>
+                        <li>assembly: Assembly ✅ (kw-only)</li>
+                        <li>respondent: Respondent ✅ (kw-only)</li>
+                    </ul>
+                </div>
+                <div>
+                    <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Returns") }}</h4>
+                    <code class="text-body-sm">RespondentEmailSendRecord</code>
+                </div>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+    {# build_email_context #}
+    {% call card(title="build_email_context()", composed=true) %}
+        {% call card_body() %}
+            <div class="flex items-center justify-between mb-4">
+                <code class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-subtle-background-panels); color: var(--color-info-600)">
+                    email_send_service.py:20
+                </code>
+                <span class="text-body-sm px-2 py-1 rounded" style="background-color: var(--color-secondary-text); color: var(--color-page-background)">⚙️ Helper</span>
+            </div>
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Build the {assembly, respondent} dict that templates render against, using AssemblyContext.from_assembly() and RespondentContext.from_respondent() view-objects. Templates never see raw domain aggregates.") }}
+            </p>
+        {% endcall %}
+    {% endcall %}
+
+    {# Data Types Reference #}
+    {% call card(title="Data Types Reference", composed=true) %}
+        {% call card_body() %}
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">EmailTemplate</h4>
+                <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{
+  id: UUID,
+  assembly_id: UUID,
+  name: str,
+  subject: str,           # Jinja
+  body_html: str,         # Jinja, HTML
+  created_at: datetime,
+  updated_at: datetime
+}</pre>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">RespondentEmailSendRecord</h4>
+                <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{
+  id: UUID,
+  respondent_id: UUID,
+  email_template_id: UUID | None,
+  to_email: str,
+  from_email: str,
+  subject: str,
+  outcome: EmailSendOutcome,   # SENT | FAILED
+  missing_variables: list[str],
+  created_at: datetime
+}</pre>
+            </div>
+            <div class="mb-6">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">AutoReplyReadinessProblem</h4>
+                <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{
+  severity: AutoReplyReadinessSeverity,   # ERROR | WARNING
+  message: str
+}</pre>
+            </div>
+            <div>
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Available template variables") }}</h4>
+                <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto" style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">assembly:
+  title, question, first_assembly_date, number_to_select
+
+respondent:
+  email, attributes (dict),
+  first_name, last_name, full_name, first_name_or_friend</pre>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+</div>

--- a/backend/templates/backoffice/showcase.html
+++ b/backend/templates/backoffice/showcase.html
@@ -16,6 +16,7 @@
 {% from "backoffice/showcase/navigation_component.html" import navigation_section %}
 {% from "backoffice/showcase/breadcrumb_component.html" import breadcrumb_section %}
 {% from "backoffice/showcase/tabs_component.html" import tabs_section %}
+{% from "backoffice/showcase/stepper_component.html" import stepper_section %}
 {% from "backoffice/showcase/alert_component.html" import alert_section %}
 {% from "backoffice/showcase/search_dropdown_component.html" import search_dropdown_section %}
 {% from "backoffice/showcase/select_dropdown_component.html" import select_dropdown_section %}
@@ -86,6 +87,7 @@
             {{ navigation_section() }}
             {{ breadcrumb_section() }}
             {{ tabs_section() }}
+            {{ stepper_section() }}
             {{ alert_section() }}
             {{ interactivity_section() }}
         </div>

--- a/backend/templates/backoffice/showcase/stepper_component.html
+++ b/backend/templates/backoffice/showcase/stepper_component.html
@@ -1,0 +1,148 @@
+{#
+ABOUTME: Showcase section for the stepper component
+ABOUTME: Pure visual showcase — no route wiring, no scroll preservation
+#}
+{% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_example, showcase_tokens, showcase_subtitle %}
+{% from "backoffice/components/stepper.html" import stepper %}
+
+{% macro stepper_section() %}
+    {% call showcase_section() %}
+        {{ showcase_title("Stepper Component") }}
+        {{ showcase_description("Numbered step navigation with two semantic modes. Tabs mode uses tablist ARIA and lets any step be reached; wizard mode marks the active step with aria-current='step' and can lock later steps until earlier ones are done. Per-step state: active, inactive, done, or error.") }}
+
+        {% call showcase_example('{% from "backoffice/components/stepper.html" import stepper %}
+
+            {{ stepper(
+            id="my-steps",
+            items=[
+            {"key": "form",    "label": "Registration page",   "href": "#", "state": "done"},
+            {"key": "email",   "label": "Auto-reply email",    "href": "#", "active": true},
+            {"key": "preview", "label": "Preview and publish", "href": "#"}
+            ],
+            aria_label="Registration setup steps",
+            mode="tabs"
+            ) }}') %}
+            <div class="flex flex-col gap-8">
+                {# Tabs mode — the common case #}
+                <div class="flex flex-col gap-2">
+                    <span class="text-label-md" style="color: var(--color-secondary-text);">Tabs mode (default)</span>
+                    {{ stepper(
+                    id="showcase-stepper-tabs",
+                    items=[
+                    {"key": "form", "label": "Registration page", "href": "#", "state": "done"},
+                    {"key": "email", "label": "Auto-reply email", "href": "#", "active": true},
+                    {"key": "preview", "label": "Preview and publish", "href": "#"}
+                    ],
+                    aria_label="Example stepper - tabs mode",
+                    mode="tabs"
+                    ) }}
+                </div>
+
+                {# Wizard mode with a locked step #}
+                <div class="flex flex-col gap-2">
+                    <span class="text-label-md" style="color: var(--color-secondary-text);">Wizard mode — step 3 locked until step 2 is done</span>
+                    {{ stepper(
+                    id="showcase-stepper-wizard",
+                    items=[
+                    {"key": "agree", "label": "Sign the agreement", "href": "#", "state": "done"},
+                    {"key": "verify", "label": "Verify your email", "href": "#", "active": true},
+                    {"key": "plan", "label": "Choose a plan", "href": "#", "disabled": true}
+                    ],
+                    aria_label="Example stepper - wizard mode",
+                    mode="wizard"
+                    ) }}
+                </div>
+
+                {# State reference #}
+                {{ showcase_subtitle("States") }}
+
+                <div class="flex flex-col gap-2">
+                    <span class="text-label-md" style="color: var(--color-secondary-text);">state: "active"</span>
+                    {{ stepper(
+                    id="showcase-stepper-state-active",
+                    items=[{"key": "a", "label": "Active step", "href": "#", "state": "active"}],
+                    aria_label="Active state",
+                    mode="wizard"
+                    ) }}
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <span class="text-label-md" style="color: var(--color-secondary-text);">state: "inactive" (default)</span>
+                    {{ stepper(
+                    id="showcase-stepper-state-inactive",
+                    items=[{"key": "a", "label": "Inactive step", "href": "#", "state": "inactive"}],
+                    aria_label="Inactive state",
+                    mode="wizard"
+                    ) }}
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <span class="text-label-md" style="color: var(--color-secondary-text);">state: "done"</span>
+                    {{ stepper(
+                    id="showcase-stepper-state-done",
+                    items=[{"key": "a", "label": "Completed step", "href": "#", "state": "done"}],
+                    aria_label="Done state",
+                    mode="wizard"
+                    ) }}
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <span class="text-label-md" style="color: var(--color-secondary-text);">state: "error"</span>
+                    {{ stepper(
+                    id="showcase-stepper-state-error",
+                    items=[{"key": "a", "label": "Step with an error", "href": "#", "state": "error"}],
+                    aria_label="Error state",
+                    mode="wizard"
+                    ) }}
+                </div>
+
+                {# Two steps #}
+                <div class="flex flex-col gap-2">
+                    <span class="text-label-md" style="color: var(--color-secondary-text);">Two steps</span>
+                    {{ stepper(
+                    id="showcase-stepper-two",
+                    items=[
+                    {"key": "one", "label": "First step", "href": "#", "state": "done"},
+                    {"key": "two", "label": "Second step", "href": "#", "active": true}
+                    ],
+                    aria_label="Example stepper - two steps",
+                    mode="tabs"
+                    ) }}
+                </div>
+
+                {# Keyboard-nav info — the tabs-mode variant supports it #}
+                <div class="p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
+                    <h4 class="text-label-md mb-2" style="color: var(--color-headings);">Keyboard navigation (tabs mode)</h4>
+                    <p class="text-body-sm mb-2" style="color: var(--color-body-text);">
+                        The stepper uses <em>manual activation</em> — arrow keys only move focus, they do not activate the step. Press Enter or Space to follow the focused step's link.
+                    </p>
+                    <ul class="text-body-sm space-y-1" style="color: var(--color-body-text);">
+                        <li><kbd class="px-1.5 py-0.5 rounded text-xs" style="background-color: var(--color-borders-dividers);">←</kbd> / <kbd class="px-1.5 py-0.5 rounded text-xs" style="background-color: var(--color-borders-dividers);">→</kbd> Move focus to previous/next step</li>
+                        <li><kbd class="px-1.5 py-0.5 rounded text-xs" style="background-color: var(--color-borders-dividers);">Home</kbd> / <kbd class="px-1.5 py-0.5 rounded text-xs" style="background-color: var(--color-borders-dividers);">End</kbd> First / last step</li>
+                        <li><kbd class="px-1.5 py-0.5 rounded text-xs" style="background-color: var(--color-borders-dividers);">Enter</kbd> / <kbd class="px-1.5 py-0.5 rounded text-xs" style="background-color: var(--color-borders-dividers);">Space</kbd> Activate the focused step</li>
+                    </ul>
+                    <p class="text-body-sm mt-3" style="color: var(--color-secondary-text);">
+                        Wired-up examples with URL state, scroll preservation and panels live at <code>/backoffice/dev/patterns?tab=stepper</code>.
+                    </p>
+                </div>
+            </div>
+        {% endcall %}
+
+        {{ showcase_tokens([
+        "--color-primary-action",
+        "--color-secondary-text",
+        "--color-headings",
+        "--color-borders-dividers",
+        "--color-success-400",
+        "--color-error-400",
+        ".stepper",
+        ".stepper-item",
+        ".stepper-item-active",
+        ".stepper-item-done",
+        ".stepper-item-error",
+        ".stepper-link",
+        ".stepper-number",
+        ".stepper-label"
+        ]) }}
+    {% endcall %}
+{% endmacro %}

--- a/backend/tests/component/test_backoffice_registration_email.py
+++ b/backend/tests/component/test_backoffice_registration_email.py
@@ -1,0 +1,402 @@
+# ABOUTME: Component tests for the backoffice auto-reply email editor route and its context loading
+# ABOUTME: Drives the real Flask route + email_template_service over a FakeUnitOfWork via a logged-in client
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from opendlp.domain.email_template import EmailTemplate
+from opendlp.domain.registration_page import (
+    RegistrationPage,
+    RegistrationPageHtml,
+    RegistrationPageStatus,
+)
+from opendlp.entrypoints.blueprints import backoffice_registration as be_reg
+from opendlp.service_layer.exceptions import EmailTemplateInvalid, EmailTemplateNotFoundError
+from tests.fakes import FakeUnitOfWork
+
+
+def _seed_page(
+    fake_store, assembly_id, *, url_slug="my-slug", form_html="<p>form</p>", auto_reply_template_id=None
+) -> RegistrationPage:
+    page = RegistrationPage(
+        assembly_id=assembly_id,
+        url_slug=url_slug,
+        status=RegistrationPageStatus.TEST,
+        auto_reply_email_template_id=auto_reply_template_id,
+    )
+    html = RegistrationPageHtml(registration_page_id=page.id, form_html=form_html)
+    with FakeUnitOfWork(store=fake_store) as uow:
+        uow.registration_pages.add(page)
+        uow.registration_page_html_sources.add(html)
+        uow.commit()
+    return page
+
+
+def _seed_template(
+    fake_store,
+    assembly_id,
+    *,
+    name="Registration auto-reply",
+    subject="Hi {{ respondent.first_name_or_friend }}",
+    body_html="<p>Body</p>",
+) -> EmailTemplate:
+    template = EmailTemplate(assembly_id=assembly_id, name=name, subject=subject, body_html=body_html)
+    with FakeUnitOfWork(store=fake_store) as uow:
+        uow.email_templates.add(template)
+        uow.commit()
+    return template
+
+
+def _get_page(fake_store, assembly_id) -> RegistrationPage:
+    with FakeUnitOfWork(store=fake_store) as uow:
+        return uow.registration_pages.get_by_assembly_id(assembly_id).create_detached_copy()
+
+
+def _get_template(fake_store, template_id) -> EmailTemplate | None:
+    with FakeUnitOfWork(store=fake_store) as uow:
+        template = uow.email_templates.get(template_id)
+        return template.create_detached_copy() if template else None
+
+
+def _list_templates(fake_store, assembly_id) -> list[EmailTemplate]:
+    with FakeUnitOfWork(store=fake_store) as uow:
+        return [t.create_detached_copy() for t in uow.email_templates.list_by_assembly(assembly_id)]
+
+
+def _patch_current_user(user_id):
+    return patch(
+        "opendlp.entrypoints.blueprints.backoffice_registration.current_user",
+        SimpleNamespace(id=user_id),
+    )
+
+
+@pytest.fixture
+def assembly_id(existing_assembly):
+    return existing_assembly.id
+
+
+class TestCreateAction:
+    """action=create seeds a default template, assigns it, and drops the user in edit mode."""
+
+    def test_creates_template_with_default_content_and_assigns_it(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={"action": "create"},
+        )
+
+        assert response.status_code == 302
+        # Lands in edit mode on the email step so the manager can customise straight away.
+        assert "section=email" in response.location
+        assert "edit=1" in response.location
+
+        templates = _list_templates(fake_store, assembly_id)
+        assert len(templates) == 1
+        template = templates[0]
+        assert template.name  # non-empty default name
+        assert "{{ assembly.title }}" in template.subject
+        assert "{{ respondent.first_name_or_friend }}" in template.body_html
+
+        page = _get_page(fake_store, assembly_id)
+        assert page.auto_reply_email_template_id == template.id
+
+
+class TestSaveAction:
+    """action=save updates fields on the existing template; save_and_next also advances step."""
+
+    def test_save_updates_subject_and_body_without_touching_name(self, logged_in_admin, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id, name="Original name")
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={
+                "action": "save",
+                "template_subject": "New subject",
+                "template_body_html": "<p>New body</p>",
+            },
+        )
+
+        assert response.status_code == 302
+        assert "section=email" in response.location
+        assert "edit=1" not in response.location
+
+        saved = _get_template(fake_store, template.id)
+        assert saved.subject == "New subject"
+        assert saved.body_html == "<p>New body</p>"
+        # Name is deliberately NOT overwritten from the form — the UI doesn't expose it.
+        assert saved.name == "Original name"
+
+    def test_save_and_next_redirects_to_preview(self, logged_in_admin, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={
+                "action": "save_and_next",
+                "template_subject": "Updated subject",
+                "template_body_html": "<p>Updated body</p>",
+            },
+        )
+
+        assert response.status_code == 302
+        assert "section=preview" in response.location
+        # save_and_next still saves the data.
+        saved = _get_template(fake_store, template.id)
+        assert saved.subject == "Updated subject"
+
+    def test_save_uses_posted_template_id_when_none_assigned(self, logged_in_admin, fake_store, assembly_id):
+        # Template exists for the assembly but auto-reply is off. The editor form
+        # posts template_id so save/enable work on the currently-displayed template.
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=None)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={
+                "action": "save",
+                "template_id": str(template.id),
+                "template_subject": "Subject via form-supplied id",
+                "template_body_html": "<p>Body via form-supplied id</p>",
+            },
+        )
+
+        assert response.status_code == 302
+        saved = _get_template(fake_store, template.id)
+        assert saved.subject == "Subject via form-supplied id"
+
+    def test_save_with_no_template_flashes_warning(self, logged_in_admin, fake_store, assembly_id):
+        # Page exists but no email template exists yet — save is a no-op with a hint.
+        _seed_page(fake_store, assembly_id)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={
+                "action": "save",
+                "template_subject": "Nope",
+                "template_body_html": "<p>Nope</p>",
+            },
+        )
+
+        assert response.status_code == 302
+        assert "section=email" in response.location
+        assert _list_templates(fake_store, assembly_id) == []
+
+
+class TestEnableDisableActions:
+    """The switch above the editor posts action=enable/disable to flip the assignment FK."""
+
+    def test_enable_assigns_the_posted_template(self, logged_in_admin, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=None)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={"action": "enable", "template_id": str(template.id)},
+        )
+
+        assert response.status_code == 302
+        assert "section=email" in response.location
+        page = _get_page(fake_store, assembly_id)
+        assert page.auto_reply_email_template_id == template.id
+
+    def test_enable_without_template_id_or_assignment_flashes_warning(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=None)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={"action": "enable"},
+        )
+
+        assert response.status_code == 302
+        page = _get_page(fake_store, assembly_id)
+        # Nothing to enable, nothing gets assigned.
+        assert page.auto_reply_email_template_id is None
+
+    def test_disable_unassigns_current_template(self, logged_in_admin, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={"action": "disable"},
+        )
+
+        assert response.status_code == 302
+        page = _get_page(fake_store, assembly_id)
+        assert page.auto_reply_email_template_id is None
+        # The template itself is kept so re-enabling later is one click.
+        assert _get_template(fake_store, template.id) is not None
+
+
+class TestErrorHandling:
+    def test_invalid_template_returns_to_edit_mode_with_flash(self, logged_in_admin, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        with patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.update_email_template",
+            side_effect=EmailTemplateInvalid(["subject must not be empty"]),
+        ):
+            response = logged_in_admin.post(
+                f"/backoffice/assembly/{assembly_id}/registration/email/save",
+                data={"action": "save", "template_subject": "", "template_body_html": "<p></p>"},
+            )
+
+        assert response.status_code == 302
+        # Lands back in edit mode so the manager can fix the problem.
+        assert "section=email" in response.location
+        assert "edit=1" in response.location
+
+    def test_email_template_not_found_flashes_error_and_redirects(self, logged_in_admin, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        with patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.update_email_template",
+            side_effect=EmailTemplateNotFoundError("gone"),
+        ):
+            response = logged_in_admin.post(
+                f"/backoffice/assembly/{assembly_id}/registration/email/save",
+                data={"action": "save", "template_subject": "x", "template_body_html": "<p>x</p>"},
+            )
+
+        assert response.status_code == 302
+        assert "section=email" in response.location
+        assert "edit=1" not in response.location
+
+    def test_no_registration_page_redirects_to_assembly_view(self, logged_in_admin, fake_store, assembly_id):
+        # No page seeded — dispatch raises RegistrationPageNotFoundError, caller falls
+        # back to the Details tab.
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={"action": "create"},
+        )
+
+        assert response.status_code == 302
+        assert f"/backoffice/assembly/{assembly_id}" in response.location
+        assert "/registration/email" not in response.location
+
+    def test_non_admin_is_redirected_off_the_backoffice(self, logged_in_user, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        response = logged_in_user.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={"action": "save", "template_subject": "x", "template_body_html": "<p>x</p>"},
+        )
+
+        assert response.status_code == 302
+        # Redirects to the dashboard (via the InsufficientPermissions handler).
+        assert "/backoffice/assembly" not in response.location or "/registration" not in response.location
+
+    def test_unexpected_error_lands_on_email_section(self, logged_in_admin, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        with patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.update_email_template",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = logged_in_admin.post(
+                f"/backoffice/assembly/{assembly_id}/registration/email/save",
+                data={"action": "save", "template_subject": "x", "template_body_html": "<p>x</p>"},
+            )
+
+        assert response.status_code == 302
+        assert "section=email" in response.location
+
+
+class TestLoadAutoReplyContext:
+    """The view route falls back to list_email_templates()[0] when nothing is assigned."""
+
+    def test_returns_assigned_template_and_enabled_true(self, app, fake_store, admin_user, existing_assembly):
+        template = _seed_template(fake_store, existing_assembly.id)
+        _seed_page(fake_store, existing_assembly.id, auto_reply_template_id=template.id)
+        page = _get_page(fake_store, existing_assembly.id)
+
+        with app.test_request_context(), _patch_current_user(admin_user.id):
+            loaded, enabled, problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
+
+        assert loaded.id == template.id
+        assert enabled is True
+        assert isinstance(problems, list)
+
+    def test_falls_back_to_first_template_when_none_assigned(self, app, fake_store, admin_user, existing_assembly):
+        template = _seed_template(fake_store, existing_assembly.id)
+        _seed_page(fake_store, existing_assembly.id, auto_reply_template_id=None)
+        page = _get_page(fake_store, existing_assembly.id)
+
+        with app.test_request_context(), _patch_current_user(admin_user.id):
+            loaded, enabled, problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
+
+        assert loaded.id == template.id
+        assert enabled is False
+        assert isinstance(problems, list)
+
+    def test_returns_none_when_no_registration_page(self, fake_store, existing_assembly):
+        loaded, enabled, problems = be_reg._load_auto_reply_context(None, existing_assembly.id)
+        assert loaded is None
+        assert enabled is False
+        assert problems == []
+
+    def test_falls_back_to_first_template_when_assigned_template_lookup_fails(
+        self, app, fake_store, admin_user, existing_assembly
+    ):
+        # Assigned template id points at nothing (data drift). We still surface the
+        # first available template so the manager can edit rather than seeing an empty state.
+        stray_id = uuid.uuid4()
+        fallback = _seed_template(fake_store, existing_assembly.id, name="Fallback")
+        _seed_page(fake_store, existing_assembly.id, auto_reply_template_id=stray_id)
+        page = _get_page(fake_store, existing_assembly.id)
+
+        with (
+            app.test_request_context(),
+            _patch_current_user(admin_user.id),
+            patch(
+                "opendlp.entrypoints.blueprints.backoffice_registration.get_email_template",
+                side_effect=EmailTemplateNotFoundError("gone"),
+            ),
+        ):
+            loaded, enabled, _problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
+
+        assert loaded.id == fallback.id
+        assert enabled is False
+
+
+class TestCreateDefaultAutoReplyTemplate:
+    """The best-effort seed on page creation should never propagate exceptions to the caller."""
+
+    def test_seed_failure_is_swallowed_and_page_creation_still_succeeds(self, logged_in_admin, fake_store, assembly_id):
+        with patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.create_email_template",
+            side_effect=RuntimeError("db down"),
+        ):
+            response = logged_in_admin.post(f"/backoffice/assembly/{assembly_id}/registration/create")
+
+        assert response.status_code == 302
+        # The page still gets created even though seeding the template failed.
+        with FakeUnitOfWork(store=fake_store) as uow:
+            page = uow.registration_pages.get_by_assembly_id(assembly_id)
+        assert page is not None
+        # No template got persisted.
+        assert _list_templates(fake_store, assembly_id) == []
+
+
+class TestPageCreationSeedsDefaultTemplate:
+    """POST to /registration/create seeds a default email template as a side effect."""
+
+    def test_create_page_route_seeds_default_template(self, logged_in_admin, fake_store, assembly_id):
+        response = logged_in_admin.post(f"/backoffice/assembly/{assembly_id}/registration/create")
+
+        assert response.status_code == 302
+        templates = _list_templates(fake_store, assembly_id)
+        assert len(templates) == 1
+        # Not assigned — the switch starts OFF; the manager can review before enabling.
+        page = _get_page(fake_store, assembly_id)
+        assert page.auto_reply_email_template_id is None

--- a/backend/tests/component/test_backoffice_registration_email.py
+++ b/backend/tests/component/test_backoffice_registration_email.py
@@ -14,7 +14,7 @@ from opendlp.domain.registration_page import (
     RegistrationPageStatus,
 )
 from opendlp.entrypoints.blueprints import backoffice_registration as be_reg
-from opendlp.service_layer.exceptions import EmailTemplateInvalid, EmailTemplateNotFoundError
+from opendlp.service_layer.exceptions import EmailTemplateNotFoundError
 from tests.fakes import FakeUnitOfWork
 
 
@@ -236,17 +236,15 @@ class TestEnableDisableActions:
 
 class TestErrorHandling:
     def test_invalid_template_returns_to_edit_mode_with_flash(self, logged_in_admin, fake_store, assembly_id):
+        # Empty subject fails EmailTemplate.validation_problems() → EmailTemplateInvalid.
+        # Drives the real service so we exercise the actual validation path, not a mocked stand-in.
         template = _seed_template(fake_store, assembly_id)
         _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
 
-        with patch(
-            "opendlp.entrypoints.blueprints.backoffice_registration.update_email_template",
-            side_effect=EmailTemplateInvalid(["subject must not be empty"]),
-        ):
-            response = logged_in_admin.post(
-                f"/backoffice/assembly/{assembly_id}/registration/email/save",
-                data={"action": "save", "template_subject": "", "template_body_html": "<p></p>"},
-            )
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={"action": "save", "template_subject": "", "template_body_html": "<p>Body</p>"},
+        )
 
         assert response.status_code == 302
         # Lands back in edit mode so the manager can fix the problem.
@@ -254,17 +252,20 @@ class TestErrorHandling:
         assert "edit=1" in response.location
 
     def test_email_template_not_found_flashes_error_and_redirects(self, logged_in_admin, fake_store, assembly_id):
-        template = _seed_template(fake_store, assembly_id)
-        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+        # Page points at a template that doesn't exist (data drift) → the real
+        # service raises EmailTemplateNotFoundError when the save tries to load it.
+        stray_id = uuid.uuid4()
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=stray_id)
 
-        with patch(
-            "opendlp.entrypoints.blueprints.backoffice_registration.update_email_template",
-            side_effect=EmailTemplateNotFoundError("gone"),
-        ):
-            response = logged_in_admin.post(
-                f"/backoffice/assembly/{assembly_id}/registration/email/save",
-                data={"action": "save", "template_subject": "x", "template_body_html": "<p>x</p>"},
-            )
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/email/save",
+            data={
+                "action": "save",
+                "template_id": str(stray_id),
+                "template_subject": "x",
+                "template_body_html": "<p>x</p>",
+            },
+        )
 
         assert response.status_code == 302
         assert "section=email" in response.location
@@ -282,7 +283,7 @@ class TestErrorHandling:
         assert f"/backoffice/assembly/{assembly_id}" in response.location
         assert "/registration/email" not in response.location
 
-    def test_non_admin_is_redirected_off_the_backoffice(self, logged_in_user, fake_store, assembly_id):
+    def test_non_admin_is_redirected_to_dashboard(self, logged_in_user, fake_store, assembly_id):
         template = _seed_template(fake_store, assembly_id)
         _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
 
@@ -292,24 +293,8 @@ class TestErrorHandling:
         )
 
         assert response.status_code == 302
-        # Redirects to the dashboard (via the InsufficientPermissions handler).
-        assert "/backoffice/assembly" not in response.location or "/registration" not in response.location
-
-    def test_unexpected_error_lands_on_email_section(self, logged_in_admin, fake_store, assembly_id):
-        template = _seed_template(fake_store, assembly_id)
-        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
-
-        with patch(
-            "opendlp.entrypoints.blueprints.backoffice_registration.update_email_template",
-            side_effect=RuntimeError("boom"),
-        ):
-            response = logged_in_admin.post(
-                f"/backoffice/assembly/{assembly_id}/registration/email/save",
-                data={"action": "save", "template_subject": "x", "template_body_html": "<p>x</p>"},
-            )
-
-        assert response.status_code == 302
-        assert "section=email" in response.location
+        # InsufficientPermissions handler redirects to the backoffice dashboard.
+        assert response.location.endswith("/backoffice/dashboard")
 
 
 class TestLoadAutoReplyContext:

--- a/backend/tests/component/test_backoffice_registration_email.py
+++ b/backend/tests/component/test_backoffice_registration_email.py
@@ -105,6 +105,34 @@ class TestCreateAction:
         assert page.auto_reply_email_template_id == template.id
 
 
+class TestEditFormMarkup:
+    """The edit form must not carry a hidden name="action" input.
+
+    Regression: a hidden <input name="action" value="save"> alongside the submit
+    buttons (Save / Save-and-next) is sent as a duplicate. request.form.get("action")
+    returns the first entry, so the hidden always wins and Save-and-next silently
+    behaves like plain Save (no advance to the preview step). The submit buttons
+    already carry the action name/value; no fallback needed.
+    """
+
+    def test_edit_mode_form_has_no_hidden_action_input(self, logged_in_admin, fake_store, assembly_id):
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration?section=email&edit=1")
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        # The Save and Save-and-next submit buttons render as <button name="action" value="…">.
+        # A hidden <input> with the same name would be sent as a duplicate and win over the
+        # button value in Werkzeug's form.get(). Other forms on the page have hidden action
+        # inputs with different values (create/enable/disable/publish) — those are OK because
+        # their surrounding forms don't have a submit button carrying name="action".
+        assert '<input type="hidden" name="action" value="save"' not in html, (
+            "hidden action=save would win over the Save-and-next button "
+            "(browsers send both fields; Werkzeug's form.get() returns the first)"
+        )
+
+
 class TestSaveAction:
     """action=save updates fields on the existing template; save_and_next also advances step."""
 

--- a/backend/tests/component/test_backoffice_registration_images.py
+++ b/backend/tests/component/test_backoffice_registration_images.py
@@ -263,8 +263,9 @@ class TestImageDetailsModalTemplate:
         assert ':value="editingImage.file_name"' in modal_block
         # Click-to-select the value
         assert "$event.target.select()" in modal_block
-        # Copy uses the new generic clipboard helper
-        assert "copyToClipboard(editingImage.file_name" in modal_block
+        # Copy uses the CSP-safe data-attribute pattern instead of string args in @click.
+        assert ':data-copy-text="editingImage.file_name"' in modal_block
+        assert "copyToClipboard($el)" in modal_block
 
     def test_original_filename_shown_in_metadata_block_only_when_present(self, modal_block):
         """Original filename sits inside the top metadata block alongside Dimensions
@@ -275,7 +276,7 @@ class TestImageDetailsModalTemplate:
         assert 'x-if="editingImage.original_filename"' in modal_block
         # No standalone copy input/button for the original filename
         assert 'id="image-details-original-filename"' not in modal_block
-        assert "copyToClipboard(editingImage.original_filename" not in modal_block
+        assert ':data-copy-text="editingImage.original_filename"' not in modal_block
 
     def test_read_only_snippet_input_has_copy_handler(self, modal_block):
         assert 'id="image-details-snippet"' in modal_block
@@ -294,8 +295,11 @@ class TestImageDetailsModalTemplate:
         assert 'button(_("Save"),' not in modal_block
 
     def test_alpine_data_block_exposes_copy_helper_and_delete_method(self, alpine_data_block):
-        # Generic clipboard helper used by the filename copy button
-        assert "copyToClipboard(text, successMessage)" in alpine_data_block
+        # CSP-safe clipboard helper: reads the copy target/message from data-* attributes
+        # on the triggering element rather than accepting string literals as arguments
+        # (Alpine CSP build doesn't officially support literal-arg method calls).
+        assert "copyToClipboard($el)" in alpine_data_block
+        assert "$el.dataset.copyText" in alpine_data_block
         # Modal-scoped delete that closes the modal on success and skips the panel's confirm()
         assert "deleteEditingImage()" in alpine_data_block
         assert "this.imageDetailsModalOpen = false" in alpine_data_block

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -86,15 +86,13 @@ class TestEditModeRendersExpectedHtml:
         assert response.status_code == 200
         body = response.get_data(as_text=True)
         assert "readonly" in _extract_textarea(body)
-        assert f"/backoffice/assembly/{assembly_id}/registration?edit=1" in body
+        # Edit link points at the section-scoped edit URL
+        assert f"/backoffice/assembly/{assembly_id}/registration?section=form&amp;edit=1" in body
+        # Next → CTA advances to the auto-reply email step
+        assert f"/backoffice/assembly/{assembly_id}/registration?section=email" in body
         assert "Cancel</a>" not in body
-        assert 'id="status-control-toggle"' in body
-        toggle_attrs = body.split('id="status-control-toggle"', 1)[1].split(">", 1)[0]
-        assert "disabled" not in toggle_attrs
 
-    def test_test_status_edit_mode_unlocks_textarea_and_disables_dropdown(
-        self, logged_in_admin, fake_store, assembly_id
-    ):
+    def test_test_status_edit_mode_shows_save_and_next_buttons(self, logged_in_admin, fake_store, assembly_id):
         _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST)
 
         response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1")
@@ -104,9 +102,8 @@ class TestEditModeRendersExpectedHtml:
         assert "readonly" not in _extract_textarea(body)
         assert "Cancel</a>" in body
         assert "Save</button>" in body
-        assert 'id="status-control-toggle"' in body
-        toggle_attrs = body.split('id="status-control-toggle"', 1)[1].split(">", 1)[0]
-        assert "disabled" in toggle_attrs
+        assert "Save and next →</button>" in body
+        # Cancel returns to read-only on the form step
         cancel_block = body.split("Cancel</a>", 1)[0]
         anchor = cancel_block.rsplit("<a", 1)[1]
         assert f"/backoffice/assembly/{assembly_id}/registration" in anchor

--- a/backend/tests/component/test_dev_email_handlers.py
+++ b/backend/tests/component/test_dev_email_handlers.py
@@ -1,0 +1,339 @@
+"""ABOUTME: Component tests for the dev /service-docs email-template handlers
+ABOUTME: Drives the 7 _handle_* functions through real services over a FakeUnitOfWork, asserting on real outcomes"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from opendlp.domain.assembly import Assembly
+from opendlp.domain.email_template import EmailTemplate
+from opendlp.domain.registration_page import RegistrationPage, RegistrationPageStatus
+from opendlp.domain.respondent_field_schema import (
+    FieldOnRegistrationPage,
+    FieldType,
+    RespondentFieldDefinition,
+    RespondentFieldGroup,
+)
+from opendlp.domain.users import User
+from opendlp.domain.value_objects import AssemblyStatus, GlobalRole
+from opendlp.entrypoints.blueprints.dev import (
+    _handle_assign_auto_reply_template,
+    _handle_auto_reply_readiness_problems,
+    _handle_create_email_template,
+    _handle_delete_email_template,
+    _handle_get_email_template,
+    _handle_list_email_templates,
+    _handle_update_email_template,
+    _serialise_email_template,
+)
+from tests.fakes import FakeStore, FakeUnitOfWork
+
+
+def _seed_admin(store: FakeStore) -> User:
+    user = User(email=f"admin-{uuid.uuid4()}@example.com", global_role=GlobalRole.ADMIN, password_hash="hash")
+    with FakeUnitOfWork(store=store) as uow:
+        uow.users.add(user)
+        uow.commit()
+    return user
+
+
+def _seed_assembly(store: FakeStore) -> Assembly:
+    assembly = Assembly(title="Test Assembly", question="?", status=AssemblyStatus.ACTIVE)
+    with FakeUnitOfWork(store=store) as uow:
+        uow.assemblies.add(assembly)
+        uow.commit()
+    return assembly
+
+
+def _seed_page(store: FakeStore, assembly_id: uuid.UUID, *, auto_reply_template_id=None) -> RegistrationPage:
+    page = RegistrationPage(
+        assembly_id=assembly_id,
+        url_slug="my-slug",
+        status=RegistrationPageStatus.TEST,
+        auto_reply_email_template_id=auto_reply_template_id,
+    )
+    with FakeUnitOfWork(store=store) as uow:
+        uow.registration_pages.add(page)
+        uow.commit()
+    return page
+
+
+def _seed_template(
+    store: FakeStore,
+    assembly_id: uuid.UUID,
+    *,
+    name="Registration auto-reply",
+    subject="Hi {{ respondent.first_name_or_friend }}",
+    body_html="<p>Hello!</p>",
+) -> EmailTemplate:
+    template = EmailTemplate(assembly_id=assembly_id, name=name, subject=subject, body_html=body_html)
+    with FakeUnitOfWork(store=store) as uow:
+        uow.email_templates.add(template)
+        uow.commit()
+    return template
+
+
+def _seed_email_field(store: FakeStore, assembly_id: uuid.UUID, *, on_page: FieldOnRegistrationPage) -> None:
+    """The auto-reply readiness check inspects the assembly's email field's on_registration_page value."""
+    field = RespondentFieldDefinition(
+        assembly_id=assembly_id,
+        field_key="email",
+        label="Email",
+        group=RespondentFieldGroup.OTHER,
+        sort_order=10,
+        field_type=FieldType.EMAIL,
+        is_fixed=True,
+        on_registration_page=on_page,
+    )
+    with FakeUnitOfWork(store=store) as uow:
+        uow.respondent_field_definitions.add(field)
+        uow.commit()
+
+
+@pytest.fixture
+def fake_store():
+    return FakeStore()
+
+
+@pytest.fixture
+def admin(fake_store):
+    return _seed_admin(fake_store)
+
+
+@pytest.fixture
+def assembly(fake_store):
+    return _seed_assembly(fake_store)
+
+
+@pytest.fixture
+def app(fake_store):
+    from opendlp.entrypoints.flask_app import create_app  # noqa: PLC0415
+
+    return create_app("testing_component", uow_factory=lambda: FakeUnitOfWork(store=fake_store))
+
+
+@pytest.fixture
+def as_admin(app, admin):
+    """Push a request context with current_user set to the seeded admin."""
+    with (
+        app.test_request_context(),
+        patch("opendlp.entrypoints.blueprints.dev.current_user", SimpleNamespace(id=admin.id)),
+    ):
+        yield
+
+
+def _uow(fake_store) -> FakeUnitOfWork:
+    return FakeUnitOfWork(store=fake_store)
+
+
+class TestSerialiseEmailTemplate:
+    def test_emits_expected_fields_with_body_preview(self):
+        template = EmailTemplate(
+            assembly_id=uuid.uuid4(),
+            name="Auto-reply",
+            subject="Thanks!",
+            body_html="<p>" + "x" * 500 + "</p>",
+        )
+        result = _serialise_email_template(template)
+        assert result["id"] == str(template.id)
+        assert result["assembly_id"] == str(template.assembly_id)
+        assert result["name"] == "Auto-reply"
+        assert result["subject"] == "Thanks!"
+        # Long bodies are truncated with an ellipsis for the preview.
+        assert result["body_html_preview"].endswith("...")
+        assert len(result["body_html_preview"]) < len(template.body_html)
+        # Byte size reflects the full body, not the truncated preview.
+        assert result["body_html_bytes"] == len(template.body_html.encode("utf-8"))
+
+    def test_short_body_is_not_truncated(self):
+        template = EmailTemplate(assembly_id=uuid.uuid4(), name="A", subject="B", body_html="<p>short</p>")
+        assert _serialise_email_template(template)["body_html_preview"] == "<p>short</p>"
+
+
+class TestHandleCreateEmailTemplate:
+    def test_creates_and_returns_serialised_template(self, fake_store, assembly, as_admin):
+        result = _handle_create_email_template(
+            uow=_uow(fake_store),
+            params={
+                "assembly_id": str(assembly.id),
+                "name": "New template",
+                "subject": "Subject",
+                "body_html": "<p>Body</p>",
+            },
+        )
+
+        assert result["status"] == "success"
+        assert result["template"]["name"] == "New template"
+        with _uow(fake_store) as uow:
+            stored = uow.email_templates.list_by_assembly(assembly.id)
+        assert len(stored) == 1
+
+    def test_invalid_template_returns_error_with_problems(self, fake_store, assembly, as_admin):
+        # Empty name/subject/body all violate the domain-level validator.
+        result = _handle_create_email_template(
+            uow=_uow(fake_store),
+            params={"assembly_id": str(assembly.id), "name": "", "subject": "", "body_html": ""},
+        )
+        assert result["status"] == "error"
+        assert result["error_type"] == "EmailTemplateInvalid"
+        assert result["problems"], "expected the list of validation problems to be surfaced"
+
+
+class TestHandleListEmailTemplates:
+    def test_returns_all_templates_for_assembly(self, fake_store, assembly, as_admin):
+        _seed_template(fake_store, assembly.id, name="A")
+        _seed_template(fake_store, assembly.id, name="B")
+
+        result = _handle_list_email_templates(
+            uow=_uow(fake_store),
+            params={"assembly_id": str(assembly.id)},
+        )
+        assert result["status"] == "success"
+        assert result["total_count"] == 2
+        names = {t["name"] for t in result["templates"]}
+        assert names == {"A", "B"}
+
+
+class TestHandleGetEmailTemplate:
+    def test_returns_serialised_template(self, fake_store, assembly, as_admin):
+        template = _seed_template(fake_store, assembly.id, name="Detailed")
+
+        result = _handle_get_email_template(
+            uow=_uow(fake_store),
+            params={"template_id": str(template.id)},
+        )
+        assert result["status"] == "success"
+        assert result["template"]["id"] == str(template.id)
+        assert result["template"]["name"] == "Detailed"
+
+    def test_missing_template_returns_error(self, fake_store, assembly, as_admin):
+        result = _handle_get_email_template(
+            uow=_uow(fake_store),
+            params={"template_id": str(uuid.uuid4())},
+        )
+        assert result["status"] == "error"
+        assert result["error_type"] == "EmailTemplateNotFoundError"
+
+
+class TestHandleUpdateEmailTemplate:
+    def test_updates_fields_and_returns_serialised_template(self, fake_store, assembly, as_admin):
+        template = _seed_template(fake_store, assembly.id, name="Old", subject="Old subj", body_html="<p>Old</p>")
+
+        result = _handle_update_email_template(
+            uow=_uow(fake_store),
+            params={
+                "template_id": str(template.id),
+                "name": "Renamed",
+                "subject": "New subj",
+                "body_html": "<p>New</p>",
+            },
+        )
+        assert result["status"] == "success"
+        with _uow(fake_store) as uow:
+            saved = uow.email_templates.get(template.id)
+        assert saved.name == "Renamed"
+        assert saved.subject == "New subj"
+
+    def test_invalid_update_returns_error_with_problems(self, fake_store, assembly, as_admin):
+        template = _seed_template(fake_store, assembly.id)
+
+        result = _handle_update_email_template(
+            uow=_uow(fake_store),
+            params={
+                "template_id": str(template.id),
+                "name": "",
+                "subject": "",
+                "body_html": "",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error_type"] == "EmailTemplateInvalid"
+        assert result["problems"]
+
+
+class TestHandleDeleteEmailTemplate:
+    def test_deletes_and_returns_id(self, fake_store, assembly, as_admin):
+        template = _seed_template(fake_store, assembly.id)
+
+        result = _handle_delete_email_template(
+            uow=_uow(fake_store),
+            params={"template_id": str(template.id)},
+        )
+        assert result == {"status": "success", "deleted_template_id": str(template.id)}
+        with _uow(fake_store) as uow:
+            assert uow.email_templates.list_by_assembly(assembly.id) == []
+
+
+class TestHandleAssignAutoReplyTemplate:
+    def test_assign_sets_the_page_fk(self, fake_store, assembly, as_admin):
+        template = _seed_template(fake_store, assembly.id)
+        _seed_page(fake_store, assembly.id)
+
+        result = _handle_assign_auto_reply_template(
+            uow=_uow(fake_store),
+            params={"assembly_id": str(assembly.id), "template_id": str(template.id)},
+        )
+        assert result["status"] == "success"
+        assert result["auto_reply_email_template_id"] == str(template.id)
+        with _uow(fake_store) as uow:
+            page = uow.registration_pages.get_by_assembly_id(assembly.id)
+        assert page.auto_reply_email_template_id == template.id
+
+    def test_clear_unassigns_the_template(self, fake_store, assembly, as_admin):
+        template = _seed_template(fake_store, assembly.id)
+        _seed_page(fake_store, assembly.id, auto_reply_template_id=template.id)
+
+        result = _handle_assign_auto_reply_template(
+            uow=_uow(fake_store),
+            params={"assembly_id": str(assembly.id), "template_id": ""},
+        )
+        assert result["status"] == "success"
+        assert result["auto_reply_email_template_id"] is None
+        with _uow(fake_store) as uow:
+            page = uow.registration_pages.get_by_assembly_id(assembly.id)
+        assert page.auto_reply_email_template_id is None
+
+    def test_no_page_returns_error(self, fake_store, assembly, as_admin):
+        template = _seed_template(fake_store, assembly.id)
+
+        result = _handle_assign_auto_reply_template(
+            uow=_uow(fake_store),
+            params={"assembly_id": str(assembly.id), "template_id": str(template.id)},
+        )
+        assert result["status"] == "error"
+        assert result["error_type"] == "RegistrationPageNotFoundError"
+
+
+class TestHandleAutoReplyReadinessProblems:
+    def test_no_email_field_reports_error_severity(self, fake_store, assembly, as_admin):
+        # No email field configured at all — the auto-reply cannot deliver.
+        result = _handle_auto_reply_readiness_problems(
+            uow=_uow(fake_store),
+            params={"assembly_id": str(assembly.id)},
+        )
+        assert result["status"] == "success"
+        assert result["problem_count"] == 1
+        assert result["problems"][0]["severity"] == "error"
+
+    def test_optional_email_field_reports_warning(self, fake_store, assembly, as_admin):
+        _seed_email_field(fake_store, assembly.id, on_page=FieldOnRegistrationPage.YES_OPTIONAL)
+
+        result = _handle_auto_reply_readiness_problems(
+            uow=_uow(fake_store),
+            params={"assembly_id": str(assembly.id)},
+        )
+        assert result["problem_count"] == 1
+        assert result["problems"][0]["severity"] == "warning"
+
+    def test_required_email_field_reports_no_problems(self, fake_store, assembly, as_admin):
+        _seed_email_field(fake_store, assembly.id, on_page=FieldOnRegistrationPage.YES_REQUIRED)
+
+        result = _handle_auto_reply_readiness_problems(
+            uow=_uow(fake_store),
+            params={"assembly_id": str(assembly.id)},
+        )
+        assert result["status"] == "success"
+        assert result["problem_count"] == 0
+        assert result["problems"] == []

--- a/backend/tests/component/test_dev_email_handlers.py
+++ b/backend/tests/component/test_dev_email_handlers.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import pytest
 
-from opendlp.domain.assembly import Assembly
 from opendlp.domain.email_template import EmailTemplate
 from opendlp.domain.registration_page import RegistrationPage, RegistrationPageStatus
 from opendlp.domain.respondent_field_schema import (
@@ -16,8 +15,6 @@ from opendlp.domain.respondent_field_schema import (
     RespondentFieldDefinition,
     RespondentFieldGroup,
 )
-from opendlp.domain.users import User
-from opendlp.domain.value_objects import AssemblyStatus, GlobalRole
 from opendlp.entrypoints.blueprints.dev import (
     _handle_assign_auto_reply_template,
     _handle_auto_reply_readiness_problems,
@@ -29,22 +26,6 @@ from opendlp.entrypoints.blueprints.dev import (
     _serialise_email_template,
 )
 from tests.fakes import FakeStore, FakeUnitOfWork
-
-
-def _seed_admin(store: FakeStore) -> User:
-    user = User(email=f"admin-{uuid.uuid4()}@example.com", global_role=GlobalRole.ADMIN, password_hash="hash")
-    with FakeUnitOfWork(store=store) as uow:
-        uow.users.add(user)
-        uow.commit()
-    return user
-
-
-def _seed_assembly(store: FakeStore) -> Assembly:
-    assembly = Assembly(title="Test Assembly", question="?", status=AssemblyStatus.ACTIVE)
-    with FakeUnitOfWork(store=store) as uow:
-        uow.assemblies.add(assembly)
-        uow.commit()
-    return assembly
 
 
 def _seed_page(store: FakeStore, assembly_id: uuid.UUID, *, auto_reply_template_id=None) -> RegistrationPage:
@@ -93,33 +74,18 @@ def _seed_email_field(store: FakeStore, assembly_id: uuid.UUID, *, on_page: Fiel
 
 
 @pytest.fixture
-def fake_store():
-    return FakeStore()
+def as_admin(app, admin_user):
+    """Push a request context with current_user set to the shared admin_user fixture.
 
-
-@pytest.fixture
-def admin(fake_store):
-    return _seed_admin(fake_store)
-
-
-@pytest.fixture
-def assembly(fake_store):
-    return _seed_assembly(fake_store)
-
-
-@pytest.fixture
-def app(fake_store):
-    from opendlp.entrypoints.flask_app import create_app  # noqa: PLC0415
-
-    return create_app("testing_component", uow_factory=lambda: FakeUnitOfWork(store=fake_store))
-
-
-@pytest.fixture
-def as_admin(app, admin):
-    """Push a request context with current_user set to the seeded admin."""
+    The dev handlers are helper functions called directly (not through the Flask
+    client), so a session-cookie login isn't enough — we still need a request
+    context, and current_user has to resolve to our admin. Patching the module-level
+    binding is the least-contrived way to do that; a session login via
+    session_transaction only helps when driving through the client.
+    """
     with (
         app.test_request_context(),
-        patch("opendlp.entrypoints.blueprints.dev.current_user", SimpleNamespace(id=admin.id)),
+        patch("opendlp.entrypoints.blueprints.dev.current_user", SimpleNamespace(id=admin_user.id)),
     ):
         yield
 
@@ -153,11 +119,11 @@ class TestSerialiseEmailTemplate:
 
 
 class TestHandleCreateEmailTemplate:
-    def test_creates_and_returns_serialised_template(self, fake_store, assembly, as_admin):
+    def test_creates_and_returns_serialised_template(self, fake_store, existing_assembly, as_admin):
         result = _handle_create_email_template(
             uow=_uow(fake_store),
             params={
-                "assembly_id": str(assembly.id),
+                "assembly_id": str(existing_assembly.id),
                 "name": "New template",
                 "subject": "Subject",
                 "body_html": "<p>Body</p>",
@@ -167,14 +133,14 @@ class TestHandleCreateEmailTemplate:
         assert result["status"] == "success"
         assert result["template"]["name"] == "New template"
         with _uow(fake_store) as uow:
-            stored = uow.email_templates.list_by_assembly(assembly.id)
+            stored = uow.email_templates.list_by_assembly(existing_assembly.id)
         assert len(stored) == 1
 
-    def test_invalid_template_returns_error_with_problems(self, fake_store, assembly, as_admin):
+    def test_invalid_template_returns_error_with_problems(self, fake_store, existing_assembly, as_admin):
         # Empty name/subject/body all violate the domain-level validator.
         result = _handle_create_email_template(
             uow=_uow(fake_store),
-            params={"assembly_id": str(assembly.id), "name": "", "subject": "", "body_html": ""},
+            params={"assembly_id": str(existing_assembly.id), "name": "", "subject": "", "body_html": ""},
         )
         assert result["status"] == "error"
         assert result["error_type"] == "EmailTemplateInvalid"
@@ -182,13 +148,13 @@ class TestHandleCreateEmailTemplate:
 
 
 class TestHandleListEmailTemplates:
-    def test_returns_all_templates_for_assembly(self, fake_store, assembly, as_admin):
-        _seed_template(fake_store, assembly.id, name="A")
-        _seed_template(fake_store, assembly.id, name="B")
+    def test_returns_all_templates_for_assembly(self, fake_store, existing_assembly, as_admin):
+        _seed_template(fake_store, existing_assembly.id, name="A")
+        _seed_template(fake_store, existing_assembly.id, name="B")
 
         result = _handle_list_email_templates(
             uow=_uow(fake_store),
-            params={"assembly_id": str(assembly.id)},
+            params={"assembly_id": str(existing_assembly.id)},
         )
         assert result["status"] == "success"
         assert result["total_count"] == 2
@@ -197,8 +163,8 @@ class TestHandleListEmailTemplates:
 
 
 class TestHandleGetEmailTemplate:
-    def test_returns_serialised_template(self, fake_store, assembly, as_admin):
-        template = _seed_template(fake_store, assembly.id, name="Detailed")
+    def test_returns_serialised_template(self, fake_store, existing_assembly, as_admin):
+        template = _seed_template(fake_store, existing_assembly.id, name="Detailed")
 
         result = _handle_get_email_template(
             uow=_uow(fake_store),
@@ -208,7 +174,7 @@ class TestHandleGetEmailTemplate:
         assert result["template"]["id"] == str(template.id)
         assert result["template"]["name"] == "Detailed"
 
-    def test_missing_template_returns_error(self, fake_store, assembly, as_admin):
+    def test_missing_template_returns_error(self, fake_store, existing_assembly, as_admin):
         result = _handle_get_email_template(
             uow=_uow(fake_store),
             params={"template_id": str(uuid.uuid4())},
@@ -218,8 +184,10 @@ class TestHandleGetEmailTemplate:
 
 
 class TestHandleUpdateEmailTemplate:
-    def test_updates_fields_and_returns_serialised_template(self, fake_store, assembly, as_admin):
-        template = _seed_template(fake_store, assembly.id, name="Old", subject="Old subj", body_html="<p>Old</p>")
+    def test_updates_fields_and_returns_serialised_template(self, fake_store, existing_assembly, as_admin):
+        template = _seed_template(
+            fake_store, existing_assembly.id, name="Old", subject="Old subj", body_html="<p>Old</p>"
+        )
 
         result = _handle_update_email_template(
             uow=_uow(fake_store),
@@ -236,8 +204,8 @@ class TestHandleUpdateEmailTemplate:
         assert saved.name == "Renamed"
         assert saved.subject == "New subj"
 
-    def test_invalid_update_returns_error_with_problems(self, fake_store, assembly, as_admin):
-        template = _seed_template(fake_store, assembly.id)
+    def test_invalid_update_returns_error_with_problems(self, fake_store, existing_assembly, as_admin):
+        template = _seed_template(fake_store, existing_assembly.id)
 
         result = _handle_update_email_template(
             uow=_uow(fake_store),
@@ -254,8 +222,8 @@ class TestHandleUpdateEmailTemplate:
 
 
 class TestHandleDeleteEmailTemplate:
-    def test_deletes_and_returns_id(self, fake_store, assembly, as_admin):
-        template = _seed_template(fake_store, assembly.id)
+    def test_deletes_and_returns_id(self, fake_store, existing_assembly, as_admin):
+        template = _seed_template(fake_store, existing_assembly.id)
 
         result = _handle_delete_email_template(
             uow=_uow(fake_store),
@@ -263,76 +231,76 @@ class TestHandleDeleteEmailTemplate:
         )
         assert result == {"status": "success", "deleted_template_id": str(template.id)}
         with _uow(fake_store) as uow:
-            assert uow.email_templates.list_by_assembly(assembly.id) == []
+            assert uow.email_templates.list_by_assembly(existing_assembly.id) == []
 
 
 class TestHandleAssignAutoReplyTemplate:
-    def test_assign_sets_the_page_fk(self, fake_store, assembly, as_admin):
-        template = _seed_template(fake_store, assembly.id)
-        _seed_page(fake_store, assembly.id)
+    def test_assign_sets_the_page_fk(self, fake_store, existing_assembly, as_admin):
+        template = _seed_template(fake_store, existing_assembly.id)
+        _seed_page(fake_store, existing_assembly.id)
 
         result = _handle_assign_auto_reply_template(
             uow=_uow(fake_store),
-            params={"assembly_id": str(assembly.id), "template_id": str(template.id)},
+            params={"assembly_id": str(existing_assembly.id), "template_id": str(template.id)},
         )
         assert result["status"] == "success"
         assert result["auto_reply_email_template_id"] == str(template.id)
         with _uow(fake_store) as uow:
-            page = uow.registration_pages.get_by_assembly_id(assembly.id)
+            page = uow.registration_pages.get_by_assembly_id(existing_assembly.id)
         assert page.auto_reply_email_template_id == template.id
 
-    def test_clear_unassigns_the_template(self, fake_store, assembly, as_admin):
-        template = _seed_template(fake_store, assembly.id)
-        _seed_page(fake_store, assembly.id, auto_reply_template_id=template.id)
+    def test_clear_unassigns_the_template(self, fake_store, existing_assembly, as_admin):
+        template = _seed_template(fake_store, existing_assembly.id)
+        _seed_page(fake_store, existing_assembly.id, auto_reply_template_id=template.id)
 
         result = _handle_assign_auto_reply_template(
             uow=_uow(fake_store),
-            params={"assembly_id": str(assembly.id), "template_id": ""},
+            params={"assembly_id": str(existing_assembly.id), "template_id": ""},
         )
         assert result["status"] == "success"
         assert result["auto_reply_email_template_id"] is None
         with _uow(fake_store) as uow:
-            page = uow.registration_pages.get_by_assembly_id(assembly.id)
+            page = uow.registration_pages.get_by_assembly_id(existing_assembly.id)
         assert page.auto_reply_email_template_id is None
 
-    def test_no_page_returns_error(self, fake_store, assembly, as_admin):
-        template = _seed_template(fake_store, assembly.id)
+    def test_no_page_returns_error(self, fake_store, existing_assembly, as_admin):
+        template = _seed_template(fake_store, existing_assembly.id)
 
         result = _handle_assign_auto_reply_template(
             uow=_uow(fake_store),
-            params={"assembly_id": str(assembly.id), "template_id": str(template.id)},
+            params={"assembly_id": str(existing_assembly.id), "template_id": str(template.id)},
         )
         assert result["status"] == "error"
         assert result["error_type"] == "RegistrationPageNotFoundError"
 
 
 class TestHandleAutoReplyReadinessProblems:
-    def test_no_email_field_reports_error_severity(self, fake_store, assembly, as_admin):
+    def test_no_email_field_reports_error_severity(self, fake_store, existing_assembly, as_admin):
         # No email field configured at all — the auto-reply cannot deliver.
         result = _handle_auto_reply_readiness_problems(
             uow=_uow(fake_store),
-            params={"assembly_id": str(assembly.id)},
+            params={"assembly_id": str(existing_assembly.id)},
         )
         assert result["status"] == "success"
         assert result["problem_count"] == 1
         assert result["problems"][0]["severity"] == "error"
 
-    def test_optional_email_field_reports_warning(self, fake_store, assembly, as_admin):
-        _seed_email_field(fake_store, assembly.id, on_page=FieldOnRegistrationPage.YES_OPTIONAL)
+    def test_optional_email_field_reports_warning(self, fake_store, existing_assembly, as_admin):
+        _seed_email_field(fake_store, existing_assembly.id, on_page=FieldOnRegistrationPage.YES_OPTIONAL)
 
         result = _handle_auto_reply_readiness_problems(
             uow=_uow(fake_store),
-            params={"assembly_id": str(assembly.id)},
+            params={"assembly_id": str(existing_assembly.id)},
         )
         assert result["problem_count"] == 1
         assert result["problems"][0]["severity"] == "warning"
 
-    def test_required_email_field_reports_no_problems(self, fake_store, assembly, as_admin):
-        _seed_email_field(fake_store, assembly.id, on_page=FieldOnRegistrationPage.YES_REQUIRED)
+    def test_required_email_field_reports_no_problems(self, fake_store, existing_assembly, as_admin):
+        _seed_email_field(fake_store, existing_assembly.id, on_page=FieldOnRegistrationPage.YES_REQUIRED)
 
         result = _handle_auto_reply_readiness_problems(
             uow=_uow(fake_store),
-            params={"assembly_id": str(assembly.id)},
+            params={"assembly_id": str(existing_assembly.id)},
         )
         assert result["status"] == "success"
         assert result["problem_count"] == 0

--- a/backend/tests/e2e/test_registration_stepper_journey.py
+++ b/backend/tests/e2e/test_registration_stepper_journey.py
@@ -1,0 +1,139 @@
+"""ABOUTME: E2E smoke test for the Registration stepper's happy-path journey
+ABOUTME: Walks admin through: create page → seed template → save form → save email → publish, over PostgreSQL"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from opendlp.domain.registration_page import RegistrationPageStatus
+from opendlp.domain.respondent_field_schema import (
+    FieldOnRegistrationPage,
+    FieldType,
+    RespondentFieldDefinition,
+    RespondentFieldGroup,
+)
+from opendlp.feature_flags import reload_flags
+from opendlp.service_layer.assembly_service import create_assembly, update_assembly
+from opendlp.service_layer.unit_of_work import SqlAlchemyUnitOfWork
+
+
+@pytest.fixture(autouse=True)
+def enable_registration_feature(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FF_REGISTRATION_PAGE", "true")
+    reload_flags()
+
+
+def _seed_assembly_with_required_email(postgres_session_factory, admin_id):
+    """Assembly with reply-to configured and an email field required on the form,
+    so the auto-reply readiness check reports no problems."""
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        assembly = create_assembly(
+            uow=uow,
+            title="Stepper Journey Assembly",
+            created_by_user_id=admin_id,
+            question="Does the journey work?",
+            first_assembly_date=(datetime.now(UTC).date() + timedelta(days=30)),
+        )
+        assembly_id = assembly.id
+
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        uow.respondent_field_definitions.add(
+            RespondentFieldDefinition(
+                assembly_id=assembly_id,
+                field_key="email",
+                label="Email",
+                group=RespondentFieldGroup.OTHER,
+                sort_order=10,
+                field_type=FieldType.EMAIL,
+                is_fixed=True,
+                on_registration_page=FieldOnRegistrationPage.YES_REQUIRED,
+            )
+        )
+        uow.commit()
+
+    update_assembly(
+        SqlAlchemyUnitOfWork(postgres_session_factory),
+        assembly_id,
+        admin_id,
+        reply_to_name="The Team",
+        reply_to_email="team@example.com",
+    )
+    return assembly_id
+
+
+READY_FORM_HTML = (
+    '<form action="{{ form_action }}" method="post">{{ csrf_form_element }}'
+    '<label for="email">Email</label><input id="email" name="email" type="email">'
+    '<button type="submit">Register</button></form>'
+)
+
+
+def test_admin_walks_form_email_preview_and_publishes(logged_in_admin, admin_user, postgres_session_factory):
+    """A single happy-path smoke: admin creates a registration page (which auto-seeds a
+    default email template), saves the form HTML on step 1, updates the email template on
+    step 2, then hits Publish from step 3. The page ends up PUBLISHED with the manager's
+    edits persisted."""
+    assembly_id = _seed_assembly_with_required_email(postgres_session_factory, admin_user.id)
+
+    # Step 0: create the registration page. Route seeds a default email template
+    # as a side effect (unassigned — the switch defaults to OFF).
+    response = logged_in_admin.post(f"/backoffice/assembly/{assembly_id}/registration/create")
+    assert response.status_code == 302
+
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        page = uow.registration_pages.get_by_assembly_id(assembly_id)
+        assert page is not None, "page should have been created"
+        assert page.auto_reply_email_template_id is None, "seeded template starts unassigned"
+        seeded = uow.email_templates.list_by_assembly(assembly_id)
+        assert len(seeded) == 1, "creation should seed exactly one default template"
+
+    # Step 1: save the form HTML with save_and_next. Redirects to the email section.
+    response = logged_in_admin.post(
+        f"/backoffice/assembly/{assembly_id}/registration/save",
+        data={"action": "save_and_next", "html_content": READY_FORM_HTML},
+    )
+    assert response.status_code == 302
+    assert "section=email" in response.location
+
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        page = uow.registration_pages.get_by_assembly_id(assembly_id)
+        html = uow.registration_page_html_sources.get_by_page_id(page.id).create_detached_copy()
+    assert "Email" in html.form_html
+
+    # Step 2: enable the auto-reply and save updated copy with save_and_next.
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        template = uow.email_templates.list_by_assembly(assembly_id)[0].create_detached_copy()
+    response = logged_in_admin.post(
+        f"/backoffice/assembly/{assembly_id}/registration/email/save",
+        data={"action": "enable", "template_id": str(template.id)},
+    )
+    assert response.status_code == 302
+
+    response = logged_in_admin.post(
+        f"/backoffice/assembly/{assembly_id}/registration/email/save",
+        data={
+            "action": "save_and_next",
+            "template_subject": "Thanks {{ respondent.first_name_or_friend }}!",
+            "template_body_html": "<p>See you at {{ assembly.title }}.</p>",
+        },
+    )
+    assert response.status_code == 302
+    assert "section=preview" in response.location
+
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        page = uow.registration_pages.get_by_assembly_id(assembly_id).create_detached_copy()
+        template = uow.email_templates.get(page.auto_reply_email_template_id).create_detached_copy()
+    assert page.auto_reply_email_template_id == template.id
+    assert "Thanks" in template.subject
+    assert "assembly.title" in template.body_html
+
+    # Step 3: publish. Same save endpoint, no html_content payload (guard skips update).
+    response = logged_in_admin.post(
+        f"/backoffice/assembly/{assembly_id}/registration/save",
+        data={"action": "publish"},
+    )
+    assert response.status_code == 302
+
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        page = uow.registration_pages.get_by_assembly_id(assembly_id).create_detached_copy()
+    assert page.status == RegistrationPageStatus.PUBLISHED

--- a/backend/tests/unit/test_stepper_macro.py
+++ b/backend/tests/unit/test_stepper_macro.py
@@ -1,0 +1,84 @@
+"""ABOUTME: Jinja render tests for the stepper macro's ARIA and screen-reader affordances.
+ABOUTME: Verifies visually-hidden state text is emitted for done/error, and mode-appropriate ARIA."""
+
+from flask import Flask, render_template_string
+
+from opendlp import config
+from opendlp.translations import gettext
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__, template_folder=str(config.get_templates_path()))
+    app.config["TESTING"] = True
+    app.jinja_env.globals["_"] = gettext
+    app.jinja_env.globals["gettext"] = gettext
+    return app
+
+
+def _render(macro_call: str) -> str:
+    app = _make_app()
+    with app.test_request_context("/"):
+        return render_template_string(
+            '{% from "backoffice/components/stepper.html" import stepper %}' + macro_call,
+        )
+
+
+_TABS_ITEMS = """items=[
+    {"key": "one",   "label": "Registration page",   "href": "?section=form",    "state": "done"},
+    {"key": "two",   "label": "Auto-reply email",    "href": "?section=email",   "active": true},
+    {"key": "three", "label": "Preview and publish", "href": "?section=preview", "state": "error"}
+]"""
+
+
+class TestStepperScreenReaderState:
+    """Regression cover for the /sf-code-review should-fix #5: done/error states
+    must not be colour-only. Screen readers should be told the state in words."""
+
+    def test_done_step_carries_visually_hidden_completed_text(self):
+        html = _render(f'{{{{ stepper(id="s", aria_label="Steps", {_TABS_ITEMS}) }}}}')
+        assert 'class="sr-only"' in html, "expected an sr-only span for state text"
+        assert "completed" in html
+
+    def test_error_step_carries_visually_hidden_error_text(self):
+        html = _render(f'{{{{ stepper(id="s", aria_label="Steps", {_TABS_ITEMS}) }}}}')
+        # "has errors" is the exact string the macro emits for the error state.
+        assert "has errors" in html
+
+    def test_active_and_inactive_steps_do_not_get_sr_only_state(self):
+        """Active is already announced via aria-selected/aria-current; inactive is the
+        default state and doesn't need announcing. Only done and error do."""
+        html = _render(
+            '{{ stepper(id="s", aria_label="Steps", items=['
+            '  {"key": "a", "label": "Active",   "href": "#", "active": true},'
+            '  {"key": "b", "label": "Inactive", "href": "#"}'
+            "]) }}"
+        )
+        # No sr-only spans emitted for these two states.
+        assert 'class="sr-only"' not in html
+
+
+class TestStepperAriaByMode:
+    def test_tabs_mode_emits_tablist_and_aria_selected(self):
+        html = _render(f'{{{{ stepper(id="s", aria_label="Steps", mode="tabs", {_TABS_ITEMS}) }}}}')
+        assert 'role="tablist"' in html
+        assert 'role="tab"' in html
+        # The step marked active carries aria-selected="true"; others "false".
+        assert 'aria-selected="true"' in html
+        assert 'aria-selected="false"' in html
+
+    def test_wizard_mode_emits_list_and_aria_current(self):
+        html = _render(f'{{{{ stepper(id="s", aria_label="Steps", mode="wizard", {_TABS_ITEMS}) }}}}')
+        assert 'role="list"' in html
+        assert 'aria-current="step"' in html
+        # Wizard mode should not emit aria-selected (that's tab semantics).
+        assert "aria-selected=" not in html
+
+    def test_disabled_wizard_step_is_non_focusable_span(self):
+        html = _render(
+            '{{ stepper(id="s", aria_label="Steps", mode="wizard", items=['
+            '  {"key": "a", "label": "One",   "href": "#", "state": "done"},'
+            '  {"key": "b", "label": "Two",   "href": "#", "active": true},'
+            '  {"key": "c", "label": "Three", "href": "#", "disabled": true}'
+            "]) }}"
+        )
+        assert 'aria-disabled="true"' in html

--- a/backend/tests/unit/test_stepper_macro.py
+++ b/backend/tests/unit/test_stepper_macro.py
@@ -35,14 +35,14 @@ class TestStepperScreenReaderState:
     must not be colour-only. Screen readers should be told the state in words."""
 
     def test_done_step_carries_visually_hidden_completed_text(self):
+        # Anchor on the exact span markup so incidental copy elsewhere in the
+        # rendered output (labels, comments) can't accidentally satisfy the assertion.
         html = _render(f'{{{{ stepper(id="s", aria_label="Steps", {_TABS_ITEMS}) }}}}')
-        assert 'class="sr-only"' in html, "expected an sr-only span for state text"
-        assert "completed" in html
+        assert '<span class="sr-only"> (completed)</span>' in html
 
     def test_error_step_carries_visually_hidden_error_text(self):
         html = _render(f'{{{{ stepper(id="s", aria_label="Steps", {_TABS_ITEMS}) }}}}')
-        # "has errors" is the exact string the macro emits for the error state.
-        assert "has errors" in html
+        assert '<span class="sr-only"> (has errors)</span>' in html
 
     def test_active_and_inactive_steps_do_not_get_sr_only_state(self):
         """Active is already announced via aria-selected/aria-current; inactive is the
@@ -82,3 +82,40 @@ class TestStepperAriaByMode:
             "]) }}"
         )
         assert 'aria-disabled="true"' in html
+
+
+class TestStepperExtraAttrsEscaping:
+    """Pass-through attribute values must be HTML-escaped, because the macro joins
+    them into a raw string and renders with |safe. An unescaped quote in a value
+    would break out of the attribute."""
+
+    def test_quote_in_pass_through_value_is_escaped(self):
+        html = _render(
+            '{{ stepper(id="s", aria_label="Steps", items=['
+            '  {"key": "a", "label": "One", "href": "#", "active": true,'
+            '   "data-note": \'evil" onclick="alert(1)\'}'
+            "]) }}"
+        )
+        # The literal attack payload must not appear intact — the quote must be
+        # entity-encoded so it cannot terminate the attribute.
+        assert 'onclick="alert(1)' not in html
+        assert "&#34;" in html or "&quot;" in html
+
+    def test_angle_bracket_in_pass_through_value_is_escaped(self):
+        html = _render(
+            '{{ stepper(id="s", aria_label="Steps", items=['
+            '  {"key": "a", "label": "One", "href": "#", "active": true,'
+            "   \"data-note\": '<script>alert(1)</script>'}"
+            "]) }}"
+        )
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_benign_pass_through_value_still_reaches_output(self):
+        html = _render(
+            '{{ stepper(id="s", aria_label="Steps", items=['
+            '  {"key": "a", "label": "One", "href": "#", "active": true,'
+            '   "data-cy": "step-one"}'
+            "]) }}"
+        )
+        assert 'data-cy="step-one"' in html


### PR DESCRIPTION
## Summary

Preparatory work for the 615 auto-reply email UI:

- **Service docs — Emails tab**: adds a new tab to `/backoffice/dev/service-docs` that documents the templated-email service methods introduced by branch 609 (create/list/get/update/delete email templates, assign auto-reply, readiness check) plus the send-path functions. Each interactive method has a Try-It panel wired to the existing execute endpoint.
- **`flask-port` justfile recipe**: lets multiple worktrees run their own Flask dev servers in parallel on the same machine without clashing on the default port.

## Test plan

- [ ] Log in as admin and open `/backoffice/dev/service-docs?tab=emails`
- [ ] Confirm the Emails tab appears alongside the existing tabs
- [ ] Run each Try-It button (create, list, get, update, delete, assign auto-reply, readiness) against a test assembly and confirm the JSON response
- [ ] Confirm existing tabs still work (no regression in Alpine controller wiring)
- [ ] Run `just flask-port 5615` in another worktree and confirm it binds to the requested port

🤖 Generated with [Claude Code](https://claude.com/claude-code)