### PR TITLE
656 cookies

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,21 +133,21 @@
         "filename": "backend/templates/base.html",
         "hashed_secret": "734859db3f50d2aadaf6ccca3c825375e6caee5d",
         "is_verified": false,
-        "line_number": 199
+        "line_number": 204
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "backend/templates/base.html",
         "hashed_secret": "46156d2be0b710827d4f0f027972e0fae663b67b",
         "is_verified": false,
-        "line_number": 208
+        "line_number": 213
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "backend/templates/base.html",
         "hashed_secret": "44d2692f724a575a12cb12837d8d31dcb6b17aac",
         "is_verified": false,
-        "line_number": 212
+        "line_number": 217
       }
     ],
     "docs/c4/new-system/workspace.json": [
@@ -169,5 +169,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-24T20:56:32Z"
+  "generated_at": "2026-07-10T14:15:51Z"
 }

--- a/backend/.claude/skills/sf-code-review/SKILL.md
+++ b/backend/.claude/skills/sf-code-review/SKILL.md
@@ -22,6 +22,7 @@ I want you to review the changes on this branch, compared to the main branch. Ge
 - Has anything been added to `config.py` (or removed)? Any new feature flags, or have we cleaned up any? If so, are there examples in `env.example` and explanations in `docs/configuration.md`
 - If templates have been added/updated, are we using the Jinja components well? Also review `docs/agent/component_accessibility.md`
 - Is most JavaScript in files under `static/js/`? Will it work with CSP restrictions - see `docs/frontend_security.md`
+- Does the change touch cookies, sessions, logging of personal data, analytics, third-party scripts, or data retention? If so, check it against `docs/personal-data.md` — especially the "What would change the answer" list. Anything on that list needs a decision, not just a review.
 
 ### Do NOT report
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -221,18 +221,27 @@ This approach maintains the separation between domain objects (plain Python) and
   exists (e.g. pre-auth), hash the value with `log_redaction.hash_email`.
 - `log_redaction.censor_pii` redacts emails and sensitive fields from all log
   output as a backstop — treat it as a safety net, not a licence to log PII.
-- See [docs/agent/617-log-redaction/](docs/agent/617-log-redaction/) for the design.
+- See [docs/personal-data.md](docs/personal-data.md) for why, and
+  [docs/agent/617-log-redaction/](docs/agent/617-log-redaction/) for the design.
 
 ### GDPR and the right to be forgotten
 
-We need to support people asking for their details to be deleted. So we should be able to find all persistent copies of someones details easily. Our strategy is to blank the details but keep a row with a unique ID - so anything that refers to that ID will not have a broken reference, but instead will know that the details have been deleted.
+We must support people asking for their details to be deleted, so every persistent copy of someone's details must be easy to find. Our strategy is to **blank the details but keep the row** with its unique ID, so anything referring to that ID keeps a valid reference and learns the details are gone.
 
-This requirement also means that we MUST NOT have copies of details in long term storage that cannot be easily found and blanked. In particular, we should not keep long term copies of uploaded or generated files (eg. CSV or Excel files) in the database or on disk. Such files can be held in memory, written to a data attribute in an HTML file sent to a user, be a file available for download in a directory which regularly has old files deleted, cached in Redis or similar.
+It follows that we MUST NOT hold copies of details in long term storage that cannot be easily found and blanked - in particular, no long term copies of uploaded or generated files (eg. CSV or Excel) in the database or on disk. Such files can be held in memory, written to a data attribute in an HTML file sent to a user, put in a download directory that is regularly swept, or cached in Redis.
+
+### Cookies, analytics and third-party scripts
+
+OpenDLP sets two cookies, both exempt from consent, so we have **no cookie banner**. That conclusion rests on premises that are invisible in the code. Adding any cookie, any analytics, or any third-party script or embed may invalidate it.
+
+Before doing any of those, read [docs/personal-data.md](docs/personal-data.md) - it is the canonical reference for cookies, PII logging and erasure, and carries a "what would change the answer" list.
 
 ## Further Documentation
 
 ### General Documentation
 
+- [Personal Data](docs/personal-data.md) - Cookies, PII logging, and the right to erasure
+- [Analytics](docs/analytics.md) - Why we have none, and the constraints if you add some
 - [Testing Strategy](docs/testing.md) - Unit, contract, integration, e2e, and BDD testing
 - [Configuration Guide](docs/configuration.md) - Detailed environment variables and config classes
 - [Command Line Interface](docs/cli.md) - System administration CLI commands

--- a/backend/docs/agent/656-cookies/research.md
+++ b/backend/docs/agent/656-cookies/research.md
@@ -12,7 +12,7 @@
 currently sets falls within a statutory exception to the consent requirement, in both the UK
 and the EU.
 
-What we *do* need is a **cookies page** and a link to it from the footer. That is a
+What we _do_ need is a **cookies page** and a link to it from the footer. That is a
 static-content task, not an engineering one.
 
 Two findings worth flagging up front:
@@ -22,7 +22,7 @@ Two findings worth flagging up front:
    fields, a signed timestamp embedded in the HTML, and Redis counters keyed on IP address.
    Nothing is stored on the user's device.
 2. **The front page sets no cookie for an anonymous visitor** — verified empirically, not just
-   by reading the code. But `/?lang=es` *does* set one, which is the only cookie in the whole
+   by reading the code. But `/?lang=es` _does_ set one, which is the only cookie in the whole
    app that needs anything beyond a plain factual disclosure.
 
 Recommended option: **Option A — cookies page, no banner** (see [§6](#6-options)).
@@ -48,21 +48,21 @@ Recommended option: **Option A — cookies page, no banner** (see [§6](#6-optio
 
 There are exactly **two** cookies. Both are first-party, both are `HttpOnly`.
 
-| Cookie | Set by | When | Lifetime | Prod attributes |
-|---|---|---|---|---|
-| `session` | Flask-Session | On CSRF token generation, `flash()`, `?lang=` selection, 2FA, OAuth start | 7 days (`PERMANENT_SESSION_LIFETIME`, `config.py:400`) | `Secure`, `SameSite=Lax`, `HttpOnly` (`config.py:561-562`) |
-| `remember_token` | Flask-Login | Only when the user ticks "remember me" at login | 7 days (`config.py:566`) | `Secure`, `SameSite=Lax`, `HttpOnly` (`config.py:564-565`) |
+| Cookie           | Set by        | When                                                                      | Lifetime                                               | Prod attributes                                            |
+| ---------------- | ------------- | ------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------- |
+| `session`        | Flask-Session | On CSRF token generation, `flash()`, `?lang=` selection, 2FA, OAuth start | 7 days (`PERMANENT_SESSION_LIFETIME`, `config.py:400`) | `Secure`, `SameSite=Lax`, `HttpOnly` (`config.py:561-562`) |
+| `remember_token` | Flask-Login   | Only when the user ticks "remember me" at login                           | 7 days (`config.py:566`)                               | `Secure`, `SameSite=Lax`, `HttpOnly` (`config.py:564-565`) |
 
 Notes:
 
-- `SESSION_TYPE = "redis"` (`config.py:509`) means the session *payload* lives in Redis, but a
+- `SESSION_TYPE = "redis"` (`config.py:509`) means the session _payload_ lives in Redis, but a
   browser-side cookie carrying the session id is still set. Server-side sessions do not avoid
   the cookie.
 - **There is no separate CSRF cookie.** Flask-WTF stores the CSRF secret inside the Flask
   session (`WTF_CSRF_COOKIE` / double-submit mode is not configured). So CSRF protection is a
-  *reason the `session` cookie gets set*, not a cookie of its own.
+  _reason the `session` cookie gets set_, not a cookie of its own.
 - **There is no language cookie.** The chosen language is stored under the `"language"` key
-  *inside* the session (`extensions.py:132`).
+  _inside_ the session (`extensions.py:132`).
 - No `localStorage`, no `sessionStorage`, no `document.cookie` anywhere in `static/`. (One
   stale comment in `templates/backoffice/patterns/_pagination.html:131` claims scroll position
   is "saved to sessionStorage" — it isn't; scroll state is passed as a URL query param via
@@ -81,18 +81,18 @@ Run against the real app with the Flask test client:
 
 So, against the three use cases in the issue:
 
-| Use case | Cookie set? | Why |
-|---|---|---|
-| **Anonymous visitor browsing the front page** | **No** | `main.index` renders no form, emits no flash, writes nothing to the session. `get_flashed_messages()` on an empty session is a read-only no-op. |
-| **Anonymous visitor on the registration page** | **Yes — `session`** | `GET /register/<slug>` calls `generate_csrf()` (`registration.py:82`), which writes the CSRF token into the session. This is CSRF protection, not bot protection. |
-| **Signed-in user** | **Yes — `session`**, plus `remember_token` if they opted in | Authentication. |
+| Use case                                       | Cookie set?                                                 | Why                                                                                                                                                               |
+| ---------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Anonymous visitor browsing the front page**  | **No**                                                      | `main.index` renders no form, emits no flash, writes nothing to the session. `get_flashed_messages()` on an empty session is a read-only no-op.                   |
+| **Anonymous visitor on the registration page** | **Yes — `session`**                                         | `GET /register/<slug>` calls `generate_csrf()` (`registration.py:82`), which writes the CSRF token into the session. This is CSRF protection, not bot protection. |
+| **Signed-in user**                             | **Yes — `session`**, plus `remember_token` if they opted in | Authentication.                                                                                                                                                   |
 
 Two caveats that flip the front-page answer:
 
 - Arriving at `/?lang=es` writes `session["language"]` and therefore sets the cookie.
 - Landing on `/` via a redirect that queued a `flash()` message sets the cookie.
 
-Neither changes the legal conclusion, but both mean *"the front page never sets a cookie"* is
+Neither changes the legal conclusion, but both mean _"the front page never sets a cookie"_ is
 not a claim we should put in writing on a cookies page. Better to say: "we set a cookie when
 you choose a language, sign in, or fill in a form."
 
@@ -116,7 +116,7 @@ we would be having a much harder conversation: those set third-party cookies and
 reCAPTCHA, are widely regarded as requiring consent — which is unworkable on a form you need
 people to complete. Worth remembering if anyone ever proposes "just add Turnstile".
 
-The one thing the registration page *does* set a cookie for is **CSRF**, which is squarely
+The one thing the registration page _does_ set a cookie for is **CSRF**, which is squarely
 exempt.
 
 ### 2.4 Third parties (not a cookie problem, but adjacent)
@@ -148,20 +148,20 @@ regulation 6; in the EU it's Article 5(3) of the ePrivacy Directive as implement
 member state. The rule is the same in shape: **you need consent to store or access information
 on a user's device, unless an exception applies.**
 
-Importantly, the rule bites on the *storage*, regardless of whether the data is personal.
+Importantly, the rule bites on the _storage_, regardless of whether the data is personal.
 
 ### 3.1 UK — PECR as amended by the DUAA 2025
 
 The Data (Use and Access) Act 2025 amended PECR with effect from **5 February 2026**; the ICO
 published final guidance on **29 April 2026**. There are now **five exceptions**:
 
-| Exception | Applies when | Extra conditions |
-|---|---|---|
-| **Communication** | Sole purpose is transmitting a communication (e.g. session-scoped load balancing) | — |
-| **Strictly necessary** | Essential to provide the service the user requests | — |
-| **Statistical purposes** ("analytics") | Sole purpose is aggregate statistics about use of *your* service, to improve it | Clear information **and** a simple, free means of objecting |
-| **Appearance** | Sole purpose is adapting appearance/functionality to the user's preference | Clear information **and** a simple, free means of objecting |
-| **Emergency assistance** | Locating a user who needs emergency help | — |
+| Exception                              | Applies when                                                                      | Extra conditions                                            |
+| -------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| **Communication**                      | Sole purpose is transmitting a communication (e.g. session-scoped load balancing) | —                                                           |
+| **Strictly necessary**                 | Essential to provide the service the user requests                                | —                                                           |
+| **Statistical purposes** ("analytics") | Sole purpose is aggregate statistics about use of _your_ service, to improve it   | Clear information **and** a simple, free means of objecting |
+| **Appearance**                         | Sole purpose is adapting appearance/functionality to the user's preference        | Clear information **and** a simple, free means of objecting |
+| **Emergency assistance**               | Locating a user who needs emergency help                                          | —                                                           |
 
 The ICO's non-exhaustive list of activities meeting **strictly necessary** includes, verbatim:
 
@@ -184,7 +184,7 @@ Under **appearance**, the ICO gives as an explicit ✔ example:
 > "Remembering the language the subscriber or user selects (eg on a multilingual website)."
 
 Crucially, the exception must be judged **from the user's perspective**, and if a technology is
-used for more than one purpose, *every* purpose must independently qualify.
+used for more than one purpose, _every_ purpose must independently qualify.
 
 ### 3.2 EU — ePrivacy Directive Art. 5(3)
 
@@ -203,7 +203,7 @@ the canonical reading of exception (B), and expressly exempts:
 - **user-security cookies** (e.g. CSRF / brute-force protection)
 - multimedia player session cookies
 - **session-scoped load-balancing cookies**
-- **UI-customisation cookies** (e.g. language choice) — *when session-scoped*
+- **UI-customisation cookies** (e.g. language choice) — _when session-scoped_
 
 **This matters to us.** `SUPPORTED_LANGUAGES` defaults to `en,es,fr,de` (`config.py:477`) and we
 ship Hungarian translations. OpenDLP is plainly intended for EU-based assemblies. So we must
@@ -215,14 +215,14 @@ logic — which is a genuine complexity cost.
 
 ## 4. Applying the law to our two cookies
 
-| Cookie | Purpose | UK basis | EU basis | Consent needed? |
-|---|---|---|---|---|
-| `session` — CSRF token on public registration form | "ensuring the security of terminal equipment" / "preventing fraud" | Strictly necessary | Strictly necessary (WP29: user-security cookie) | **No** |
-| `session` — CSRF token on any logged-in form | Security | Strictly necessary | Strictly necessary | **No** |
-| `session` — authentication after login | "authenticating the subscriber or user" | Strictly necessary | Strictly necessary (WP29: authentication session cookie) | **No** |
-| `session` — flash messages | "recording information or selections the user makes" | Strictly necessary | Strictly necessary (user-input cookie) | **No** |
-| `session` — `?lang=` language choice | Remembering a language the user explicitly chose | **Appearance** exception → needs info + opt-out | WP29 UI-customisation → strictly necessary **if session-scoped** | **No**, with caveats — see 4.1 |
-| `remember_token` — "remember me" | Persistent login | Not strictly necessary — but see 4.2 | Same | **No**, the checkbox *is* the consent — see 4.2 |
+| Cookie                                             | Purpose                                                            | UK basis                                        | EU basis                                                         | Consent needed?                                 |
+| -------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------- |
+| `session` — CSRF token on public registration form | "ensuring the security of terminal equipment" / "preventing fraud" | Strictly necessary                              | Strictly necessary (WP29: user-security cookie)                  | **No**                                          |
+| `session` — CSRF token on any logged-in form       | Security                                                           | Strictly necessary                              | Strictly necessary                                               | **No**                                          |
+| `session` — authentication after login             | "authenticating the subscriber or user"                            | Strictly necessary                              | Strictly necessary (WP29: authentication session cookie)         | **No**                                          |
+| `session` — flash messages                         | "recording information or selections the user makes"               | Strictly necessary                              | Strictly necessary (user-input cookie)                           | **No**                                          |
+| `session` — `?lang=` language choice               | Remembering a language the user explicitly chose                   | **Appearance** exception → needs info + opt-out | WP29 UI-customisation → strictly necessary **if session-scoped** | **No**, with caveats — see 4.1                  |
+| `remember_token` — "remember me"                   | Persistent login                                                   | Not strictly necessary — but see 4.2            | Same                                                             | **No**, the checkbox _is_ the consent — see 4.2 |
 
 ### 4.1 The language cookie is the one genuine wrinkle
 
@@ -236,7 +236,7 @@ Two problems, both minor, both fixable without a banner:
   UI-customisation cookie needs "additional information" to be exempt, not necessarily consent
   — the user has, after all, deliberately clicked a language.
 
-There is a decent argument that a user clicking "Español" has *explicitly requested* the
+There is a decent argument that a user clicking "Español" has _explicitly requested_ the
 service of being shown Spanish, which lands it back in strictly-necessary. I would not lose
 sleep over this. But it's the one place where a lawyer might quibble, so it's flagged as an
 open question ([Q3](#q3-the-language-cookie)).
@@ -246,7 +246,7 @@ cookie**. Everything else requires them to log in or open a form.
 
 ### 4.2 "Remember me" — the checkbox is the consent
 
-The ICO and WP29 both take the view that a **persistent** login cookie is *not* strictly
+The ICO and WP29 both take the view that a **persistent** login cookie is _not_ strictly
 necessary: the user's reasonable expectation is that the session ends when the browser closes.
 
 But this does not require a banner. The standard, regulator-endorsed answer is that **the
@@ -255,6 +255,7 @@ unambiguous, affirmative act, freely given, and unticked by default. That is tex
 standard consent.
 
 Requirements to make that hold:
+
 - The checkbox must be **unticked by default** (verify this).
 - The label should make the consequence clear — "Keep me signed in for 7 days (sets a cookie
   on this device)" rather than a bare "Remember me".
@@ -271,7 +272,7 @@ No, because:
 
 - Every cookie we set is exempt from consent (§4).
 - No advertising, ever (stated policy). No analytics today. No cross-site tracking.
-- The two exempt-with-conditions items (language, remember-me) are satisfied by *information*
+- The two exempt-with-conditions items (language, remember-me) are satisfied by _information_
   and by a checkbox respectively, not by a consent gate.
 
 The GOV.UK Design System agrees with this reading:
@@ -283,11 +284,11 @@ The GOV.UK Design System agrees with this reading:
 And the ICO is clear that even where every cookie is exempt, the **transparency duty under
 UK GDPR Articles 13/14 still applies** — users must be told what is stored and why.
 
-There is also a positive argument for *not* having a banner. OpenDLP exists to run democratic
+There is also a positive argument for _not_ having a banner. OpenDLP exists to run democratic
 lotteries; its public-facing page is a registration form completed by members of the public who
 were invited by post, many of whom are not confident internet users. A consent banner on that
 form is friction on the one interaction that matters, in exchange for zero privacy gain. And a
-banner that offers no real choice ("Accept" with nothing to reject) is *worse* than none — the
+banner that offers no real choice ("Accept" with nothing to reject) is _worse_ than none — the
 ICO explicitly criticises consent theatre, and it trains users to click through banners that
 do matter elsewhere.
 
@@ -295,12 +296,13 @@ do matter elsewhere.
 
 ## 6. Options
 
-### Option A — Cookies page, no banner *(recommended)*
+### Option A — Cookies page, no banner _(recommended)_
 
 Add a `/cookies` page listing both cookies, linked from the footer. Reword the "remember me"
 label. Add a line to the privacy notice.
 
 **Pros**
+
 - Legally correct for what we do today, in both UK and EU.
 - Zero friction on the registration form — the interaction we most care about.
 - No new dependency, no new JS, no CSP headaches.
@@ -308,10 +310,11 @@ label. Add a line to the privacy notice.
 - Roughly a day of work, mostly content.
 
 **Cons**
+
 - Someone has to keep the cookies page accurate as the app changes.
 - If we add analytics later, we then have to build the banner anyway (but see §7 — we'd have to
   do that under any option).
-- Requires the confidence to *not* ship a banner, which can feel exposed if a client asks
+- Requires the confidence to _not_ ship a banner, which can feel exposed if a client asks
   "where's your cookie banner?". Mitigation: the cookies page answers that question, and we can
   point at the GOV.UK precedent.
 
@@ -320,28 +323,30 @@ label. Add a line to the privacy notice.
 Ship the GOV.UK cookie banner component in its "we only use essential cookies" form.
 
 **Pros**
+
 - Visibly signals that we've thought about it. Reassuring to institutional clients.
 - The scaffolding exists if analytics arrive later.
 
 **Cons**
+
 - **Not recommended by GOV.UK for essential-only services.** We'd be adding a banner the
   guidance says to skip.
 - It is consent theatre: nothing to accept or reject. Actively bad practice.
 - Friction on the public registration form, hurting completion rates for the users we most
   need to reach.
-- Still needs the cookies page anyway, so it is strictly *additional* work, not alternative.
+- Still needs the cookies page anyway, so it is strictly _additional_ work, not alternative.
 
 ### Option C — A Flask consent library
 
 **Assessment: don't.** The landscape is thin.
 
-| Library | State | Verdict |
-|---|---|---|
-| `Flask-Consent` | 11 stars, 12 commits, 3 tags, no recent activity | Effectively unmaintained. A toy. |
-| `flask-cookies` | Built to wire up **Google Tag Manager** consent modes | Solves a problem we do not have and never will |
-| Commercial CMPs (CookieYes, Usercentrics, OneTrust) | Mature | Third-party JS that phones home; ironic on a privacy tool; costs money; CSP pain |
+| Library                                             | State                                                 | Verdict                                                                          |
+| --------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `Flask-Consent`                                     | 11 stars, 12 commits, 3 tags, no recent activity      | Effectively unmaintained. A toy.                                                 |
+| `flask-cookies`                                     | Built to wire up **Google Tag Manager** consent modes | Solves a problem we do not have and never will                                   |
+| Commercial CMPs (CookieYes, Usercentrics, OneTrust) | Mature                                                | Third-party JS that phones home; ironic on a privacy tool; costs money; CSP pain |
 
-**Pros of a library:** categories and opt-out plumbing for free, *if* we ever need them.
+**Pros of a library:** categories and opt-out plumbing for free, _if_ we ever need them.
 
 **Cons:** every option either is unmaintained, is built around ad-tech we reject, or introduces
 the exact third-party tracking we are trying to avoid. Against our "boring technology with a
@@ -357,10 +362,12 @@ boring, mature, well-documented choice here; the "library" is the design system.
 Detect UK vs EU visitors and apply the DUAA analytics exception only to UK users.
 
 **Pros**
+
 - Maximises analytics coverage under UK law.
 
 **Cons**
-- Only worth anything *if* we adopt analytics **and** decide the UK relaxation is worth
+
+- Only worth anything _if_ we adopt analytics **and** decide the UK relaxation is worth
   exploiting. Speculative on both counts.
 - Geo-IP adds a dependency, and misclassification creates the legal exposure it was meant to
   avoid.
@@ -397,7 +404,7 @@ Google.
   Foundation about whether shipping Google tracking on a democratic-participation tool is
   consistent with the project's values.
 
-**Path 3 — Self-hosted analytics that *does* set a first-party cookie** (e.g. Matomo with
+**Path 3 — Self-hosted analytics that _does_ set a first-party cookie** (e.g. Matomo with
 cookies on).
 
 - UK: likely fits the new statistical-purposes exception → **information + opt-out**, no
@@ -422,7 +429,7 @@ Small, and mostly content:
    security (CSRF), sign-in, form messages and language choice; explain `remember_token`;
    explain there is no advertising and no analytics. Must be i18n'd (`_()`), like everything
    else.
-2. **Footer link** — from `base.html` *and* `base_public.html`, so the registration form has it
+2. **Footer link** — from `base.html` _and_ `base_public.html`, so the registration form has it
    too. GOV.UK requires this.
 3. **"Remember me" label** — confirm it is unticked by default; reword so the cookie
    consequence is explicit.
@@ -447,6 +454,8 @@ It rests on: no advertising, no analytics, no third-party cookies. All three ver
 code today. If there's a commitment to a client or funder that assumes a banner exists,
 that changes the calculus and I should know.
 
+COMMENT: I've done some reading myself and I accept the conclusion
+
 ### Q2. Do we need sign-off from someone legally qualified?
 
 I've read the primary sources and I'm confident in the analysis, but I'm not a lawyer, and
@@ -456,6 +465,8 @@ organisation have a DPO or retained legal advice that should bless this? The cos
 low; the cost of being wrong is an ICO complaint on a project whose entire premise is public
 trust.
 
+COMMENT: we might need sign off before merging the branch, but we can do a draft implementation now.
+
 ### Q3. The language cookie
 
 Are you comfortable relying on "the user explicitly clicked Español, therefore it's part of the
@@ -463,24 +474,32 @@ service they requested"? The alternative — making the language preference a se
 rather than riding the 7-day session — would put it beyond any argument under WP29, at the cost
 that users re-pick their language each week. I lean towards leaving it and documenting it.
 
+COMMENT: I agree, just document it.
+
 ### Q4. Is analytics actually coming?
 
 You said "might be added at some point". If it's genuinely on the roadmap, I'd rather we commit
 to a **cookieless, self-hosted** tool now (§7 Path 1) and design the cookies page around that,
 than build a banner later. If it's idle speculation, ignore this.
 
+COMMENT: Let's commit to a cookieless self-hosted tool.
+
 ### Q5. Is the EU exposure real?
 
 I've assumed OpenDLP serves EU assemblies, based on `SUPPORTED_LANGUAGES = en,es,fr,de` plus
 Hungarian translations. If in fact it's UK-only for the foreseeable future, the analysis gets
-*easier* (the DUAA exceptions become available), but I don't think it changes the
+_easier_ (the DUAA exceptions become available), but I don't think it changes the
 recommendation — Option A works under both regimes, which is precisely its appeal.
+
+COMMENT: Yes, people in the EU are a key audience for us. And the service is hosted in the EU.
 
 ### Q6. Should I raise the jsDelivr issue separately?
 
 Self-hosting govuk-frontend, Alpine and htmx removes a third-party IP disclosure on every page
 load. I think this is a bigger genuine privacy improvement than anything in this document, and
 it's a contained piece of work. Want me to open an issue?
+
+COMMENT: I'll raise it myself.
 
 ---
 

--- a/backend/docs/agent/656-cookies/research.md
+++ b/backend/docs/agent/656-cookies/research.md
@@ -1,0 +1,517 @@
+# Cookie consent — research
+
+**Issue:** #656
+**Status:** Research complete, awaiting decision from Hamish
+**Date:** 2026-07-10
+
+---
+
+## TL;DR
+
+**We almost certainly do not need a cookie consent banner today.** Every cookie OpenDLP
+currently sets falls within a statutory exception to the consent requirement, in both the UK
+and the EU.
+
+What we *do* need is a **cookies page** and a link to it from the footer. That is a
+static-content task, not an engineering one.
+
+Two findings worth flagging up front:
+
+1. **The bot protection does not use cookies at all.** The assumption in the issue is wrong
+   (details in [§2.3](#23-correction-bot-protection-uses-no-cookies)). It is honeypot form
+   fields, a signed timestamp embedded in the HTML, and Redis counters keyed on IP address.
+   Nothing is stored on the user's device.
+2. **The front page sets no cookie for an anonymous visitor** — verified empirically, not just
+   by reading the code. But `/?lang=es` *does* set one, which is the only cookie in the whole
+   app that needs anything beyond a plain factual disclosure.
+
+Recommended option: **Option A — cookies page, no banner** (see [§6](#6-options)).
+
+---
+
+## 1. Method
+
+- Read `docs/agent/614-bot-protection/{plan,research}.md` and the shipped implementation.
+- Full static audit of `config.py`, `extensions.py`, `flask_app.py`, all blueprints, all
+  templates, and all of `static/` for `document.cookie` / `localStorage` / `sessionStorage`.
+- **Empirical verification** with the Flask test client, observing real `Set-Cookie` headers.
+- Primary legal sources: ICO's guidance on storage and access technologies (the version
+  reflecting the Data (Use and Access) Act 2025, in force 5 February 2026), PECR reg. 6, and
+  Article 29 Working Party Opinion 04/2012 for the EU position.
+- Secondary: GOV.UK Design System, law-firm analyses of the DUAA changes.
+
+---
+
+## 2. What cookies do we actually set?
+
+### 2.1 The complete list
+
+There are exactly **two** cookies. Both are first-party, both are `HttpOnly`.
+
+| Cookie | Set by | When | Lifetime | Prod attributes |
+|---|---|---|---|---|
+| `session` | Flask-Session | On CSRF token generation, `flash()`, `?lang=` selection, 2FA, OAuth start | 7 days (`PERMANENT_SESSION_LIFETIME`, `config.py:400`) | `Secure`, `SameSite=Lax`, `HttpOnly` (`config.py:561-562`) |
+| `remember_token` | Flask-Login | Only when the user ticks "remember me" at login | 7 days (`config.py:566`) | `Secure`, `SameSite=Lax`, `HttpOnly` (`config.py:564-565`) |
+
+Notes:
+
+- `SESSION_TYPE = "redis"` (`config.py:509`) means the session *payload* lives in Redis, but a
+  browser-side cookie carrying the session id is still set. Server-side sessions do not avoid
+  the cookie.
+- **There is no separate CSRF cookie.** Flask-WTF stores the CSRF secret inside the Flask
+  session (`WTF_CSRF_COOKIE` / double-submit mode is not configured). So CSRF protection is a
+  *reason the `session` cookie gets set*, not a cookie of its own.
+- **There is no language cookie.** The chosen language is stored under the `"language"` key
+  *inside* the session (`extensions.py:132`).
+- No `localStorage`, no `sessionStorage`, no `document.cookie` anywhere in `static/`. (One
+  stale comment in `templates/backoffice/patterns/_pagination.html:131` claims scroll position
+  is "saved to sessionStorage" — it isn't; scroll state is passed as a URL query param via
+  `scroll_utils.py`. Worth fixing the comment separately; it is not a cookie issue.)
+- No analytics, no Sentry, no Tag Manager, no advertising. Confirmed by grep.
+
+### 2.2 Which pages set a cookie? (empirically verified)
+
+Run against the real app with the Flask test client:
+
+```
+/                    -> 200  Set-Cookie: (none)
+/?lang=es            -> 200  Set-Cookie: session=…; Expires=…; HttpOnly; Path=/
+/auth/login          -> 200  Set-Cookie: session=…; Expires=…; HttpOnly; Path=/
+```
+
+So, against the three use cases in the issue:
+
+| Use case | Cookie set? | Why |
+|---|---|---|
+| **Anonymous visitor browsing the front page** | **No** | `main.index` renders no form, emits no flash, writes nothing to the session. `get_flashed_messages()` on an empty session is a read-only no-op. |
+| **Anonymous visitor on the registration page** | **Yes — `session`** | `GET /register/<slug>` calls `generate_csrf()` (`registration.py:82`), which writes the CSRF token into the session. This is CSRF protection, not bot protection. |
+| **Signed-in user** | **Yes — `session`**, plus `remember_token` if they opted in | Authentication. |
+
+Two caveats that flip the front-page answer:
+
+- Arriving at `/?lang=es` writes `session["language"]` and therefore sets the cookie.
+- Landing on `/` via a redirect that queued a `flash()` message sets the cookie.
+
+Neither changes the legal conclusion, but both mean *"the front page never sets a cookie"* is
+not a claim we should put in writing on a cookies page. Better to say: "we set a cookie when
+you choose a language, sign in, or fill in a form."
+
+### 2.3 Correction: bot protection uses no cookies
+
+`docs/agent/614-bot-protection/plan.md` (status: COMPLETE) and the shipped code confirm the
+mechanism is entirely server-side and stateless with respect to the user's device:
+
+1. **Honeypot** — hidden `_opendlp_ttoken_` input (`registration.py:80-94`). A form field.
+2. **Form-timing token** — `_timing_token`, an `itsdangerous.TimestampSigner` value embedded
+   in the HTML (`registration.py:59-61`). A form field.
+3. **Rate limiting** — Redis counters keyed on IP and email
+   (`registration_bot_protection_service.py`). Server-side only.
+4. **`X-Robots-Tag: noindex`** — a response header.
+
+There is no Turnstile, no reCAPTCHA, no hCaptcha, no altcha. Nothing is written to the device.
+
+This is worth internalising, because it means **we have accidentally built the
+privacy-friendly version of bot protection**. Had we chosen Cloudflare Turnstile or reCAPTCHA,
+we would be having a much harder conversation: those set third-party cookies and, for
+reCAPTCHA, are widely regarded as requiring consent — which is unworkable on a form you need
+people to complete. Worth remembering if anyone ever proposes "just add Turnstile".
+
+The one thing the registration page *does* set a cookie for is **CSRF**, which is squarely
+exempt.
+
+### 2.4 Third parties (not a cookie problem, but adjacent)
+
+`base.html:197-216` and `base_public.html:32` load govuk-frontend, Alpine.js and htmx from
+`cdn.jsdelivr.net` on **every page, including the front page**.
+
+- jsDelivr does not set cookies on static asset requests, so this is **outside PECR**.
+- But it does disclose every visitor's **IP address and referrer** to a third party (Fastly /
+  Cloudflare, jsDelivr's providers) on every page load, before any consent or notice.
+- That is a UK/EU GDPR transparency question, not a cookie question — and it is arguably a
+  bigger real-world privacy exposure than any cookie we set.
+
+Google Fonts are allow-listed in the CSP (`flask_app.py:218-219`) but **not actually used** —
+`static/css/application.css` contains no `@import` and no reference to `fonts.gstatic.com`.
+Fonts are self-hosted. Good. The CSP allowance is dead config and could be tightened.
+
+**Recommendation (separate issue):** self-host the three CDN assets. They are small, we
+already have a static pipeline, and it removes the third-party disclosure entirely. This also
+removes a supply-chain risk and a hard dependency on jsDelivr's uptime. I'd treat this as
+higher priority than the cookie banner question.
+
+---
+
+## 3. The legal framework
+
+Cookies are governed by **ePrivacy** law, not primarily by GDPR. In the UK that's PECR
+regulation 6; in the EU it's Article 5(3) of the ePrivacy Directive as implemented by each
+member state. The rule is the same in shape: **you need consent to store or access information
+on a user's device, unless an exception applies.**
+
+Importantly, the rule bites on the *storage*, regardless of whether the data is personal.
+
+### 3.1 UK — PECR as amended by the DUAA 2025
+
+The Data (Use and Access) Act 2025 amended PECR with effect from **5 February 2026**; the ICO
+published final guidance on **29 April 2026**. There are now **five exceptions**:
+
+| Exception | Applies when | Extra conditions |
+|---|---|---|
+| **Communication** | Sole purpose is transmitting a communication (e.g. session-scoped load balancing) | — |
+| **Strictly necessary** | Essential to provide the service the user requests | — |
+| **Statistical purposes** ("analytics") | Sole purpose is aggregate statistics about use of *your* service, to improve it | Clear information **and** a simple, free means of objecting |
+| **Appearance** | Sole purpose is adapting appearance/functionality to the user's preference | Clear information **and** a simple, free means of objecting |
+| **Emergency assistance** | Locating a user who needs emergency help | — |
+
+The ICO's non-exhaustive list of activities meeting **strictly necessary** includes, verbatim:
+
+> - ensuring the security of terminal equipment;
+> - preventing or detecting fraud;
+> - preventing or detecting technical faults;
+> - authenticating the subscriber or user; and
+> - recording information or selections the user makes on an online service.
+
+And, from the worked examples:
+
+> "Identifying a user once they have logged in to an online service for the duration of their
+> visit to the site … ✔"
+
+> "Session cookies used to store a user's preference can rely on the strictly necessary
+> exception, provided they are not linked to a persistent identifier."
+
+Under **appearance**, the ICO gives as an explicit ✔ example:
+
+> "Remembering the language the subscriber or user selects (eg on a multilingual website)."
+
+Crucially, the exception must be judged **from the user's perspective**, and if a technology is
+used for more than one purpose, *every* purpose must independently qualify.
+
+### 3.2 EU — ePrivacy Directive Art. 5(3)
+
+The DUAA relaxations are **UK-only**. The EU has not followed: the ePrivacy Regulation that
+would have modernised this was formally **withdrawn by the Commission in February 2025**, so
+the 2002/2009 Directive still governs, with only two exceptions:
+
+- **(A)** sole purpose of carrying out transmission; and
+- **(B)** strictly necessary to provide a service explicitly requested by the user.
+
+There is **no analytics exception in the EU.** Article 29 Working Party Opinion 04/2012 remains
+the canonical reading of exception (B), and expressly exempts:
+
+- user-input cookies (form data, shopping baskets)
+- **authentication session cookies**
+- **user-security cookies** (e.g. CSRF / brute-force protection)
+- multimedia player session cookies
+- **session-scoped load-balancing cookies**
+- **UI-customisation cookies** (e.g. language choice) — *when session-scoped*
+
+**This matters to us.** `SUPPORTED_LANGUAGES` defaults to `en,es,fr,de` (`config.py:477`) and we
+ship Hungarian translations. OpenDLP is plainly intended for EU-based assemblies. So we must
+satisfy the **stricter EU rule**, and we cannot lean on the UK's new analytics exception for
+EU users. Any future analytics decision has to be made on the EU footing, or with geo-based
+logic — which is a genuine complexity cost.
+
+---
+
+## 4. Applying the law to our two cookies
+
+| Cookie | Purpose | UK basis | EU basis | Consent needed? |
+|---|---|---|---|---|
+| `session` — CSRF token on public registration form | "ensuring the security of terminal equipment" / "preventing fraud" | Strictly necessary | Strictly necessary (WP29: user-security cookie) | **No** |
+| `session` — CSRF token on any logged-in form | Security | Strictly necessary | Strictly necessary | **No** |
+| `session` — authentication after login | "authenticating the subscriber or user" | Strictly necessary | Strictly necessary (WP29: authentication session cookie) | **No** |
+| `session` — flash messages | "recording information or selections the user makes" | Strictly necessary | Strictly necessary (user-input cookie) | **No** |
+| `session` — `?lang=` language choice | Remembering a language the user explicitly chose | **Appearance** exception → needs info + opt-out | WP29 UI-customisation → strictly necessary **if session-scoped** | **No**, with caveats — see 4.1 |
+| `remember_token` — "remember me" | Persistent login | Not strictly necessary — but see 4.2 | Same | **No**, the checkbox *is* the consent — see 4.2 |
+
+### 4.1 The language cookie is the one genuine wrinkle
+
+Two problems, both minor, both fixable without a banner:
+
+- **UK:** the appearance exception carries an information + opt-out duty. The opt-out is
+  trivially satisfied: the user can pick a different language, and the value only persists
+  because they chose it. But we should say so on the cookies page.
+- **EU:** WP29 exempts UI-customisation cookies **when they are session cookies**. Ours rides
+  on the 7-day `session` cookie, so it is persistent. WP29 says a persistent
+  UI-customisation cookie needs "additional information" to be exempt, not necessarily consent
+  — the user has, after all, deliberately clicked a language.
+
+There is a decent argument that a user clicking "Español" has *explicitly requested* the
+service of being shown Spanish, which lands it back in strictly-necessary. I would not lose
+sleep over this. But it's the one place where a lawyer might quibble, so it's flagged as an
+open question ([Q3](#q3-the-language-cookie)).
+
+Note also: language selection is the **only way an anonymous front-page visitor can acquire a
+cookie**. Everything else requires them to log in or open a form.
+
+### 4.2 "Remember me" — the checkbox is the consent
+
+The ICO and WP29 both take the view that a **persistent** login cookie is *not* strictly
+necessary: the user's reasonable expectation is that the session ends when the browser closes.
+
+But this does not require a banner. The standard, regulator-endorsed answer is that **the
+"remember me" checkbox itself constitutes the consent** — it is a specific, informed,
+unambiguous, affirmative act, freely given, and unticked by default. That is textbook GDPR-
+standard consent.
+
+Requirements to make that hold:
+- The checkbox must be **unticked by default** (verify this).
+- The label should make the consequence clear — "Keep me signed in for 7 days (sets a cookie
+  on this device)" rather than a bare "Remember me".
+- The cookies page should describe `remember_token`.
+
+**Action:** confirm the checkbox is unticked by default and reword the label. That is the only
+code change the law actually compels.
+
+---
+
+## 5. Do we need a banner? — the reasoning
+
+No, because:
+
+- Every cookie we set is exempt from consent (§4).
+- No advertising, ever (stated policy). No analytics today. No cross-site tracking.
+- The two exempt-with-conditions items (language, remember-me) are satisfied by *information*
+  and by a checkbox respectively, not by a consent gate.
+
+The GOV.UK Design System agrees with this reading:
+
+> "If your service only uses essential or 'strictly necessary' cookies, you may skip the
+> banner. However, you must still inform users about these essential cookies through a
+> dedicated cookies page linked in your footer."
+
+And the ICO is clear that even where every cookie is exempt, the **transparency duty under
+UK GDPR Articles 13/14 still applies** — users must be told what is stored and why.
+
+There is also a positive argument for *not* having a banner. OpenDLP exists to run democratic
+lotteries; its public-facing page is a registration form completed by members of the public who
+were invited by post, many of whom are not confident internet users. A consent banner on that
+form is friction on the one interaction that matters, in exchange for zero privacy gain. And a
+banner that offers no real choice ("Accept" with nothing to reject) is *worse* than none — the
+ICO explicitly criticises consent theatre, and it trains users to click through banners that
+do matter elsewhere.
+
+---
+
+## 6. Options
+
+### Option A — Cookies page, no banner *(recommended)*
+
+Add a `/cookies` page listing both cookies, linked from the footer. Reword the "remember me"
+label. Add a line to the privacy notice.
+
+**Pros**
+- Legally correct for what we do today, in both UK and EU.
+- Zero friction on the registration form — the interaction we most care about.
+- No new dependency, no new JS, no CSP headaches.
+- Follows GOV.UK guidance exactly, and matches our existing design system.
+- Roughly a day of work, mostly content.
+
+**Cons**
+- Someone has to keep the cookies page accurate as the app changes.
+- If we add analytics later, we then have to build the banner anyway (but see §7 — we'd have to
+  do that under any option).
+- Requires the confidence to *not* ship a banner, which can feel exposed if a client asks
+  "where's your cookie banner?". Mitigation: the cookies page answers that question, and we can
+  point at the GOV.UK precedent.
+
+### Option B — GOV.UK cookie banner now, with only an "essential cookies" message
+
+Ship the GOV.UK cookie banner component in its "we only use essential cookies" form.
+
+**Pros**
+- Visibly signals that we've thought about it. Reassuring to institutional clients.
+- The scaffolding exists if analytics arrive later.
+
+**Cons**
+- **Not recommended by GOV.UK for essential-only services.** We'd be adding a banner the
+  guidance says to skip.
+- It is consent theatre: nothing to accept or reject. Actively bad practice.
+- Friction on the public registration form, hurting completion rates for the users we most
+  need to reach.
+- Still needs the cookies page anyway, so it is strictly *additional* work, not alternative.
+
+### Option C — A Flask consent library
+
+**Assessment: don't.** The landscape is thin.
+
+| Library | State | Verdict |
+|---|---|---|
+| `Flask-Consent` | 11 stars, 12 commits, 3 tags, no recent activity | Effectively unmaintained. A toy. |
+| `flask-cookies` | Built to wire up **Google Tag Manager** consent modes | Solves a problem we do not have and never will |
+| Commercial CMPs (CookieYes, Usercentrics, OneTrust) | Mature | Third-party JS that phones home; ironic on a privacy tool; costs money; CSP pain |
+
+**Pros of a library:** categories and opt-out plumbing for free, *if* we ever need them.
+
+**Cons:** every option either is unmaintained, is built around ad-tech we reject, or introduces
+the exact third-party tracking we are trying to avoid. Against our "boring technology with a
+track record" rule, none of these qualify. And the thing they'd save us — a signed cookie
+storing a preferences dict, plus a `has_consent(category)` helper — is genuinely about 60 lines
+of code we could own outright.
+
+If we ever need a banner, **implement it directly** using the GOV.UK component. That is the
+boring, mature, well-documented choice here; the "library" is the design system.
+
+### Option D — Full geo-aware consent management
+
+Detect UK vs EU visitors and apply the DUAA analytics exception only to UK users.
+
+**Pros**
+- Maximises analytics coverage under UK law.
+
+**Cons**
+- Only worth anything *if* we adopt analytics **and** decide the UK relaxation is worth
+  exploiting. Speculative on both counts.
+- Geo-IP adds a dependency, and misclassification creates the legal exposure it was meant to
+  avoid.
+- Complexity is disproportionate for a project with no advertising and no commercial analytics
+  motive.
+
+**Verdict:** premature. Revisit only if analytics is actually adopted (§7).
+
+---
+
+## 7. If we add analytics later
+
+This is the decision that would change everything, so it's worth pre-computing.
+
+The choice is **not** "analytics or no analytics" — it's "which analytics".
+
+**Path 1 — Cookieless, self-hosted analytics (Plausible, Umami, GoatCounter, Matomo in
+cookieless mode).** These set **no cookies at all** and store no device identifier.
+
+- No PECR trigger at all, because nothing is stored on or read from the device.
+- **Still no banner needed, in the UK or the EU.**
+- Self-hosting keeps the data ours; no third-party disclosure.
+- This is what I'd argue for. It preserves the current, comfortable position, and the
+  data quality is entirely adequate for "which pages do people bounce from".
+
+**Path 2 — Google Analytics.** Sets cookies, is a third party, is used for advertising by
+Google.
+
+- UK: does **not** qualify for the DUAA statistical exception, because that exception requires
+  the data not be used by the third party for its own purposes.
+- EU: unambiguously requires prior opt-in consent.
+- ⇒ We would need a real banner, real category logic, and (given our EU users) an
+  opt-in-by-default-off gate. Plus a legitimate argument to have inside the Sortition
+  Foundation about whether shipping Google tracking on a democratic-participation tool is
+  consistent with the project's values.
+
+**Path 3 — Self-hosted analytics that *does* set a first-party cookie** (e.g. Matomo with
+cookies on).
+
+- UK: likely fits the new statistical-purposes exception → **information + opt-out**, no
+  opt-in banner.
+- EU: **no analytics exception exists** → opt-in consent required.
+- ⇒ Because we serve EU users, we would be building a full consent banner anyway. The UK
+  relaxation buys us nothing unless we also build geo-logic (Option D).
+
+**The asymmetry is stark.** Path 1 costs a banner-free life. Paths 2 and 3 both cost a full
+consent mechanism, because of our EU users. So if analytics is ever wanted, **Path 1 is
+overwhelmingly the right call**, and it happens to be the one most aligned with what this
+project is for.
+
+---
+
+## 8. Proposed implementation (if Option A is approved)
+
+Small, and mostly content:
+
+1. **`/cookies` page** — new route on the `main` blueprint, template using the GOV.UK table
+   component. Columns: Name, Purpose, Expires. Two rows. Explain that the session cookie covers
+   security (CSRF), sign-in, form messages and language choice; explain `remember_token`;
+   explain there is no advertising and no analytics. Must be i18n'd (`_()`), like everything
+   else.
+2. **Footer link** — from `base.html` *and* `base_public.html`, so the registration form has it
+   too. GOV.UK requires this.
+3. **"Remember me" label** — confirm it is unticked by default; reword so the cookie
+   consequence is explicit.
+4. **Privacy notice** — add a cookies paragraph pointing at `/cookies`.
+5. **Tests** — a route test for `/cookies` (200, both cookie names present in the rendered
+   body), and a test asserting `GET /` emits **no** `Set-Cookie`. That second test is the
+   valuable one: it locks in the property this whole analysis rests on, and will fail loudly
+   the day someone adds a `flash()` to the front page.
+
+Explicitly **not** in scope: any banner, any consent cookie, any JS.
+
+Separately, and I'd argue more urgently: **self-host the jsDelivr assets** (§2.4). Happy to
+raise that as its own issue.
+
+---
+
+## 9. Open questions for Hamish
+
+### Q1. Do you accept the "no banner" conclusion?
+
+It rests on: no advertising, no analytics, no third-party cookies. All three verified in the
+code today. If there's a commitment to a client or funder that assumes a banner exists,
+that changes the calculus and I should know.
+
+### Q2. Do we need sign-off from someone legally qualified?
+
+I've read the primary sources and I'm confident in the analysis, but I'm not a lawyer, and
+"Claude read the ICO website" is not a defensible position in a DPIA. Given the Sortition
+Foundation processes fairly sensitive demographic data about members of the public, does the
+organisation have a DPO or retained legal advice that should bless this? The cost of asking is
+low; the cost of being wrong is an ICO complaint on a project whose entire premise is public
+trust.
+
+### Q3. The language cookie
+
+Are you comfortable relying on "the user explicitly clicked Español, therefore it's part of the
+service they requested"? The alternative — making the language preference a session-only cookie
+rather than riding the 7-day session — would put it beyond any argument under WP29, at the cost
+that users re-pick their language each week. I lean towards leaving it and documenting it.
+
+### Q4. Is analytics actually coming?
+
+You said "might be added at some point". If it's genuinely on the roadmap, I'd rather we commit
+to a **cookieless, self-hosted** tool now (§7 Path 1) and design the cookies page around that,
+than build a banner later. If it's idle speculation, ignore this.
+
+### Q5. Is the EU exposure real?
+
+I've assumed OpenDLP serves EU assemblies, based on `SUPPORTED_LANGUAGES = en,es,fr,de` plus
+Hungarian translations. If in fact it's UK-only for the foreseeable future, the analysis gets
+*easier* (the DUAA exceptions become available), but I don't think it changes the
+recommendation — Option A works under both regimes, which is precisely its appeal.
+
+### Q6. Should I raise the jsDelivr issue separately?
+
+Self-hosting govuk-frontend, Alpine and htmx removes a third-party IP disclosure on every page
+load. I think this is a bigger genuine privacy improvement than anything in this document, and
+it's a contained piece of work. Want me to open an issue?
+
+---
+
+## 10. Sources
+
+**Primary**
+
+- [ICO — What are the exceptions? (storage and access technologies)](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/guidance-on-the-use-of-storage-and-access-technologies/what-are-the-exceptions/) — the five exceptions, worked examples, "simple means of objecting"
+- [ICO — Cookies and similar technologies (PECR guide)](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/guide-to-pecr/cookies-and-similar-technologies/)
+- [ICO — Guidance on the use of cookies and similar technologies (PDF)](https://ico.org.uk/media2/kz0doybw/guidance-on-the-use-of-cookies-and-similar-technologies-1-0.pdf)
+- [Article 29 Working Party, Opinion 04/2012 on Cookie Consent Exemption (WP194)](https://ec.europa.eu/justice/article-29/documentation/opinion-recommendation/files/2012/wp194_en.pdf) — the canonical EU list of exempt cookie types
+
+**Design system**
+
+- [GOV.UK Design System — Cookie banner](https://design-system.service.gov.uk/components/cookie-banner/)
+- [GOV.UK Design System — Cookies page](https://design-system.service.gov.uk/patterns/cookies-page/)
+
+**DUAA 2025 analysis**
+
+- [Bird & Bird — Current UK cookie laws: insights from the final ICO guidance](https://www.twobirds.com/en/insights/2026/current-uk-cookie-laws-insights-from-the-final-ico-guidance)
+- [Brodies — Storage and access technologies: ICO publishes updated guidance](https://brodies.com/insights/ip-technology-and-data/storage-and-access-technologies-ico-publishes-updated-guidance-on-the-use-of-cookies-and-other-tracking-technologies/)
+- [Stevens & Bolton — The DUAA 2025: cookies, what is changing](https://www.stevens-bolton.com/insights/102mqbh/the-data-use-and-access-act-2025-cookies-what-is-changing-and-what-you-need-t/)
+- [Clifford Chance — UK ICO's updated guidance for new exceptions to cookie consents](https://www.cliffordchance.com/insights/resources/blogs/talking-tech/en/articles/2025/09/uk-ico-s-updated-guidance-for-new-exceptions-to-cookie-consents-.html)
+- [Burges Salmon — Key insights from the ICO's updated draft cookies guidance following DUAA](https://www.burges-salmon.com/articles/102l7bs/key-insights-from-the-icos-updated-draft-cookies-guidance-following-duaa/)
+
+**EU / UK divergence**
+
+- [Cognisys — Is there a difference between UK and EU GDPR? (2026)](https://cognisys.co.uk/blog/is-there-a-difference-between-uk-and-eu-gdpr-what-changed-in-2026/)
+- [CookieChimp — Do analytics cookies require consent? The 2026 answer](https://cookiechimp.com/blog/do-analytics-cookies-require-consent)
+
+**Libraries assessed**
+
+- [Flask-Consent (GitHub)](https://github.com/02JanDal/Flask-Consent) — 11 stars, 12 commits; unmaintained
+- [flask-cookies (GitHub)](https://github.com/cccnrc/flask-cookies) — Google Tag Manager oriented

--- a/backend/docs/agent/656-cookies/research.md
+++ b/backend/docs/agent/656-cookies/research.md
@@ -472,6 +472,10 @@ discovers the constraint before they discover the lawyer.
 Option A is approved (§9 D1), with the cookies page hosted on the docs site (§9 D8). The work is
 small, and mostly content.
 
+**Progress:** items 2, 3, 4 and 7 are done. Item 6 is in progress. Item 1 is in the docs repo,
+not this one. Item 5 has no in-app target — there is no privacy notice template in the app
+(§8.10).
+
 1. **Cookies page on the docs site** — authored at
    `https://docs.sortitionlab.org/data-and-legal/cookies/`, in the docs repo, not here. Content:
    a table of Name / Purpose / Expires, two rows. Explain that the session cookie covers security
@@ -763,6 +767,29 @@ another is more machinery than a two-cookie app deserves. I think it survives on
 the cost of the tripwires is a few sentences each, and the failure they prevent — shipping Google
 Analytics onto a democratic-participation tool hosted in the EU, with no consent mechanism — is
 bad enough to be worth a few sentences.
+
+### 8.10 Two things found during implementation
+
+**There is no privacy notice in the app.** Item 5 of the list above assumed one existed. Nothing
+under `templates/` mentions privacy; the notice, if there is one, lives on the docs site. So
+"add a cookies paragraph to the privacy notice" is a docs-repo task, not a code task, and it is
+recorded here rather than silently dropped.
+
+**`REMEMBER_COOKIE_DURATION = 7 days` is set only in `FlaskProductionConfig`** (`config.py:569`),
+not in `FlaskBaseConfig`. Outside production the cookie inherits Flask-Login's default of **365
+days**. Production is what the public sees, so the "7 days" on the cookies page and on the
+remember-me label is accurate for real users, and nothing here is a compliance defect.
+
+But it is a trap. Anyone reading `FlaskBaseConfig` to learn the cookie's lifetime gets the wrong
+answer, and a future non-production deployment (a demo or staging instance with real people on
+it) would quietly hand out year-long cookies. Moving the setting to `FlaskBaseConfig` would fix
+this in one line. It is deliberately **not** done here, because it is outside this issue's
+scope — it is flagged in `docs/personal-data.md` and worth its own issue.
+
+**A third, smaller one:** the backoffice footer (`templates/backoffice/components/footer.html`)
+also needed the cookies link. §8.3 only named `base.html` and `base_public.html`. The backoffice
+is where signed-in users spend their time, so all three footers now carry it. This is the case
+§8.2.2 anticipated, and `tests/unit/test_dashboard_feature_flags.py` was updated accordingly.
 
 ---
 

--- a/backend/docs/agent/656-cookies/research.md
+++ b/backend/docs/agent/656-cookies/research.md
@@ -1,7 +1,8 @@
 # Cookie consent — research
 
 **Issue:** #656
-**Status:** Research complete, awaiting decision from Hamish
+**Status:** Research complete, all decisions made (see [§9](#9-decisions)). Ready for
+implementation; legal sign-off required before the branch merges.
 **Date:** 2026-07-10
 
 ---
@@ -12,8 +13,11 @@
 currently sets falls within a statutory exception to the consent requirement, in both the UK
 and the EU.
 
-What we _do_ need is a **cookies page** and a link to it from the footer. That is a
-static-content task, not an engineering one.
+What we _do_ need is a **cookies page** and a link to it from the footer. The page will be
+published on the docs site (`docs.sortitionlab.org`) alongside the User Data Agreement, and
+linked via a configurable URL (§9 D8) — so it is mostly a content task. The one piece of real
+engineering is that `base_public.html`, the template behind the public registration form, has
+**no footer at all** and needs one (§8.3).
 
 Two findings worth flagging up front:
 
@@ -26,6 +30,10 @@ Two findings worth flagging up front:
    app that needs anything beyond a plain factual disclosure.
 
 Recommended option: **Option A — cookies page, no banner** (see [§6](#6-options)).
+
+**Agreed.** Option A is the chosen approach, and if analytics is ever added it will be
+cookieless and self-hosted (§7 Path 1). Both decisions are recorded in [§9](#9-decisions).
+The one outstanding gate is legal sign-off before merge.
 
 ---
 
@@ -205,11 +213,24 @@ the canonical reading of exception (B), and expressly exempts:
 - **session-scoped load-balancing cookies**
 - **UI-customisation cookies** (e.g. language choice) — _when session-scoped_
 
-**This matters to us.** `SUPPORTED_LANGUAGES` defaults to `en,es,fr,de` (`config.py:477`) and we
-ship Hungarian translations. OpenDLP is plainly intended for EU-based assemblies. So we must
-satisfy the **stricter EU rule**, and we cannot lean on the UK's new analytics exception for
-EU users. Any future analytics decision has to be made on the EU footing, or with geo-based
-logic — which is a genuine complexity cost.
+**This matters to us, and more than I first thought.** Two independent facts put us on the EU
+footing:
+
+1. **EU users.** `SUPPORTED_LANGUAGES` defaults to `en,es,fr,de` (`config.py:477`) and we ship
+   Hungarian translations. People in the EU are a key audience (confirmed).
+2. **EU hosting.** The service is hosted in the EU (confirmed). That is an *establishment* in
+   the Union, which engages EU law directly rather than merely via the extraterritorial
+   targeting test.
+
+The second is the stronger point. Where a service targets EU users from outside, there is at
+least an argument about scope. Where it is *established and hosted* in the EU, the ePrivacy
+Directive as implemented by that member state applies straightforwardly, and the UK's DUAA
+relaxations are simply unavailable.
+
+So: we must satisfy the **stricter EU rule**, and we cannot lean on the UK's new analytics
+exception at all. Any future analytics decision has to be made on the EU footing, or with
+geo-based logic — which is a genuine complexity cost, and which §7 concludes is not worth
+paying.
 
 ---
 
@@ -238,8 +259,11 @@ Two problems, both minor, both fixable without a banner:
 
 There is a decent argument that a user clicking "Español" has _explicitly requested_ the
 service of being shown Spanish, which lands it back in strictly-necessary. I would not lose
-sleep over this. But it's the one place where a lawyer might quibble, so it's flagged as an
-open question ([Q3](#q3-the-language-cookie)).
+sleep over this. But it's the one place where a lawyer might quibble, so it is called out for
+the sign-off in D6.
+
+**Decided ([D3](#d3-the-language-cookie-stays-as-it-is-and-gets-documented)):** leave the
+behaviour alone, document the reasoning. No code change.
 
 Note also: language selection is the **only way an anonymous front-page visitor can acquire a
 cookie**. Everything else requires them to log in or open a form.
@@ -296,10 +320,15 @@ do matter elsewhere.
 
 ## 6. Options
 
-### Option A — Cookies page, no banner _(recommended)_
+### Option A — Cookies page, no banner _(recommended; **approved**, §9 D1)_
 
-Add a `/cookies` page listing both cookies, linked from the footer. Reword the "remember me"
-label. Add a line to the privacy notice.
+Publish a cookies page **on the docs site** (`docs.sortitionlab.org`), and link to it from the
+app footer via a configurable URL — exactly as we already do for the User Data Agreement.
+Reword the "remember me" label. Add a line to the privacy notice.
+
+**Decided (§9 D8):** the page is hosted externally, not served by Flask. New config var
+`HELP_SITE_COOKIES`, defaulting to `https://docs.sortitionlab.org/data-and-legal/cookies/`,
+threaded through in the same way as `HELP_SITE_DATA_AGREEMENT`. Mechanics in §8.2.
 
 **Pros**
 
@@ -307,11 +336,15 @@ label. Add a line to the privacy notice.
 - Zero friction on the registration form — the interaction we most care about.
 - No new dependency, no new JS, no CSP headaches.
 - Follows GOV.UK guidance exactly, and matches our existing design system.
+- Hosting it on the docs site matches the established pattern for legal content, keeps legal
+  copy out of the deploy cycle, and lets it be corrected without shipping the app.
 - Roughly a day of work, mostly content.
 
 **Cons**
 
-- Someone has to keep the cookies page accurate as the app changes.
+- Someone has to keep the cookies page accurate as the app changes — and now that "someone"
+  is editing a *different repo*, so drift is likelier, not less likely (§8.2, §8.7).
+- The docs site is English-only; an in-app page would have gone through `_()`. See §8.7.
 - If we add analytics later, we then have to build the banner anyway (but see §7 — we'd have to
   do that under any option).
 - Requires the confidence to _not_ ship a banner, which can feel exposed if a client asks
@@ -368,17 +401,26 @@ Detect UK vs EU visitors and apply the DUAA analytics exception only to UK users
 **Cons**
 
 - Only worth anything _if_ we adopt analytics **and** decide the UK relaxation is worth
-  exploiting. Speculative on both counts.
+  exploiting. Speculative on both counts — and §9 now settles both against it.
 - Geo-IP adds a dependency, and misclassification creates the legal exposure it was meant to
   avoid.
 - Complexity is disproportionate for a project with no advertising and no commercial analytics
   motive.
+- **The service is hosted in the EU** (§3.2). Geo-gating the *user* does not help when the
+  *controller and the hosting* are established in the EU — EU law applies to the service, not
+  merely to whichever visitors happen to be in the Union.
 
-**Verdict:** premature. Revisit only if analytics is actually adopted (§7).
+**Verdict: rejected, not merely premature.** The commitment to cookieless analytics (§9 D2)
+removes the only scenario in which this would have paid for itself, and the EU hosting removes
+the legal basis it was built on.
 
 ---
 
 ## 7. If we add analytics later
+
+> **Decision (§9 D2): if analytics is ever added, it will be cookieless and self-hosted —
+> Path 1 below.** The rest of this section records why, and what would have to be true for
+> that to change.
 
 This is the decision that would change everything, so it's worth pre-computing.
 
@@ -414,92 +456,452 @@ cookies on).
   relaxation buys us nothing unless we also build geo-logic (Option D).
 
 **The asymmetry is stark.** Path 1 costs a banner-free life. Paths 2 and 3 both cost a full
-consent mechanism, because of our EU users. So if analytics is ever wanted, **Path 1 is
-overwhelmingly the right call**, and it happens to be the one most aligned with what this
-project is for.
+consent mechanism, because we have EU users *and* EU hosting (§3.2). So if analytics is ever
+wanted, **Path 1 is overwhelmingly the right call**, and it happens to be the one most aligned
+with what this project is for.
+
+This is now settled rather than advisory (§9 D2). The practical consequence for the work in §8:
+the cookies page can state plainly that we use no analytics cookies, and that commitment should
+be recorded in `docs/personal-data.md` so a future contributor reaching for Google Analytics
+discovers the constraint before they discover the lawyer.
 
 ---
 
-## 8. Proposed implementation (if Option A is approved)
+## 8. Proposed implementation
 
-Small, and mostly content:
+Option A is approved (§9 D1), with the cookies page hosted on the docs site (§9 D8). The work is
+small, and mostly content.
 
-1. **`/cookies` page** — new route on the `main` blueprint, template using the GOV.UK table
-   component. Columns: Name, Purpose, Expires. Two rows. Explain that the session cookie covers
-   security (CSRF), sign-in, form messages and language choice; explain `remember_token`;
-   explain there is no advertising and no analytics. Must be i18n'd (`_()`), like everything
-   else.
-2. **Footer link** — from `base.html` _and_ `base_public.html`, so the registration form has it
-   too. GOV.UK requires this.
-3. **"Remember me" label** — confirm it is unticked by default; reword so the cookie
-   consequence is explicit.
-4. **Privacy notice** — add a cookies paragraph pointing at `/cookies`.
-5. **Tests** — a route test for `/cookies` (200, both cookie names present in the rendered
-   body), and a test asserting `GET /` emits **no** `Set-Cookie`. That second test is the
-   valuable one: it locks in the property this whole analysis rests on, and will fail loudly
+1. **Cookies page on the docs site** — authored at
+   `https://docs.sortitionlab.org/data-and-legal/cookies/`, in the docs repo, not here. Content:
+   a table of Name / Purpose / Expires, two rows. Explain that the session cookie covers security
+   (CSRF), sign-in, form messages and language choice; explain `remember_token`; state plainly
+   that there is no advertising and no analytics.
+2. **`HELP_SITE_COOKIES` config var** — threaded through exactly as `HELP_SITE_DATA_AGREEMENT`
+   is. Mechanics and the gotchas in §8.2.
+3. **Footer links** — `base.html` has a footer and takes a one-line addition.
+   **`base_public.html` has no footer at all** — this needs building. See §8.3; it is the only
+   item here with real work in it.
+4. **"Remember me" label** — confirm it is unticked by default; reword so the cookie
+   consequence is explicit. This is the only code change the law actually compels (§4.2).
+5. **Privacy notice** — add a cookies paragraph pointing at the docs-site page.
+6. **`docs/personal-data.md`** — a permanent reference doc, and the most important item on this
+   list. See §8.4–§8.6.
+7. **Tests** — a test asserting `GET /` emits **no** `Set-Cookie`, and context-processor tests
+   for the new URL. Note we *lose* the ability to test the page's content, because it is no
+   longer ours (§8.7). The `GET /` test is now the only executable check in the whole scheme; it
+   locks in the property this analysis rests on, and will fail loudly
    the day someone adds a `flash()` to the front page.
+
+### 8.1 Hosting the page on the docs site
+
+The User Data Agreement is already an external page linked from the app by a configurable URL.
+The cookies page follows the same pattern. This is the right call: it keeps legal copy out of the
+deploy cycle, so a wording fix from a lawyer does not require a release, and it puts all the
+"data and legal" pages in one place for a reader.
+
+### 8.2 Threading `HELP_SITE_COOKIES` through
+
+Traced from the existing `HELP_SITE_DATA_AGREEMENT`. Five files, plus tests:
+
+| File | Change |
+|---|---|
+| `src/opendlp/config.py:441-444` | Add `self.HELP_SITE_COOKIES: str = os.environ.get("HELP_SITE_COOKIES", "https://docs.sortitionlab.org/data-and-legal/cookies/")` alongside `HELP_SITE_HOME` / `HELP_SITE_DATA_AGREEMENT`. |
+| `src/opendlp/entrypoints/context_processors.py:131-134` | Convert `get_help_site_urls()` to return a `NamedTuple` (§8.2.1) and add the third URL. |
+| `src/opendlp/entrypoints/context_processors.py:156,165` | Use attribute access and expose `help_site_cookies` in `inject_template_globals()`. |
+| `env.example:89-91` | Add `HELP_SITE_COOKIES=...` under the existing "External help site URLs" comment. |
+| `docs/configuration.md:200-210` | Add to the same block; update the prose, which currently says the URLs feed the header "Help" link and footer "User Data Agreement" link. |
+
+#### 8.2.1 `get_help_site_urls()` returns a NamedTuple
+
+**Decided (§9 D9).** Today it returns a positional `tuple[str, str]`:
+
+```python
+@cache
+def get_help_site_urls() -> tuple[str, str]:
+    flask_config = config.get_config()
+    return flask_config.HELP_SITE_HOME, flask_config.HELP_SITE_DATA_AGREEMENT
+```
+
+Two positional strings is survivable; three is where positional unpacking starts inviting
+silent transposition bugs — the elements are all `str`, so swapping two would type-check, pass
+mypy, and quietly render the wrong link. Replace with a `typing.NamedTuple`:
+
+```python
+class HelpSiteUrls(NamedTuple):
+    home: str
+    data_agreement: str
+    cookies: str
+
+
+@cache
+def get_help_site_urls() -> HelpSiteUrls:
+    flask_config = config.get_config()
+    return HelpSiteUrls(
+        home=flask_config.HELP_SITE_HOME,
+        data_agreement=flask_config.HELP_SITE_DATA_AGREEMENT,
+        cookies=flask_config.HELP_SITE_COOKIES,
+    )
+```
+
+and at the call site (`context_processors.py:156`), replace the tuple unpacking with attribute
+access: `help_site_urls.home`, `.data_agreement`, `.cookies`.
+
+Notes:
+
+- `NamedTuple` is `typing` stdlib — boring, no new dependency. It is immutable and hashable, so
+  it remains compatible with the `@cache` decorator.
+- There is exactly **one call site** (`context_processors.py:156`), so this is a contained
+  change, not a sprawling refactor. That is what makes it worth doing now rather than "later".
+- It stays tuple-compatible, so nothing that treats the result as a sequence breaks.
+- `src/` currently contains no other `NamedTuple`, so this introduces the idiom. Given it is
+  stdlib and the alternative is a bare 3-tuple of same-typed strings, I think that is fine — but
+  worth a reviewer's eye, since "match the surrounding style" is a house rule.
+
+#### 8.2.2 Tests
+
+- `tests/unit/test_context_processors.py:132-137` hard-codes the two default URLs and must gain
+  an assertion for `help_site_cookies`.
+- **Correction to an earlier draft of this document:** `tests/unit/test_dashboard_feature_flags.py:90`
+  is *not* affected by the NamedTuple change. It never calls `get_help_site_urls()`; it passes
+  `help_site_data_agreement=` straight into `render_template_string` as a template variable. It
+  only needs touching if `backoffice/components/footer.html` gains a cookies link that the test's
+  rendered template then requires.
+- `get_help_site_urls` is `@cache`d and, unlike `_get_file_hash` / `get_opendlp_version` /
+  `get_service_account_email`, has no `cache_clear()` call in the test suite. Any test that wants
+  to vary `HELP_SITE_COOKIES` via the environment will need one. Worth knowing before writing the
+  tests, not after.
+
+### 8.3 `base_public.html` has no footer — the one piece of real work
+
+`templates/base.html:175` already has a footer with the `help_site_data_agreement` link; adding a
+cookies link there is one line.
+
+**`templates/base_public.html` has no footer whatsoever.** It goes from `<main>` (line 27-29)
+straight to `</body>` (line 43). There is no `govuk-footer` markup in the file at all.
+
+This matters more than it sounds. `base_public.html` is the template behind the **public
+registration form** — which is:
+
+- the one page an anonymous member of the public actually lands on;
+- the page that **does** set a cookie (`generate_csrf()`, §2.2); and
+- therefore the single page on the site that most needs a cookies link.
+
+GOV.UK is explicit that the cookies page must be linked from the footer. So this task requires
+**adding a footer to `base_public.html`**, not just adding a link to an existing one.
+
+**Decided (§9 D11):** add a minimal GOV.UK footer, carrying the cookies link and the User Data
+Agreement link, and nothing else. The public page should stay uncluttered — it is the one page
+where added visual noise costs us completions from people we reached by post.
+
+Because this is a visible change to the most sensitive template we have, the rendered page wants
+its own look rather than being waved through as "add a link". Check it against the GOV.UK footer
+component and `docs/agent/component_accessibility.md`.
+
+### 8.4 The documentation problem
+
+The conclusion "no banner needed" is only valid while its premises hold. Those premises are
+invisible in the code: nothing in `config.py` announces that adding Google Analytics would
+oblige us to build a consent mechanism. A future contributor — or a future us — will reach for
+an analytics snippet and have no idea they have just walked into PECR.
+
+Worse, the person about to break a rule usually reads only the doc for the area they are
+working in. Someone adding a language cookie reads `docs/translations.md`. Someone swapping the
+honeypot for Turnstile reads `docs/bot-protection.md`. Neither has any reason to open a doc
+about cookies. **A central doc nobody is routed to is a doc that does not exist.**
+
+So the design has two halves: one canonical doc, and a set of tripwires in the docs people
+actually read.
+
+### 8.5 `docs/personal-data.md` — the hub
+
+**On the name.** The suggestion was `user-data.md`. I'd argue against it, on a specific
+codebase-local ground: *User* is a domain term here — `domain/users.py`, an aggregate with
+roles and passwords. But the most sensitive personal data we hold belongs to **registrants**,
+who are explicitly *not* `User`s (see `CLAUDE.md`: "Users/Organisers are separate aggregates
+from Assembly/Registrants"). A doc called `user-data.md` invites a reader to conclude it does
+not govern the registration pool, which is exactly backwards. `personal-data.md` is the UK/EU
+GDPR term of art, and it correctly spans cookies (device identifiers), log lines, registrants,
+users, and the IP addresses in our rate-limit keys.
+
+**What it contains.** A hub, covering:
+
+- **Principles** — the standing constraints, which are the actual load-bearing content:
+  - no advertising, ever;
+  - no analytics that sets a cookie or reads the device — if analytics is added it must be
+    cookieless and self-hosted (§7 Path 1, decided in §9 D2);
+  - no third-party cookies; no cross-site or cross-device tracking;
+  - bot protection stays server-side (no Turnstile / reCAPTCHA / hCaptcha);
+  - never log raw PII;
+  - no long-term copies of personal data that cannot be found and blanked.
+- **Cookies** — canonical, and deliberately so. The §2.1 table, the legal conclusion and its
+  statutory basis (strictly necessary; appearance), and the language-cookie reasoning (§9 D3).
+  The public page on the docs site is a *copy* of this table written for a lay audience; this
+  file is the source of truth, and must say so, naming the published URL and instructing anyone
+  who edits the table to update the published page (§8.9).
+- **The English-only trade-off** — record that the published cookies page is not translated, that
+  this was a deliberate decision (§9 D10) taken to keep legal copy out of the deploy cycle, and
+  that translating it is the remedy if the language mix of registrants makes it bite. Written
+  down so a future reader finds a decision rather than an oversight.
+- **The EU footing** — EU users *and* EU hosting, so the UK DUAA relaxations do not apply
+  (§3.2). The single fact most likely to be forgotten and most likely to cause an error.
+- **Logging PII** — the *principle* and the why, linking to `docs/agent/code_quality_rules.md`
+  for the code-level rules.
+- **GDPR / right to be forgotten** — the blank-don't-delete strategy, and the prohibition on
+  long-term file storage. Currently in `AGENTS.md`.
+- **"What would change the answer"** — a short, blunt list: *if you are about to do any of the
+  following, this doc is now wrong and you must revisit issue #656.* Covers each principle
+  above, plus adding any new persistent cookie, plus adding a third-party script.
+- **Legal sign-off status** (§9 D6), so nobody assumes more assurance than we have.
+- A pointer back to this research doc for the full reasoning.
+
+**What it does *not* do: absorb `code_quality_rules.md`'s logging section.** That section is
+code-level how-to — use `structlog`, pass `user_id` not `email`, hash with `hash_email`, beware
+`error=str(e)` — with good/bad examples. Three reasons to leave it where it is:
+
+1. `sf-code-review` already routes reviewers to `code_quality_rules.md`. Moving the rules breaks
+   a working path.
+2. Copying them creates two sources of truth that will drift. The next person to update one will
+   not know about the other.
+3. It is the right *altitude* split. `personal-data.md` answers "what may I do, and why";
+   `code_quality_rules.md` answers "how do I write the log call". Hub states the principle and
+   links; the how-to stays put.
+
+Note that `code_quality_rules.md:39-40` *already* justifies the logging rule by reference to
+GDPR erasure. The unifying thread is latent in the text; the hub just makes it explicit.
+
+For the same reason, the `AGENTS.md` sections on "Logging (PII / secrets)" and "GDPR and the
+right to be forgotten" should shrink to short pointers at `personal-data.md` rather than being
+deleted or duplicated. `AGENTS.md` is loaded into every agent's context, so it should carry the
+one-line rule and the link, not the full treatment. (`CLAUDE.md` is a symlink to `AGENTS.md`,
+so this is one edit, not two.)
+
+Add `personal-data.md` to the *Further Documentation* list in `AGENTS.md`.
+
+### 8.6 Tripwires — links from the docs people actually read
+
+Each of these is two or three sentences: state the assumption that currently holds, say what
+would break it, link to the hub. They are not summaries of the hub; they are alarms.
+
+| Doc | Assumption to state | Why it's the right place |
+|---|---|---|
+| `docs/bot-protection.md` | Current protection is honeypot + signed timing token + Redis IP counters, and **sets no cookies and stores nothing on the device**. Turnstile/reCAPTCHA/hCaptcha would introduce third-party cookies and a consent requirement. Also: rate-limit keys contain **IP addresses**, which are personal data, retained only for the counter TTL. | It has a *Related documentation* section already. Anyone replacing the honeypot reads this file first. |
+| `docs/translations.md` | Language detection order (line 99-105) has "Session preference (persisted across requests)" as step 2 — **this is the one cookie an anonymous front-page visitor can acquire**. It rides the 7-day session cookie. Relies on the *appearance* exception / explicit user choice. | Anyone touching locale persistence, or adding a dedicated `lang` cookie, reads this. Step 3 ("user account language preference — future feature") is a DB field, not a cookie, and is fine. |
+| `docs/analytics.md` *(new)* | **We have no analytics, deliberately.** If you are adding it, it must be cookieless and self-hosted (Plausible / Umami / GoatCounter / Matomo-cookieless). Google Analytics is ruled out. Anything that sets a cookie or reads the device requires a full opt-in consent banner, because we are hosted in the EU. | A doc for a thing that does not exist is exactly right here: it is a tripwire. The person who greps `docs/` for "analytics" before adding it is the person we need to catch. |
+
+Two further candidates, weaker, worth a line each if cheap:
+
+- `docs/configuration.md` — where `SESSION_*` / `REMEMBER_COOKIE_*` are documented; a pointer
+  saves someone lengthening a cookie lifetime without thought.
+- `docs/frontend_security.md` — the CSP allowlist is where a third-party script gets waved
+  through (§2.4).
+
+### 8.7 `sf-code-review` — make it a standing check
+
+Add a bullet to *Things to Check* in `.claude/skills/sf-code-review/SKILL.md`:
+
+> - Does the change touch cookies, sessions, logging of personal data, analytics, third-party
+>   scripts, or data retention? If so, check it against `docs/personal-data.md` — especially the
+>   "what would change the answer" list.
+
+This is the piece that makes the whole structure self-enforcing rather than aspirational. The
+tripwires catch someone who reads the docs; the review check catches someone who doesn't.
+
+Worth being honest about the limit: the skill's instructions say "if the diff is big, consider
+giving each of the Things to Check to a subagent", so this bullet must be self-contained enough
+to hand to a subagent with no other context. Phrasing it as "check the diff against this named
+file" rather than "consider privacy implications" is deliberate.
+
+### 8.8 Scope and sequencing
 
 Explicitly **not** in scope: any banner, any consent cookie, any JS.
 
-Separately, and I'd argue more urgently: **self-host the jsDelivr assets** (§2.4). Happy to
-raise that as its own issue.
+**Sequencing gate (§9 D6):** the draft implementation can proceed now, but the branch must not
+merge until someone legally qualified has signed off the conclusion. Practically: build it,
+open the PR, mark it draft or block the merge, and get the sign-off in parallel.
+`docs/personal-data.md` should carry the sign-off status so the record travels with the code.
+
+Separately, and I'd argue more urgently: **self-host the jsDelivr assets** (§2.4). Hamish is
+raising this himself (§9 D7); it is out of scope for this issue.
+
+### 8.9 Risks
+
+**A hub that rots.** The obvious failure mode is that `personal-data.md` becomes a grab-bag
+nobody maintains, and the tripwires point at something stale. Mitigations, in order of how much
+I trust them:
+
+1. **The `sf-code-review` bullet** (§8.7) — the only one with teeth, because it runs on every
+   review.
+2. **The `GET /` no-cookie test** (§8 item 7) — turns one premise into a build failure rather
+   than a document.
+3. Keeping the hub short, and linking rather than copying, so there is less to rot.
+
+**A cookies page that rots, in another repo.** Hosting on the docs site (§9 D8) trades one
+maintenance problem for a slightly worse one. The page must accurately list the cookies we set;
+that list now lives outside the repo where the cookies are defined, in a codebase with no
+knowledge of `config.py`. Nothing fails when they diverge, and an inaccurate cookies page is a
+compliance failure in a way that an inaccurate help page is not.
+
+Two mitigations, both cheap:
+
+- Make `docs/personal-data.md` the **canonical source of the cookie table** (§8.5), and have the
+  docs-site page be a copy of it written for a public audience. Then "is the docs site right?"
+  reduces to "is `personal-data.md` right?", which the review check (§8.7) already asks.
+- Have `personal-data.md` name the docs-site URL and say explicitly: *if you change the cookie
+  table here, update the published page too.*
+
+**Loss of translation.** An in-app page would have gone through `_()` and been translated
+alongside everything else. The docs site is English-only. So a Hungarian-speaking registrant on
+the registration form gets a footer link to an English cookies page. Not a legal defect —
+PECR/GDPR require "clear and comprehensive information", with no explicit language mandate, and
+nothing here requires consent anyway — but it is a real accessibility regression for exactly the
+audience the public form exists to serve. **Accepted deliberately** (§9 D10), and to be recorded
+as such in `docs/personal-data.md` so it reads as a decision rather than an oversight.
+
+**The counter-argument to the whole structure**, honestly stated: five documents referring to one
+another is more machinery than a two-cookie app deserves. I think it survives on the grounds that
+the cost of the tripwires is a few sentences each, and the failure they prevent — shipping Google
+Analytics onto a democratic-participation tool hosted in the EU, with no consent mechanism — is
+bad enough to be worth a few sentences.
 
 ---
 
-## 9. Open questions for Hamish
+## 9. Decisions
 
-### Q1. Do you accept the "no banner" conclusion?
+All six open questions raised by this research have been answered by Hamish. Recorded here so
+the reasoning survives the branch.
 
-It rests on: no advertising, no analytics, no third-party cookies. All three verified in the
-code today. If there's a commitment to a client or funder that assumes a banner exists,
-that changes the calculus and I should know.
+### D1. Option A is approved — cookies page, no banner
 
-COMMENT: I've done some reading myself and I accept the conclusion
+Hamish independently read the material and accepts the conclusion. No client or funder
+commitment assumes a banner exists.
 
-### Q2. Do we need sign-off from someone legally qualified?
+### D2. If analytics arrives, it will be cookieless and self-hosted
 
-I've read the primary sources and I'm confident in the analysis, but I'm not a lawyer, and
-"Claude read the ICO website" is not a defensible position in a DPIA. Given the Sortition
-Foundation processes fairly sensitive demographic data about members of the public, does the
-organisation have a DPO or retained legal advice that should bless this? The cost of asking is
-low; the cost of being wrong is an ICO complaint on a project whose entire premise is public
-trust.
+Hamish was already inclined towards cookieless self-hosted analytics, and is happy to commit on
+this basis. This turns §7 Path 1 from a recommendation into a **standing constraint**, which is
+what makes the "no banner" answer durable rather than a snapshot: the conclusion cannot be
+quietly invalidated by someone dropping in a GA snippet, because the constraint is now written
+down (§8.5), routed to from `docs/analytics.md` (§8.6), and checked on every code review (§8.7).
 
-COMMENT: we might need sign off before merging the branch, but we can do a draft implementation now.
+Corollary: **Option D (geo-aware consent) is rejected outright**, not deferred.
 
-### Q3. The language cookie
+### D3. The language cookie stays as it is, and gets documented
 
-Are you comfortable relying on "the user explicitly clicked Español, therefore it's part of the
-service they requested"? The alternative — making the language preference a session-only cookie
-rather than riding the 7-day session — would put it beyond any argument under WP29, at the cost
-that users re-pick their language each week. I lean towards leaving it and documenting it.
+Agreed: rely on "the user explicitly chose Español, so it forms part of the service they
+requested", and document the reasoning rather than re-engineering the session. No code change.
+It goes in `docs/personal-data.md` with its rationale, and is flagged from `docs/translations.md`
+(§8.6), so that the argument is on record if it is ever
+challenged, rather than being reconstructed from scratch under pressure.
 
-COMMENT: I agree, just document it.
+### D4. We are firmly on the EU footing — users *and* hosting
 
-### Q4. Is analytics actually coming?
+Confirmed: people in the EU are a key audience, **and the service is hosted in the EU**.
 
-You said "might be added at some point". If it's genuinely on the roadmap, I'd rather we commit
-to a **cookieless, self-hosted** tool now (§7 Path 1) and design the cookies page around that,
-than build a banner later. If it's idle speculation, ignore this.
+The hosting fact is new to this analysis and strengthens it. An EU establishment engages EU law
+directly, so we are not relying on a scope argument about who our visitors are. Consequences,
+now settled rather than assumed:
 
-COMMENT: Let's commit to a cookieless self-hosted tool.
+- The UK DUAA relaxations (statistical purposes, appearance) are **unavailable to us**.
+- Every cookie must clear the narrower two-exception ePrivacy test, which §4 shows they all do.
+- Any cookie-setting analytics would require **prior opt-in consent**, with no UK escape hatch.
 
-### Q5. Is the EU exposure real?
+§3.2 has been updated accordingly. This is the fact most likely to be forgotten by a future
+contributor, so it is called out explicitly in the permanent doc (§8.2).
 
-I've assumed OpenDLP serves EU assemblies, based on `SUPPORTED_LANGUAGES = en,es,fr,de` plus
-Hungarian translations. If in fact it's UK-only for the foreseeable future, the analysis gets
-_easier_ (the DUAA exceptions become available), but I don't think it changes the
-recommendation — Option A works under both regimes, which is precisely its appeal.
+### D5. Draft implementation proceeds now, with a documentation hub and tripwires
 
-COMMENT: Yes, people in the EU are a key audience for us. And the service is hosted in the EU.
+Per §8. Hamish asked that future work be able to find both the assumptions made and what would
+change them — a conclusion is only as durable as the record of its premises. That grew into the
+structure in §8.4–§8.7:
 
-### Q6. Should I raise the jsDelivr issue separately?
+- a single canonical `docs/personal-data.md` (named for the GDPR term, *not* `user-data.md`,
+  because "User" is a domain aggregate here and registrants are not Users — §8.5);
+- short tripwire sections in `docs/bot-protection.md`, `docs/translations.md`, and a new
+  `docs/analytics.md`, each stating the assumption its area currently relies on and linking to
+  the hub (§8.6);
+- a standing check in `.claude/skills/sf-code-review/SKILL.md` (§8.7).
 
-Self-hosting govuk-frontend, Alpine and htmx removes a third-party IP disclosure on every page
-load. I think this is a bigger genuine privacy improvement than anything in this document, and
-it's a contained piece of work. Want me to open an issue?
+The hub links to `docs/agent/code_quality_rules.md` for the code-level logging rules rather than
+absorbing them, to avoid two sources of truth (§8.5).
 
-COMMENT: I'll raise it myself.
+### D6. Legal sign-off is a merge gate, not a start gate
+
+We may need sign-off before merging the branch; a draft implementation can proceed in parallel.
+So: build it, open the PR, hold the merge until someone legally qualified has blessed the
+conclusion. `docs/personal-data.md` should record the sign-off status, so nobody downstream
+assumes more assurance than we actually have.
+
+I'd still note the asymmetry that motivated the question: the cost of asking is low, and the
+cost of being wrong is an ICO complaint against a project whose entire premise is public trust.
+
+### D7. The jsDelivr issue — Hamish will raise it
+
+Out of scope here. Self-hosting govuk-frontend, Alpine and htmx would remove a third-party IP
+and referrer disclosure on every page load (§2.4). Not a PECR matter — nothing is stored on the
+device — but in my view a larger real-world privacy improvement than anything in this document.
+
+### D8. The cookies page is hosted on the docs site, not served by Flask
+
+Following the User Data Agreement pattern. New config var `HELP_SITE_COOKIES`, default
+`https://docs.sortitionlab.org/data-and-legal/cookies/`, threaded through `config.py`,
+`context_processors.py`, `env.example` and `docs/configuration.md` (§8.2).
+
+This simplifies the app — no route, no template, no i18n for the page — and keeps legal copy out
+of the deploy cycle. It creates two consequences worth naming rather than discovering later:
+
+1. **We can no longer test the page's contents**, because they aren't ours. The mitigation is to
+   make `docs/personal-data.md` the canonical cookie table and treat the published page as a
+   rendering of it (§8.9). After this, the `GET /` no-`Set-Cookie` assertion is the *only*
+   executable check in the entire scheme, which raises its value considerably.
+2. **The page will be English-only** where an in-app page would have been translated. Accepted
+   and noted (§9 D10).
+
+One implementation detail the pattern hides, in §8.2: `get_help_site_urls()` returns a positional
+tuple, which becomes a `NamedTuple` (§9 D9).
+
+### D9. `get_help_site_urls()` becomes a NamedTuple
+
+Agreed to make the change rather than defer it. Design in §8.2.1.
+
+The reasoning that makes this worth doing *now* rather than filing for later: with three
+same-typed strings, positional unpacking gets a transposition bug past both mypy and the type
+checker silently — you would find out when a footer link pointed at the wrong page. There is
+exactly one call site, `NamedTuple` is `typing` stdlib (no new dependency), and it stays hashable
+so `@cache` keeps working. Small, contained, and it removes a real class of error.
+
+Two things a reviewer should look at: it introduces the `NamedTuple` idiom to `src/`, which has
+none today; and `get_help_site_urls` has no `cache_clear()` in the test suite, unlike its
+siblings, which matters if a test wants to vary the URL via the environment (§8.2.2).
+
+### D10. The English-only cookies page is accepted, and noted
+
+Agreed: accept it, note it. The docs site is not translated; a Hungarian- or Spanish-speaking
+registrant on the public form gets a footer link to an English page.
+
+Not a legal defect — the information duty is "clear and comprehensive", with no language mandate,
+and none of our cookies require consent in the first place. But it is a real accessibility
+regression for exactly the audience the public registration form exists to reach: people invited
+by post who may not be confident in English.
+
+So it must be **written down rather than quietly accepted**. `docs/personal-data.md` should record
+that the published cookies page is English-only, that this was a deliberate trade for keeping
+legal copy out of the deploy cycle, and that translating it is the obvious remedy if the language
+mix of registrants ever makes it bite. That way the next person to look at this finds a decision,
+not an oversight.
+
+### D11. Add a minimal GOV.UK footer to `base_public.html`
+
+Agreed. `base_public.html` has no footer at all — it runs from `<main>` (lines 27-29) straight to
+`</body>` (line 43), with no `govuk-footer` markup anywhere (§8.3).
+
+Scope: a minimal GOV.UK footer carrying the cookies link and the User Data Agreement link, and
+nothing else. The public registration form should stay uncluttered — it is the one page where
+added visual noise costs us completions from people we reached by post.
+
+This is the only item in the plan with meaningful implementation work, and it lands on the most
+sensitive template we have, so it deserves its own careful review of the rendered page rather
+than being waved through as "add a link".
 
 ---
 

--- a/backend/docs/agent/656-cookies/research.md
+++ b/backend/docs/agent/656-cookies/research.md
@@ -472,9 +472,12 @@ discovers the constraint before they discover the lawyer.
 Option A is approved (§9 D1), with the cookies page hosted on the docs site (§9 D8). The work is
 small, and mostly content.
 
-**Progress:** items 2, 3, 4 and 7 are done. Item 6 is in progress. Item 1 is in the docs repo,
-not this one. Item 5 has no in-app target — there is no privacy notice template in the app
-(§8.10).
+**Progress: complete in this repo.** Items 2, 3, 4, 6 and 7 are done. Item 1 is in the docs
+repo, not this one, and remains outstanding. Item 5 has no in-app target — there is no privacy
+notice template in the app (§8.10).
+
+Remaining before merge: author the cookies page on the docs site (item 1), and obtain legal
+sign-off (D6).
 
 1. **Cookies page on the docs site** — authored at
    `https://docs.sortitionlab.org/data-and-legal/cookies/`, in the docs repo, not here. Content:

--- a/backend/docs/agent/code_quality_rules.md
+++ b/backend/docs/agent/code_quality_rules.md
@@ -108,7 +108,8 @@ except Exception as e:
 Specific, expected exceptions (e.g. `except NotFoundError`) where no traceback
 is wanted may stay on `logger.error`.
 
-See [docs/agent/617-log-redaction/](617-log-redaction/) for the redaction design.
+See [docs/personal-data.md](../personal-data.md) for why these rules exist and what else they
+constrain, and [docs/agent/617-log-redaction/](617-log-redaction/) for the redaction design.
 
 ## Cyclomatic Complexity
 

--- a/backend/docs/analytics.md
+++ b/backend/docs/analytics.md
@@ -1,0 +1,40 @@
+# Analytics
+
+**OpenDLP has no analytics. This is deliberate, not an oversight.**
+
+If you are here because you are about to add some, read this first, then read
+[docs/personal-data.md](personal-data.md).
+
+## The constraint
+
+Any analytics added to OpenDLP **must be cookieless and self-hosted** — Plausible, Umami,
+GoatCounter, or Matomo in cookieless mode. These set no cookies and store no device
+identifier, so they trigger no consent requirement in either the UK or the EU, and the data
+stays ours.
+
+**Google Analytics is ruled out**, on two independent grounds: it requires prior opt-in
+consent from our EU users, and shipping Google tracking on a democratic-participation tool is
+not consistent with what this project is for.
+
+**Anything that sets a cookie or reads the device requires a full opt-in consent banner.**
+We are hosted in the EU, and there is no analytics exception under EU ePrivacy law — the UK's
+2025 relaxation does not reach us. That is true even of a self-hosted tool, if it sets a
+first-party cookie.
+
+## Why this is written down
+
+The "we need no cookie banner" conclusion in [docs/personal-data.md](personal-data.md) rests on
+having no analytics cookies. Dropping in a snippet would invalidate it silently: nothing would
+fail, no test would go red, and we would be out of compliance without anyone noticing.
+
+So the constraint lives here, where someone who greps `docs/` for "analytics" will find it
+before they find the lawyer.
+
+Full reasoning, including what each analytics path would cost us:
+[docs/agent/656-cookies/research.md §7](agent/656-cookies/research.md).
+
+## Related documentation
+
+- [docs/personal-data.md](personal-data.md) — cookies, logging, and erasure
+- [docs/frontend_security.md](frontend_security.md) — the CSP allowlist, which is where a
+  third-party script gets waved through

--- a/backend/docs/bot-protection.md
+++ b/backend/docs/bot-protection.md
@@ -92,7 +92,22 @@ redis-cli DEL reg_ratelimit:ip:<ip>
 redis-cli DEL reg_ratelimit:email:<email>
 ```
 
+## Privacy assumptions
+
+The current protection is honeypot + signed timing token + Redis IP counters. It **sets no
+cookies and stores nothing on the user's device** — everything is a form field, a response
+header, or a server-side counter.
+
+This matters. Replacing it with **Turnstile, reCAPTCHA or hCaptcha** would introduce
+third-party cookies and, for reCAPTCHA, a consent requirement — which is unworkable on a form
+we need members of the public to complete. If you are considering that, read
+[docs/personal-data.md](personal-data.md) first.
+
+Note also that the rate-limit keys above contain **IP addresses and email addresses**, which
+are personal data. They are retained only for the counter's TTL.
+
 ## Related documentation
 
+- [Personal Data](personal-data.md) — cookies, logging, and the right to erasure
 - [Frontend Security Guidelines](frontend_security.md) — CSP, nonce requirements, and JavaScript patterns
 - [research.md](agent/614-bot-protection/research.md) — Full threat model, call-centre handling options, and later-round work (address-match integration, email-job signed links)

--- a/backend/docs/configuration.md
+++ b/backend/docs/configuration.md
@@ -198,7 +198,8 @@ description, provisioning steps, and operator runbook.
 
 ### Help Site URLs
 
-External help site URLs linked from base templates (header "Help" link and footer "User Data Agreement" link):
+External help site URLs linked from base templates (header "Help" link, and the footer
+"User Data Agreement" and "Cookies" links):
 
 ```bash
 # Help site landing page (replaces the in-app support page)
@@ -206,7 +207,19 @@ HELP_SITE_HOME=https://docs.sortitionlab.org/help/
 
 # Data agreement page (replaces the in-app user data agreement page)
 HELP_SITE_DATA_AGREEMENT=https://docs.sortitionlab.org/data-and-legal/data-agreement/
+
+# Cookies page, linked from the footer of every page including the public
+# registration form. Must accurately list the cookies we set - see
+# docs/personal-data.md, which is the canonical source of that list.
+HELP_SITE_COOKIES=https://docs.sortitionlab.org/data-and-legal/cookies/
 ```
+
+### Session and cookie lifetimes
+
+`SESSION_COOKIE_*` and `REMEMBER_COOKIE_*` control the only two cookies OpenDLP sets.
+Before changing their lifetimes, or adding a cookie, read
+[docs/personal-data.md](personal-data.md) — the "no cookie banner" conclusion rests on
+what those cookies are for and how long they last.
 
 ### Site Banner Configuration
 

--- a/backend/docs/frontend_security.md
+++ b/backend/docs/frontend_security.md
@@ -197,6 +197,11 @@ Before adding frontend code, verify:
 - [ ] External JS/CSS referenced with cache busting (`v=static_hashes('relative/path/to/file')`)
 - [ ] No use of eval(), Function(), or similar
 - [ ] All scripts from trusted CDNs only
+- [ ] No new third-party script, font, embed or analytics snippet — see [Personal Data](personal-data.md)
+
+Widening the CSP allowlist is how a third-party script gets waved through. A third party that
+sets a cookie, or that reads the device, would oblige us to build a consent banner we do not
+have. Read [docs/personal-data.md](personal-data.md) before adding a host to the allowlist.
 
 ## Testing CSP Compliance
 
@@ -207,6 +212,7 @@ Before adding frontend code, verify:
 
 ## Further Reading
 
+- [Personal Data](personal-data.md) — cookies, third-party scripts, logging, and erasure
 - [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 - [Alpine.js CSP Build](https://alpinejs.dev/advanced/csp)
 - [OWASP: Cross Site Scripting Prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)

--- a/backend/docs/personal-data.md
+++ b/backend/docs/personal-data.md
@@ -1,0 +1,190 @@
+# Personal Data
+
+This is the canonical reference for how OpenDLP handles personal data: cookies, logging,
+and the right to erasure. It exists so that the assumptions behind our current legal
+position are written down, and so that anyone about to invalidate one of them finds out
+before they ship it.
+
+**If you are changing anything to do with cookies, sessions, logging of personal data,
+analytics, third-party scripts, or data retention, read [What would change the
+answer](#what-would-change-the-answer) first.**
+
+Full reasoning behind the cookie conclusions: [docs/agent/656-cookies/research.md](agent/656-cookies/research.md).
+
+## Why "personal data" and not "user data"
+
+*User* is a domain term here — `domain/users.py` is an aggregate with roles and passwords.
+The most sensitive personal data we hold belongs to **registrants**, who are explicitly not
+`User`s. "Personal data" is the UK/EU GDPR term of art, and it correctly spans cookies
+(device identifiers), log lines, registrants, users, and the IP addresses in our rate-limit
+keys.
+
+## Principles
+
+These are standing constraints, not defaults. Changing one is a decision, not a refactor.
+
+- **No advertising, ever.**
+- **No analytics that sets a cookie or reads the device.** If analytics is added it must be
+  cookieless and self-hosted. See [docs/analytics.md](analytics.md).
+- **No third-party cookies. No cross-site or cross-device tracking.**
+- **Bot protection stays server-side** — no Turnstile, reCAPTCHA or hCaptcha. See
+  [docs/bot-protection.md](bot-protection.md).
+- **Never log raw PII.**
+- **No long-term copies of personal data that cannot be found and blanked.**
+
+## The EU footing
+
+**People in the EU are a key audience, and the service is hosted in the EU.**
+
+This is the single fact most likely to be forgotten, and the one most likely to cause an
+error. An EU establishment engages EU law directly. So:
+
+- The UK Data (Use and Access) Act 2025 relaxations — the *statistical purposes* and
+  *appearance* exceptions — are **unavailable to us**.
+- Every cookie must clear the narrower EU ePrivacy test, which has only two exceptions:
+  transmission, and strictly necessary for a service the user explicitly requested.
+- **Any cookie-setting analytics would require prior opt-in consent**, with no UK escape hatch.
+
+Do not reason from ICO guidance alone. It is the more permissive of the two regimes we are
+subject to.
+
+## Cookies
+
+**This table is the source of truth.** The public cookies page at
+<https://docs.sortitionlab.org/data-and-legal/cookies/> (configured by `HELP_SITE_COOKIES`)
+is a copy of it written for a lay audience. **If you change this table, update the published
+page too** — nothing fails when they diverge, and an inaccurate cookies page is a compliance
+failure in a way that an inaccurate help page is not.
+
+There are exactly two cookies. Both are first-party and `HttpOnly`.
+
+| Cookie | Set by | When | Lifetime | Purpose |
+|---|---|---|---|---|
+| `session` | Flask-Session | CSRF token generation, `flash()`, `?lang=` selection, 2FA, OAuth start | 7 days | Security (CSRF), sign-in, form messages, language choice |
+| `remember_token` | Flask-Login | Only when the user ticks "keep me signed in" | 7 days in production | Persistent login |
+
+Notes:
+
+- `SESSION_TYPE = "redis"` means the session *payload* lives in Redis, but a browser-side
+  cookie carrying the session id is still set. Server-side sessions do not avoid the cookie.
+- There is **no separate CSRF cookie** — Flask-WTF stores the CSRF secret inside the session.
+- There is **no language cookie** — the choice is stored under the `"language"` key inside
+  the session.
+- No `localStorage`, no `sessionStorage`, no `document.cookie` anywhere in `static/`.
+- **`REMEMBER_COOKIE_DURATION` is set to 7 days only in `FlaskProductionConfig`.** Outside
+  production the cookie inherits Flask-Login's default of **365 days**. Production is what
+  the public sees, so the published page is accurate — but a non-production deployment with
+  real people on it would hand out year-long cookies. Worth fixing; see
+  [research.md §8.10](agent/656-cookies/research.md).
+
+### We do not need a cookie banner
+
+Every cookie above falls within a statutory exception to the consent requirement, under both
+UK and EU law:
+
+- **`session`** is strictly necessary for security (CSRF), authentication, and recording the
+  user's own form input. All are expressly exempt.
+- **`remember_token`** is *not* strictly necessary — but the checkbox **is** the consent. It
+  is a specific, informed, unambiguous, affirmative act, unticked by default. That is textbook
+  GDPR-standard consent, and it is why the label names the cookie rather than saying
+  "Remember me".
+- **The language choice** rides on the `session` cookie. We rely on the argument that a user
+  who clicks "Español" has explicitly requested the service of being shown Spanish, which puts
+  it back inside *strictly necessary*. This is the one place a lawyer might quibble; the
+  reasoning is set out in [research.md §4.1](agent/656-cookies/research.md).
+
+GOV.UK guidance is explicit that an essential-cookies-only service may skip the banner, but
+must still have a cookies page linked from the footer. That is what we do — all three footers
+(`base.html`, `base_public.html`, `backoffice/components/footer.html`) carry the link.
+
+A banner offering nothing to reject would be consent theatre. The ICO criticises it, and it
+would put friction on the public registration form — the one interaction we most need to
+succeed, completed by people invited by post who may not be confident internet users.
+
+**Legal sign-off status: not yet obtained.** The analysis in `research.md` is the work of a
+careful non-lawyer. Sign-off is a merge gate for issue #656. Do not cite this document as
+legal advice.
+
+### The published page is English-only
+
+The docs site is not translated, so a Hungarian- or Spanish-speaking registrant on the public
+form gets a footer link to an English page. This is a **deliberate trade**, made to keep legal
+copy out of the deploy cycle so a wording fix does not require a release.
+
+It is not a legal defect — the duty is to give "clear and comprehensive information", with no
+language mandate, and none of our cookies require consent in the first place. But it is a real
+accessibility regression for exactly the audience the public form exists to reach. If the
+language mix of registrants ever makes it bite, the remedy is to translate the page, or to
+serve it from the app.
+
+## Logging
+
+Logs are long-lived and widely accessible, so they must never become a copy of personal data
+we would then have to find and blank for an erasure request.
+
+The principle: **log a stable identifier, never the person.** Log `user_id` (a UUID), which
+survives erasure because the row is blanked rather than deleted. Where no UUID exists yet —
+pre-auth, login rate limiting — hash the value instead.
+
+`log_redaction.censor_pii` redacts emails and sensitive field names from all log output. It
+is a **backstop, not a licence**: it cannot redact a name or address embedded in the free text
+of an exception message.
+
+The code-level rules — `structlog.get_logger`, structured key/value fields, `hash_email`, and
+the trap in `error=str(e)` — live in
+[docs/agent/code_quality_rules.md](agent/code_quality_rules.md#logging-pii--secrets). That is
+the right altitude split: this file says what you may do and why, that one says how to write
+the log call. Design notes: [docs/agent/617-log-redaction/](agent/617-log-redaction/).
+
+Note that our bot-protection rate-limit keys contain **IP addresses**, which are personal
+data. They are retained only for the counter's TTL.
+
+## GDPR and the right to be forgotten
+
+We must support people asking for their details to be deleted, which means we must be able to
+find every persistent copy of someone's details easily.
+
+**The strategy is to blank the details but keep the row**, with its unique ID intact. Anything
+referring to that ID keeps a valid reference, and learns that the details are gone.
+
+The consequence, which is a hard constraint: **we must not hold copies of personal data in
+long-term storage that cannot be easily found and blanked.** In particular, no long-term copies
+of uploaded or generated files (CSV, Excel) in the database or on disk. Such files may be held
+in memory, written into a data attribute of an HTML page sent to the user, placed in a download
+directory that is regularly swept, or cached in Redis.
+
+When adding a table that holds personal data, add a corresponding `DELETE` to
+`_delete_all_test_data()` in `tests/conftest.py` and to `delete_all_except_standard_users()` in
+`tests/bdd/conftest.py`, respecting foreign-key ordering.
+
+## What would change the answer
+
+**If you are about to do any of the following, this document is now wrong, and you must revisit
+[issue #656](agent/656-cookies/research.md) before shipping.**
+
+- Adding **any analytics**, or any third-party script or embed — including a font, a map, a
+  video player, or an error reporter such as Sentry.
+- Adding **any new cookie**, or any use of `localStorage`, `sessionStorage` or `document.cookie`.
+- Making an existing cookie **persistent**, or lengthening its lifetime.
+- Using an existing cookie for a **new purpose**. Every purpose must independently qualify for
+  an exception — a cookie that is exempt for CSRF is not automatically exempt for anything else.
+- Replacing the honeypot bot protection with **Turnstile, reCAPTCHA or hCaptcha**.
+- Adding a **dedicated language cookie**, or otherwise changing how the language preference
+  persists.
+- Writing a `flash()` or a CSRF token into **the front page** (`main.index`). It currently sets
+  no cookie for an anonymous visitor, and
+  `tests/unit/test_flask_app.py::test_index_sets_no_cookie_for_anonymous_visitor` will fail if
+  that changes. That test failing is a signal to think, not a signal to update the assertion.
+- Storing personal data anywhere it **cannot be found and blanked** on request.
+
+Most of these need a cookie consent banner, which we do not have and do not want. All of them
+need a decision, not a commit.
+
+## Related documentation
+
+- [docs/agent/656-cookies/research.md](agent/656-cookies/research.md) — the full legal analysis
+- [docs/analytics.md](analytics.md) — why we have none, and what to do if you add some
+- [docs/bot-protection.md](bot-protection.md) — honeypot, timing token, rate limits
+- [docs/translations.md](translations.md) — language detection and the session preference
+- [docs/agent/code_quality_rules.md](agent/code_quality_rules.md#logging-pii--secrets) — how to write a safe log call
+- [docs/configuration.md](configuration.md) — `SESSION_COOKIE_*`, `REMEMBER_COOKIE_*`, `HELP_SITE_COOKIES`

--- a/backend/docs/translations.md
+++ b/backend/docs/translations.md
@@ -104,8 +104,24 @@ OpenDLP detects user language in this order:
 4. Browser Accept-Language header
 5. Default locale fallback
 
+### The session preference is a cookie
+
+Step 2 stores the language under the `"language"` key inside the Flask session, so it rides on
+the 7-day `session` cookie. **This is the only cookie an anonymous front-page visitor can
+acquire** — everything else requires them to sign in or open a form.
+
+There is no dedicated language cookie, and adding one would be a decision rather than a
+refactor. We rely on the argument that a user who clicks "Español" has explicitly requested
+the service of being shown Spanish, which keeps the cookie inside the *strictly necessary*
+exception and means we need no consent banner.
+
+If you are changing how the language preference persists — a dedicated cookie, a longer
+lifetime, `localStorage` — read [docs/personal-data.md](personal-data.md) first. Step 3, the
+future account preference, is a database field rather than a cookie, and raises none of this.
+
 ## Further Reading
 
+- [Personal Data](personal-data.md) — cookies, logging, and the right to erasure
 - [Flask-Babel Documentation](https://python-babel.github.io/flask-babel/)
 - [GNU gettext Manual](https://www.gnu.org/software/gettext/manual/)
 - [Babel Documentation](https://babel.pocoo.org/)

--- a/backend/env.example
+++ b/backend/env.example
@@ -89,6 +89,7 @@ SUPPORT_EMAIL=opendlp-support@sortitionfoundation.org
 # External help site URLs (linked from base templates)
 HELP_SITE_HOME=https://docs.sortitionlab.org/help/
 HELP_SITE_DATA_AGREEMENT=https://docs.sortitionlab.org/data-and-legal/data-agreement/
+HELP_SITE_COOKIES=https://docs.sortitionlab.org/data-and-legal/cookies/
 # Solver backend for sortition-algorithms: 'mip' (CBC) or 'highspy' (HiGHS)
 # If not set, defaults to 'highspy' on macOS and 'mip' on other platforms
 # SOLVER_BACKEND=

--- a/backend/src/opendlp/config.py
+++ b/backend/src/opendlp/config.py
@@ -442,6 +442,9 @@ class FlaskBaseConfig:
         self.HELP_SITE_DATA_AGREEMENT: str = os.environ.get(
             "HELP_SITE_DATA_AGREEMENT", "https://docs.sortitionlab.org/data-and-legal/data-agreement/"
         )
+        self.HELP_SITE_COOKIES: str = os.environ.get(
+            "HELP_SITE_COOKIES", "https://docs.sortitionlab.org/data-and-legal/cookies/"
+        )
 
         # Login rate limiting
         self.LOGIN_RATE_LIMIT_PER_EMAIL: int = int(os.environ.get("LOGIN_RATE_LIMIT_PER_EMAIL", "5"))

--- a/backend/src/opendlp/entrypoints/context_processors.py
+++ b/backend/src/opendlp/entrypoints/context_processors.py
@@ -8,6 +8,7 @@ import subprocess
 from collections.abc import Callable
 from functools import cache
 from pathlib import Path
+from typing import NamedTuple
 
 from opendlp import config
 from opendlp.feature_flags import has_feature
@@ -128,10 +129,22 @@ def get_support_email() -> str:
     return flask_config.SUPPORT_EMAIL
 
 
+class HelpSiteUrls(NamedTuple):
+    """URLs of pages published on the external docs site."""
+
+    home: str
+    data_agreement: str
+    cookies: str
+
+
 @cache
-def get_help_site_urls() -> tuple[str, str]:
+def get_help_site_urls() -> HelpSiteUrls:
     flask_config = config.get_config()
-    return flask_config.HELP_SITE_HOME, flask_config.HELP_SITE_DATA_AGREEMENT
+    return HelpSiteUrls(
+        home=flask_config.HELP_SITE_HOME,
+        data_agreement=flask_config.HELP_SITE_DATA_AGREEMENT,
+        cookies=flask_config.HELP_SITE_COOKIES,
+    )
 
 
 def inject_feature_flags() -> dict[str, object]:
@@ -153,7 +166,7 @@ def inject_template_globals() -> dict[str, str | Callable]:
     support email, and external help-site URLs.
     """
     site_banner_text, site_banner_colour = get_site_banner_config()
-    help_site_home, help_site_data_agreement = get_help_site_urls()
+    help_site_urls = get_help_site_urls()
     return {
         "opendlp_version": get_opendlp_version(),
         "google_service_account_email": get_service_account_email(),
@@ -161,6 +174,7 @@ def inject_template_globals() -> dict[str, str | Callable]:
         "site_banner_colour": site_banner_colour,
         "static_hashes": static_hashes,
         "support_email_address": get_support_email(),
-        "help_site_home": help_site_home,
-        "help_site_data_agreement": help_site_data_agreement,
+        "help_site_home": help_site_urls.home,
+        "help_site_data_agreement": help_site_urls.data_agreement,
+        "help_site_cookies": help_site_urls.cookies,
     }

--- a/backend/src/opendlp/entrypoints/forms.py
+++ b/backend/src/opendlp/entrypoints/forms.py
@@ -101,7 +101,9 @@ class LoginForm(FlaskForm):  # type: ignore[no-any-unimported]
         _l("Password"), validators=[DataRequired()], render_kw={"autocomplete": "current-password"}
     )
 
-    remember_me = BooleanField(_l("Remember me"))
+    # Ticking this is the user's consent for the persistent remember_token cookie,
+    # so the label must state the consequence. See docs/personal-data.md.
+    remember_me = BooleanField(_l("Keep me signed in for 7 days (sets a cookie on this device)"))
 
 
 class RegistrationForm(FlaskForm):  # type: ignore[no-any-unimported]

--- a/backend/templates/backoffice/components/footer.html
+++ b/backend/templates/backoffice/components/footer.html
@@ -15,6 +15,9 @@ ABOUTME: Site-wide footer with support links and version info
                 <a href="{{ help_site_data_agreement }}" target="_blank" class="text-body-sm transition duration-150 ease-in-out hover:opacity-80" style="color: var(--color-secondary-text);">
                     {{ _("User Data Agreement") }}
                 </a>
+                <a href="{{ help_site_cookies }}" target="_blank" class="text-body-sm transition duration-150 ease-in-out hover:opacity-80" style="color: var(--color-secondary-text);">
+                    {{ _("Cookies") }}
+                </a>
                 {% if feature('dashboard_switch_links') %}
                     <a href="{{ url_for('main.dashboard') }}" class="text-body-sm transition duration-150 ease-in-out hover:opacity-80" style="color: var(--color-secondary-text);">
                         {{ _("Old Dashboard") }}

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -175,6 +175,11 @@
                                    href="{{ help_site_data_agreement }}"
                                    target="_blank">{{ _("User Data Agreement") }}</a>
                             </li>
+                            <li class="govuk-footer__inline-list-item">
+                                <a class="govuk-footer__link"
+                                   href="{{ help_site_cookies }}"
+                                   target="_blank">{{ _("Cookies") }}</a>
+                            </li>
                             {% if feature('dashboard_switch_links') %}
                                 <li class="govuk-footer__inline-list-item">
                                     <a class="govuk-footer__link"

--- a/backend/templates/base_public.html
+++ b/backend/templates/base_public.html
@@ -28,6 +28,27 @@
                 {% block content %}{% endblock %}
             </main>
         </div>
+        <footer class="govuk-footer" role="contentinfo">
+            <div class="govuk-width-container">
+                <div class="govuk-footer__meta">
+                    <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                        <h2 class="govuk-visually-hidden">{{ _("Support links") }}</h2>
+                        <ul class="govuk-footer__inline-list">
+                            <li class="govuk-footer__inline-list-item">
+                                <a class="govuk-footer__link"
+                                   href="{{ help_site_data_agreement }}"
+                                   target="_blank">{{ _("User Data Agreement") }}</a>
+                            </li>
+                            <li class="govuk-footer__inline-list-item">
+                                <a class="govuk-footer__link"
+                                   href="{{ help_site_cookies }}"
+                                   target="_blank">{{ _("Cookies") }}</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </footer>
         <script nonce="{{ csp_nonce }}"
                 src="https://cdn.jsdelivr.net/npm/govuk-frontend@5.11.1/dist/govuk/all.bundle.min.js"
                 integrity="sha384-gDZkBYDiXRQUvstxmxJ+TbB7CxTGzhmH+ZmBAGzbAEgYb/bglRLXcnh6ZxhaVYLy"{# pragma: allowlist secret #}

--- a/backend/tests/e2e/test_registration_public.py
+++ b/backend/tests/e2e/test_registration_public.py
@@ -200,6 +200,19 @@ class TestRegistrationFormRendering:
         assert b"govuk-button" in response.data
         assert b"name" in response.data
 
+    def test_public_form_footer_links_to_cookies_page(
+        self, client: FlaskClient, published_registration_page: RegistrationPage
+    ) -> None:
+        """The public form is the one page an anonymous visitor lands on, and the one
+        that sets a cookie, so GOV.UK requires a footer link to the cookies page."""
+        response = client.get(
+            route_url(client, "registration.show_registration_form", url_slug=published_registration_page.url_slug)
+        )
+
+        assert b"govuk-footer" in response.data
+        assert b"https://docs.sortitionlab.org/data-and-legal/cookies/" in response.data
+        assert b"https://docs.sortitionlab.org/data-and-legal/data-agreement/" in response.data
+
 
 class TestRegistrationFormSubmission:
     """Test POST /register/<url_slug> route."""

--- a/backend/tests/unit/test_context_processors.py
+++ b/backend/tests/unit/test_context_processors.py
@@ -2,6 +2,7 @@
 ABOUTME: Tests context processors that inject variables into template context"""
 
 import hashlib
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,6 +10,7 @@ import pytest
 
 from opendlp.entrypoints.context_processors import (
     _get_file_hash,
+    get_help_site_urls,
     get_opendlp_version,
     get_service_account_email,
     inject_template_globals,
@@ -135,6 +137,30 @@ class TestInjectTemplateGlobals:
 
         assert context["help_site_home"] == "https://docs.sortitionlab.org/help/"
         assert context["help_site_data_agreement"] == "https://docs.sortitionlab.org/data-and-legal/data-agreement/"
+        assert context["help_site_cookies"] == "https://docs.sortitionlab.org/data-and-legal/cookies/"
+
+
+class TestGetHelpSiteUrls:
+    """Test the get_help_site_urls context processor helper."""
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        get_help_site_urls.cache_clear()
+        yield
+        get_help_site_urls.cache_clear()
+
+    def test_returns_named_tuple_with_attribute_access(self):
+        """Test that the URLs are reachable by name, not just by position."""
+        urls = get_help_site_urls()
+
+        assert urls.home == "https://docs.sortitionlab.org/help/"
+        assert urls.data_agreement == "https://docs.sortitionlab.org/data-and-legal/data-agreement/"
+        assert urls.cookies == "https://docs.sortitionlab.org/data-and-legal/cookies/"
+
+    def test_cookies_url_can_be_overridden_by_environment(self):
+        """Test that HELP_SITE_COOKIES overrides the default cookies page URL."""
+        with patch.dict(os.environ, {"HELP_SITE_COOKIES": "https://example.com/cookies/"}):
+            assert get_help_site_urls().cookies == "https://example.com/cookies/"
 
 
 class TestGetOpendlpVersion:

--- a/backend/tests/unit/test_dashboard_feature_flags.py
+++ b/backend/tests/unit/test_dashboard_feature_flags.py
@@ -88,6 +88,7 @@ class TestFooterOldDashboardLink:
             return render_template_string(
                 template,
                 help_site_data_agreement="https://example.com/data",
+                help_site_cookies="https://example.com/cookies",
                 opendlp_version="test-version",
             )
 
@@ -105,3 +106,9 @@ class TestFooterOldDashboardLink:
         html = self._render_footer()
         assert "Old Dashboard" in html
         assert "/dashboard" in html
+
+    def test_footer_links_to_cookies_page(self, monkeypatch):
+        """The backoffice footer must carry the cookies link, as the GOV.UK footer does."""
+        monkeypatch.delenv("FF_DASHBOARD_SWITCH_LINKS", raising=False)
+        html = self._render_footer()
+        assert "https://example.com/cookies" in html

--- a/backend/tests/unit/test_flask_app.py
+++ b/backend/tests/unit/test_flask_app.py
@@ -121,6 +121,24 @@ class TestMainBlueprint:
         assert response.status_code == 200
         assert b"OpenDLP" in response.data
 
+    def test_index_sets_no_cookie_for_anonymous_visitor(self, client: FlaskClient) -> None:
+        """The front page must set no cookie for an anonymous visitor.
+
+        This is the load-bearing premise of docs/personal-data.md: an anonymous
+        visitor acquires a cookie only by choosing a language, signing in, or
+        opening a form. Adding a flash(), a CSRF token, or any session write to
+        the index view would break that, and must be a deliberate decision.
+        """
+        response = client.get("/")
+
+        assert response.status_code == 200
+        assert "Set-Cookie" not in response.headers
+
+    def test_index_footer_links_to_cookies_page(self, client: FlaskClient) -> None:
+        """Test the footer carries a cookies page link, as GOV.UK guidance requires."""
+        response = client.get("/")
+        assert b"https://docs.sortitionlab.org/data-and-legal/cookies/" in response.data
+
     def test_dashboard_requires_login(self, client: FlaskClient) -> None:
         """Test dashboard route requires authentication."""
         response = client.get("/dashboard")

--- a/backend/tests/unit/test_login_form.py
+++ b/backend/tests/unit/test_login_form.py
@@ -1,0 +1,27 @@
+"""ABOUTME: Unit tests for the login form's remember-me consent properties
+ABOUTME: The checkbox is the consent for the persistent remember_token cookie"""
+
+from opendlp.entrypoints.flask_app import create_app
+from opendlp.entrypoints.forms import LoginForm
+
+
+class TestRememberMeConsent:
+    """The remember_token cookie is not strictly necessary, so the checkbox itself
+    carries the consent. That only holds if it is unticked by default and its label
+    tells the user what ticking it does. See docs/personal-data.md.
+    """
+
+    def test_remember_me_is_unticked_by_default(self) -> None:
+        app = create_app("testing")
+        with app.test_request_context("/auth/login"):
+            form = LoginForm()
+
+            assert form.remember_me.data is False
+
+    def test_remember_me_label_states_the_cookie_consequence(self) -> None:
+        app = create_app("testing")
+        with app.test_request_context("/auth/login"):
+            form = LoginForm()
+            label = str(form.remember_me.label.text)
+
+            assert "cookie" in label.lower()

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-14 09:14+0000\n"
+"POT-Creation-Date: 2026-07-14 15:02+0100\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -239,257 +239,256 @@ msgstr "A(z) „%(email)s” e-mail címmel rendelkező felhasználó már léte
 msgid "Number cannot be negative"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:97 src/opendlp/entrypoints/forms.py:131
-#: src/opendlp/entrypoints/forms.py:171 src/opendlp/entrypoints/forms.py:182
+#: src/opendlp/entrypoints/forms.py:97 src/opendlp/entrypoints/forms.py:133
+#: src/opendlp/entrypoints/forms.py:173 src/opendlp/entrypoints/forms.py:184
 #: templates/profile/view.html:10
 msgid "Email address"
 msgstr "Email cím"
 
-#: src/opendlp/entrypoints/forms.py:101 src/opendlp/entrypoints/forms.py:137
-#: src/opendlp/entrypoints/forms.py:499 templates/admin/user_view.html:75
+#: src/opendlp/entrypoints/forms.py:101 src/opendlp/entrypoints/forms.py:139
+#: src/opendlp/entrypoints/forms.py:501 templates/admin/user_view.html:75
 #: templates/profile/view.html:37
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/opendlp/entrypoints/forms.py:104
-#, fuzzy
-msgid "Remember me"
-msgstr "Maradjak bejelentkezve"
+#: src/opendlp/entrypoints/forms.py:106
+msgid "Keep me signed in for 7 days (sets a cookie on this device)"
+msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:111 src/opendlp/entrypoints/forms.py:513
+#: src/opendlp/entrypoints/forms.py:113 src/opendlp/entrypoints/forms.py:515
 #: templates/admin/invite_view.html:22
 msgid "Invite Code"
 msgstr "Meghívó kód"
 
-#: src/opendlp/entrypoints/forms.py:113 src/opendlp/entrypoints/forms.py:515
+#: src/opendlp/entrypoints/forms.py:115 src/opendlp/entrypoints/forms.py:517
 #, fuzzy
 msgid "Enter your invitation code to register"
 msgstr "Add meg a meghívókódodat a regisztrációhoz"
 
-#: src/opendlp/entrypoints/forms.py:117 src/opendlp/entrypoints/forms.py:381
-#: src/opendlp/entrypoints/forms.py:459 templates/admin/user_view.html:28
+#: src/opendlp/entrypoints/forms.py:119 src/opendlp/entrypoints/forms.py:383
+#: src/opendlp/entrypoints/forms.py:461 templates/admin/user_view.html:28
 #: templates/profile/view.html:16
 msgid "First Name"
 msgstr "Keresztnév"
 
-#: src/opendlp/entrypoints/forms.py:119
+#: src/opendlp/entrypoints/forms.py:121
 msgid "Optional - your first name"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:124 src/opendlp/entrypoints/forms.py:388
-#: src/opendlp/entrypoints/forms.py:466 templates/admin/user_view.html:38
+#: src/opendlp/entrypoints/forms.py:126 src/opendlp/entrypoints/forms.py:390
+#: src/opendlp/entrypoints/forms.py:468 templates/admin/user_view.html:38
 #: templates/profile/view.html:22
 msgid "Last Name"
 msgstr "Vezetéknév"
 
-#: src/opendlp/entrypoints/forms.py:126
+#: src/opendlp/entrypoints/forms.py:128
 msgid "Optional - your last name"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:141 src/opendlp/entrypoints/forms.py:503
+#: src/opendlp/entrypoints/forms.py:143 src/opendlp/entrypoints/forms.py:505
 #, fuzzy
 msgid "Confirm Password"
 msgstr "Új jelszó"
 
-#: src/opendlp/entrypoints/forms.py:142 src/opendlp/entrypoints/forms.py:198
-#: src/opendlp/entrypoints/forms.py:490 src/opendlp/entrypoints/forms.py:504
+#: src/opendlp/entrypoints/forms.py:144 src/opendlp/entrypoints/forms.py:200
+#: src/opendlp/entrypoints/forms.py:492 src/opendlp/entrypoints/forms.py:506
 #, fuzzy
 msgid "Passwords must match"
 msgstr "Új jelszó"
 
-#: src/opendlp/entrypoints/forms.py:147 src/opendlp/entrypoints/forms.py:519
+#: src/opendlp/entrypoints/forms.py:149 src/opendlp/entrypoints/forms.py:521
 #, fuzzy
 msgid "Accept Data Agreement"
 msgstr "Adatkezelési megállapodás megtekintése"
 
-#: src/opendlp/entrypoints/forms.py:148 src/opendlp/entrypoints/forms.py:520
+#: src/opendlp/entrypoints/forms.py:150 src/opendlp/entrypoints/forms.py:522
 #, fuzzy
 msgid "You must accept the data agreement to register"
 msgstr ""
 "A folytatáshoz kérjük, olvassa el és fogadja el az adatkezelési "
 "megállapodásunkat."
 
-#: src/opendlp/entrypoints/forms.py:149 src/opendlp/entrypoints/forms.py:521
+#: src/opendlp/entrypoints/forms.py:151 src/opendlp/entrypoints/forms.py:523
 #, fuzzy
 msgid "I agree to the data agreement"
 msgstr "Adatkezelési megállapodás megtekintése"
 
-#: src/opendlp/entrypoints/forms.py:160 src/opendlp/entrypoints/forms.py:532
+#: src/opendlp/entrypoints/forms.py:162 src/opendlp/entrypoints/forms.py:534
 msgid "Invalid or expired invite code."
 msgstr "Érvénytelen vagy lejárt meghívó kód."
 
-#: src/opendlp/entrypoints/forms.py:173
+#: src/opendlp/entrypoints/forms.py:175
 #, fuzzy
 msgid "Enter your email address to receive a password reset link"
 msgstr "Add meg az e-mail címed, hogy megkapd a jelszó-visszaállító linket"
 
-#: src/opendlp/entrypoints/forms.py:184
+#: src/opendlp/entrypoints/forms.py:186
 #, fuzzy
 msgid "Enter your email address and we will send you a new confirmation link"
 msgstr "Add meg az e-mail címed, hogy megkapd a jelszó-visszaállító linket"
 
-#: src/opendlp/entrypoints/forms.py:193 src/opendlp/entrypoints/forms.py:483
+#: src/opendlp/entrypoints/forms.py:195 src/opendlp/entrypoints/forms.py:485
 #, fuzzy
 msgid "New Password"
 msgstr "Új jelszó"
 
-#: src/opendlp/entrypoints/forms.py:197 src/opendlp/entrypoints/forms.py:489
+#: src/opendlp/entrypoints/forms.py:199 src/opendlp/entrypoints/forms.py:491
 #, fuzzy
 msgid "Confirm New Password"
 msgstr "Új jelszó"
 
-#: src/opendlp/entrypoints/forms.py:207
+#: src/opendlp/entrypoints/forms.py:209
 #, fuzzy
 msgid "Assembly Title"
 msgstr "Közösségi gyűlés"
 
-#: src/opendlp/entrypoints/forms.py:209
+#: src/opendlp/entrypoints/forms.py:211
 #, fuzzy
 msgid "Enter the title for this assembly"
 msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
 
-#: src/opendlp/entrypoints/forms.py:213
+#: src/opendlp/entrypoints/forms.py:215
 #: templates/backoffice/assembly_details.html:44
 #: templates/main/view_assembly_details.html:6
 msgid "Assembly Question"
 msgstr "A gyűlés fő témája"
 
-#: src/opendlp/entrypoints/forms.py:215
+#: src/opendlp/entrypoints/forms.py:217
 msgid "Optional - the key question this assembly will address"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:220
+#: src/opendlp/entrypoints/forms.py:222
 #: templates/backoffice/assembly_details.html:68
 #: templates/main/view_assembly_details.html:20
 msgid "First Assembly Date"
 msgstr "Első gyűlés időpontja"
 
-#: src/opendlp/entrypoints/forms.py:222
+#: src/opendlp/entrypoints/forms.py:224
 msgid "Optional - when the first assembly meeting will take place"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:226
+#: src/opendlp/entrypoints/forms.py:228
 #: templates/backoffice/assembly_details.html:77
 #: templates/main/view_assembly_details.html:27
 msgid "Number to Select"
 msgstr "Kiválasztandó emberek száma"
 
-#: src/opendlp/entrypoints/forms.py:228
+#: src/opendlp/entrypoints/forms.py:230
 msgid "The number of participants to select for this assembly"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:245
+#: src/opendlp/entrypoints/forms.py:247
 #, fuzzy
 msgid "Google Spreadsheet URL"
 msgstr "Google Táblázat teljes linkje"
 
-#: src/opendlp/entrypoints/forms.py:247
+#: src/opendlp/entrypoints/forms.py:249
 msgid "Full URL of the Google Spreadsheet containing respondent data"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:266
+#: src/opendlp/entrypoints/forms.py:268
 msgid ""
 "You must specify address columns when 'Check Same Address' is enabled. "
 "Please enter column names or disable 'Check Same Address'."
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:277 src/opendlp/entrypoints/forms.py:293
+#: src/opendlp/entrypoints/forms.py:279 src/opendlp/entrypoints/forms.py:295
 #, fuzzy
 msgid "Respondents Tab Name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: src/opendlp/entrypoints/forms.py:279
+#: src/opendlp/entrypoints/forms.py:281
 msgid ""
 "Name of the tab containing respondents data in the Google Spreadsheet - "
 "for initial Selection"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:285 src/opendlp/entrypoints/forms.py:301
+#: src/opendlp/entrypoints/forms.py:287 src/opendlp/entrypoints/forms.py:303
 #, fuzzy
 msgid "Targets Tab Name"
 msgstr "Vezetéknév"
 
-#: src/opendlp/entrypoints/forms.py:287
+#: src/opendlp/entrypoints/forms.py:289
 msgid ""
 "Name of the tab containing categories, category values and targets - for "
 "initial Selection"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:295
+#: src/opendlp/entrypoints/forms.py:297
 msgid ""
 "Name of the tab containing respondents data in the Google Spreadsheet - "
 "for Replacements"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:303
+#: src/opendlp/entrypoints/forms.py:305
 msgid ""
 "Name of the tab containing categories, category values and targets - for "
 "Replacements"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:308
+#: src/opendlp/entrypoints/forms.py:310
 msgid "Already Selected Tab Name"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:310
+#: src/opendlp/entrypoints/forms.py:312
 msgid "Name of the tab containing already selected people (used for Replacements)"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:315 src/opendlp/entrypoints/forms.py:625
+#: src/opendlp/entrypoints/forms.py:317 src/opendlp/entrypoints/forms.py:627
 #: templates/backoffice/assembly_data.html:175
 #: templates/backoffice/assembly_data.html:432
 #: templates/gsheets/components/view_config.html:48
 msgid "Check Same Address"
 msgstr "Címegyezés ellenőrzése"
 
-#: src/opendlp/entrypoints/forms.py:316
+#: src/opendlp/entrypoints/forms.py:318
 msgid "Enable checking for participants with the same address"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:321
+#: src/opendlp/entrypoints/forms.py:323
 #: templates/backoffice/assembly_data.html:181
 #: templates/gsheets/components/view_config.html:54
 msgid "Generate Remaining Tab"
 msgstr "Fennmaradó résztvevők lap generálása"
 
-#: src/opendlp/entrypoints/forms.py:322
+#: src/opendlp/entrypoints/forms.py:324
 msgid "Create a tab with remaining participants after selection"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:327
+#: src/opendlp/entrypoints/forms.py:329
 #: templates/backoffice/assembly_data.html:191
 #, fuzzy
 msgid "Team Configuration"
 msgstr "Google Táblázat beállításainak eltávolítása"
 
-#: src/opendlp/entrypoints/forms.py:329
+#: src/opendlp/entrypoints/forms.py:331
 #: templates/backoffice/assembly_data.html:193
 msgid "UK Team"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:330
+#: src/opendlp/entrypoints/forms.py:332
 #: templates/backoffice/assembly_data.html:194
 msgid "EU Team"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:331
+#: src/opendlp/entrypoints/forms.py:333
 #: templates/backoffice/assembly_data.html:195
 msgid "Australia Team"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:332
+#: src/opendlp/entrypoints/forms.py:334
 #: templates/backoffice/assembly_data.html:196
 #, fuzzy
 msgid "Custom configuration"
 msgstr "Beállítások mentése"
 
-#: src/opendlp/entrypoints/forms.py:337
+#: src/opendlp/entrypoints/forms.py:339
 msgid ""
 "Select the team configuration to use for default settings for ID Column, "
 "Address Columns and Columns To Keep."
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:342 src/opendlp/entrypoints/forms.py:613
+#: src/opendlp/entrypoints/forms.py:344 src/opendlp/entrypoints/forms.py:615
 #: templates/backoffice/assembly_data.html:209
 #: templates/backoffice/assembly_data.html:239
 #: templates/backoffice/assembly_data.html:397
@@ -498,130 +497,130 @@ msgstr ""
 msgid "ID Column"
 msgstr "ID (azonosító) oszlop"
 
-#: src/opendlp/entrypoints/forms.py:346
+#: src/opendlp/entrypoints/forms.py:348
 msgid ""
 "Name of column containing unique identifiers for respondents. Note will "
 "be overridden if the Team Configuration is not 'Custom'."
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:351
+#: src/opendlp/entrypoints/forms.py:353
 #: templates/backoffice/assembly_data.html:217
 #: templates/backoffice/assembly_data.html:245
 #: templates/gsheets/components/view_config.html:66
 msgid "Address Columns"
 msgstr "Cím oszlopok"
 
-#: src/opendlp/entrypoints/forms.py:354
+#: src/opendlp/entrypoints/forms.py:356
 msgid ""
 "Comma-separated list of column names used for checking same address "
 "(e.g., primary_address1, zip_royal_mail). Note will be overridden if the "
 "Team Configuration is not 'Custom'."
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:360
+#: src/opendlp/entrypoints/forms.py:362
 #: templates/backoffice/assembly_data.html:225
 #: templates/backoffice/assembly_data.html:251
 #: templates/gsheets/components/view_config.html:72
 msgid "Columns to Keep"
 msgstr "Megtartandó oszlopok"
 
-#: src/opendlp/entrypoints/forms.py:363
+#: src/opendlp/entrypoints/forms.py:365
 msgid ""
 "Comma-separated list of column names to keep in output (e.g., first_name,"
 " last_name, email). Note will be overridden if the Team Configuration is "
 "not 'Custom'."
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:383
+#: src/opendlp/entrypoints/forms.py:385
 #, fuzzy
 msgid "User's first name"
 msgstr "Keresztnév"
 
-#: src/opendlp/entrypoints/forms.py:390
+#: src/opendlp/entrypoints/forms.py:392
 #, fuzzy
 msgid "User's last name"
 msgstr "Vezetéknév"
 
-#: src/opendlp/entrypoints/forms.py:395 templates/admin/user_view.html:48
+#: src/opendlp/entrypoints/forms.py:397 templates/admin/user_view.html:48
 #, fuzzy
 msgid "Global Role"
 msgstr "Szereped/jogosultságod"
 
-#: src/opendlp/entrypoints/forms.py:399
+#: src/opendlp/entrypoints/forms.py:401
 msgid "User's global role determines their permissions across the system"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:403
+#: src/opendlp/entrypoints/forms.py:405
 #, fuzzy
 msgid "Active Account"
 msgstr "Hozzon létre fiókot"
 
-#: src/opendlp/entrypoints/forms.py:404
+#: src/opendlp/entrypoints/forms.py:406
 msgid "Inactive users cannot log in to the system"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:413
+#: src/opendlp/entrypoints/forms.py:415
 msgid "Role for New User"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:417
+#: src/opendlp/entrypoints/forms.py:419
 msgid "The role that will be granted to the user who uses this invite"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:422
+#: src/opendlp/entrypoints/forms.py:424
 #, fuzzy
 msgid "Email Address (Optional)"
 msgstr "Email cím"
 
-#: src/opendlp/entrypoints/forms.py:424
+#: src/opendlp/entrypoints/forms.py:426
 msgid "Optional - if provided, the invite will be emailed to this address"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:429
+#: src/opendlp/entrypoints/forms.py:431
 msgid "Expires In (Hours)"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:431
+#: src/opendlp/entrypoints/forms.py:433
 msgid ""
 "Optional - number of hours until the invite expires (default: 168 hours /"
 " 7 days)"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:440
+#: src/opendlp/entrypoints/forms.py:442
 #, fuzzy
 msgid "User Email"
 msgstr "Hiba részletei"
 
-#: src/opendlp/entrypoints/forms.py:442
+#: src/opendlp/entrypoints/forms.py:444
 #, fuzzy
 msgid "Select a user to add to this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/forms.py:446
+#: src/opendlp/entrypoints/forms.py:448
 #, fuzzy
 msgid "Assembly Role"
 msgstr "Közösségi gyűlés"
 
-#: src/opendlp/entrypoints/forms.py:450
+#: src/opendlp/entrypoints/forms.py:452
 msgid "Select the role this user will have on the assembly"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:461
+#: src/opendlp/entrypoints/forms.py:463
 #, fuzzy
 msgid "Your first name"
 msgstr "Keresztnév"
 
-#: src/opendlp/entrypoints/forms.py:468
+#: src/opendlp/entrypoints/forms.py:470
 #, fuzzy
 msgid "Your last name"
 msgstr "Vezetéknév"
 
-#: src/opendlp/entrypoints/forms.py:477
+#: src/opendlp/entrypoints/forms.py:479
 #, fuzzy
 msgid "Current Password"
 msgstr "Új jelszó"
 
-#: src/opendlp/entrypoints/forms.py:543 src/opendlp/entrypoints/forms.py:595
+#: src/opendlp/entrypoints/forms.py:545 src/opendlp/entrypoints/forms.py:597
 #: templates/backoffice/assembly_data.html:339
 #: templates/backoffice/assembly_data.html:391
 #: templates/backoffice/assembly_targets.html:193
@@ -629,28 +628,28 @@ msgstr "Új jelszó"
 msgid "CSV File"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:545 src/opendlp/entrypoints/forms.py:597
+#: src/opendlp/entrypoints/forms.py:547 src/opendlp/entrypoints/forms.py:599
 msgid "Please select a CSV file to upload"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:546 src/opendlp/entrypoints/forms.py:598
+#: src/opendlp/entrypoints/forms.py:548 src/opendlp/entrypoints/forms.py:600
 msgid "Only CSV files are allowed"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:548
+#: src/opendlp/entrypoints/forms.py:550
 msgid "Select a CSV file containing target categories"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:556 src/opendlp/entrypoints/forms.py:566
+#: src/opendlp/entrypoints/forms.py:558 src/opendlp/entrypoints/forms.py:568
 #, fuzzy
 msgid "Category Name"
 msgstr "Kategóriákat tartalmazó lapful neve"
 
-#: src/opendlp/entrypoints/forms.py:558
+#: src/opendlp/entrypoints/forms.py:560
 msgid "e.g. Gender, Age, Ethnicity"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:575
+#: src/opendlp/entrypoints/forms.py:577
 #: templates/backoffice/targets/category_block.html:96
 #: templates/targets/components/category_block.html:69
 #: templates/targets/components/category_block.html:136
@@ -658,11 +657,11 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:577
+#: src/opendlp/entrypoints/forms.py:579
 msgid "e.g. Male, Female, 16-29"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:581
+#: src/opendlp/entrypoints/forms.py:583
 #: src/opendlp/service_layer/selection_report.py:220
 #: templates/backoffice/targets/category_block.html:98
 #: templates/targets/components/category_block.html:70
@@ -671,7 +670,7 @@ msgstr ""
 msgid "Min"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:586
+#: src/opendlp/entrypoints/forms.py:588
 #: src/opendlp/service_layer/selection_report.py:221
 #: templates/backoffice/targets/category_block.html:100
 #: templates/targets/components/category_block.html:71
@@ -680,58 +679,58 @@ msgstr ""
 msgid "Max"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:600
+#: src/opendlp/entrypoints/forms.py:602
 msgid "Select a CSV file containing respondent data"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:604
+#: src/opendlp/entrypoints/forms.py:606
 msgid "Replace all existing respondents"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:606
+#: src/opendlp/entrypoints/forms.py:608
 msgid ""
 "Warning: this will delete all existing respondents for this assembly "
 "before importing. Uncheck to add to existing respondents."
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:616
+#: src/opendlp/entrypoints/forms.py:618
 #: templates/backoffice/assembly_data.html:400
 msgid ""
 "Name of column containing unique identifiers. If blank, the first column "
 "in the CSV will be used."
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:627
+#: src/opendlp/entrypoints/forms.py:629
 msgid "Prevent selecting multiple participants from the same address"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:631
+#: src/opendlp/entrypoints/forms.py:633
 #: templates/backoffice/assembly_data.html:461
 #, fuzzy
 msgid "Address Attributes"
 msgstr "Cím oszlopok"
 
-#: src/opendlp/entrypoints/forms.py:633
+#: src/opendlp/entrypoints/forms.py:635
 msgid "Comma-separated respondent attribute names used for address matching"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:637
+#: src/opendlp/entrypoints/forms.py:639
 #: templates/backoffice/assembly_data.html:470
 #, fuzzy
 msgid "Attributes to Keep"
 msgstr "Megtartandó oszlopok"
 
-#: src/opendlp/entrypoints/forms.py:639
+#: src/opendlp/entrypoints/forms.py:641
 msgid "Comma-separated respondent attribute names to include in CSV output"
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:658
+#: src/opendlp/entrypoints/forms.py:660
 msgid ""
 "You must specify address attributes when 'Check Same Address' is enabled."
 " Please enter attribute names or disable 'Check Same Address'."
 msgstr ""
 
-#: src/opendlp/entrypoints/forms.py:675 src/opendlp/entrypoints/forms.py:684
+#: src/opendlp/entrypoints/forms.py:677 src/opendlp/entrypoints/forms.py:686
 #, python-format
 msgid "Unrecognised attribute names: %(names)s"
 msgstr ""
@@ -3186,25 +3185,35 @@ msgid "Important"
 msgstr "Fontos"
 
 #: templates/backoffice/components/footer.html:16 templates/base.html:176
+#: templates/base_public.html:40
 msgid "User Data Agreement"
 msgstr "Felhasználói Adatkezelési Megállapodás"
 
-#: templates/base.html:181
+#: templates/backoffice/components/footer.html:19 templates/base.html:181
+#: templates/base_public.html:45
+msgid "Cookies"
+msgstr ""
+
+#: templates/base.html:186
 #, fuzzy
 msgid "New Dashboard"
 msgstr "Irányító pult"
 
-#: templates/base.html:185
+#: templates/base.html:190
 msgid "OpenDLP Version"
 msgstr ""
 
-#: templates/backoffice/components/footer.html:30 templates/base.html:190
+#: templates/backoffice/components/footer.html:33 templates/base.html:195
 msgid ""
 "OpenDLP is an open source platform for Democratic Lottery and Citizens' "
 "Assembly management."
 msgstr ""
 "Az OpenDLPegy nyílt forráskódú platform közösségi gyűlések szervezésére "
 "és a résztvevők véletlenszerű kiválasztására."
+
+#: templates/base_public.html:35
+msgid "Support links"
+msgstr ""
 
 #: templates/admin/index.html:2 templates/admin/index.html:4
 #, fuzzy
@@ -6046,12 +6055,12 @@ msgstr "Kiválasztandó emberek száma"
 msgid "Enter a positive number"
 msgstr ""
 
-#: templates/backoffice/components/footer.html:20
+#: templates/backoffice/components/footer.html:23
 #, fuzzy
 msgid "Old Dashboard"
 msgstr "Irányító pult"
 
-#: templates/backoffice/components/footer.html:24
+#: templates/backoffice/components/footer.html:27
 msgid "Version"
 msgstr ""
 
@@ -13116,3 +13125,4 @@ msgstr ""
 
 #~ msgid "Filter"
 #~ msgstr "Állapot"
+


### PR DESCRIPTION
Bits and pieces to be inline with cookie-related laws.

- cookie URL config
- links to cookie URL in all footers
- docs updates to help keep us inline with our policies, assumptions etc
- NO cookie banner or optional cookie reject pop up - we don't believe it is required.