### PR TITLE
Allow YouTube embeds in registration pages via CSP frame-src (#769)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -5,7 +5,7 @@
 .mypy_cache
 .coverage
 __pycache__/
-assets/node_modules/
+node_modules/
 public/
 
 .coverage

--- a/backend/docs/frontend_security.md
+++ b/backend/docs/frontend_security.md
@@ -220,6 +220,11 @@ Widening the CSP allowlist is how a third-party script gets waved through. A thi
 sets a cookie, or that reads the device, would oblige us to build a consent banner we do not
 have. Read [docs/personal-data.md](personal-data.md) before adding a host to the allowlist.
 
+The one sanctioned embed host is `https://www.youtube-nocookie.com` in `frame-src`, so
+organisers can embed YouTube videos in registration pages using YouTube's
+"privacy-enhanced mode" embed code. Plain `www.youtube.com` embeds are deliberately blocked —
+see [Personal Data](personal-data.md#third-party-embeds-the-youtube-exception).
+
 ## Testing CSP Compliance
 
 1. Load page in browser with DevTools open

--- a/backend/docs/personal-data.md
+++ b/backend/docs/personal-data.md
@@ -157,13 +157,35 @@ When adding a table that holds personal data, add a corresponding `DELETE` to
 `_delete_all_test_data()` in `tests/conftest.py` and to `delete_all_except_standard_users()` in
 `tests/bdd/conftest.py`, respecting foreign-key ordering.
 
+## Third-party embeds: the YouTube exception
+
+There is exactly **one** sanctioned third-party embed: YouTube videos in assembly
+registration pages, via the **privacy-enhanced domain only** (`www.youtube-nocookie.com`),
+allowed through the CSP `frame-src` directive (issue #769).
+
+The reasoning:
+
+- In privacy-enhanced mode YouTube sets **no cookies until the visitor plays the video**.
+  Merely viewing a registration page containing an embed stores nothing on the device, so
+  the no-consent-banner position holds for visitors who do not press play.
+- Pressing play is a deliberate act requesting content from YouTube; the visitor's IP
+  reaches Google at that point, as it would if they followed a link.
+- Plain `www.youtube.com` embeds set tracking cookies on page load and are **deliberately
+  not allowed** — organisers must use YouTube's "privacy-enhanced mode" embed code, and the
+  CSP blocks anything else. A test (`test_csp_allows_youtube_nocookie_frames_only`) pins
+  this.
+
+Widening this to plain YouTube, or adding any other embed host, reopens the consent-banner
+question below.
+
 ## What would change the answer
 
 **If you are about to do any of the following, this document is now wrong, and you must revisit
 [issue #656](agent/656-cookies/research.md) before shipping.**
 
 - Adding **any analytics**, or any third-party script or embed — including a font, a map, a
-  video player, or an error reporter such as Sentry.
+  video player, or an error reporter such as Sentry. The single existing exception is
+  documented in [Third-party embeds: the YouTube exception](#third-party-embeds-the-youtube-exception).
 - Adding **any new cookie**, or any use of `localStorage`, `sessionStorage` or `document.cookie`.
 - Making an existing cookie **persistent**, or lengthening its lifetime.
 - Using an existing cookie for a **new purpose**. Every purpose must independently qualify for

--- a/backend/src/opendlp/entrypoints/flask_app.py
+++ b/backend/src/opendlp/entrypoints/flask_app.py
@@ -218,6 +218,9 @@ def get_secure_headers(config: Config) -> Secure:
         .style_src("'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net", "https://fonts.googleapis.com")
         .font_src("'self'", "https://cdn.jsdelivr.net", "https://fonts.gstatic.com")
         .img_src("'self'", "data:")
+        # Only YouTube's privacy-enhanced domain: it sets no cookies until playback,
+        # which keeps us within the no-consent-banner position in docs/personal-data.md.
+        .frame_src("'self'", "https://www.youtube-nocookie.com")
         .frame_ancestors("'none'")
         .form_action("'self'", "https://accounts.google.com", "https://login.microsoftonline.com")
         .base_uri("'self'")

--- a/backend/tests/unit/test_flask_app.py
+++ b/backend/tests/unit/test_flask_app.py
@@ -105,6 +105,16 @@ class TestFlaskApp:
             assert response.headers["X-Content-Type-Options"] == "nosniff"
             assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
 
+    def test_csp_allows_youtube_nocookie_frames_only(self) -> None:
+        """The CSP must allow YouTube privacy-enhanced embeds but not plain youtube.com."""
+        app = create_app("testing")
+
+        with app.test_client() as client:
+            response = client.get("/")
+            csp = response.headers["Content-Security-Policy"]
+            assert "frame-src 'self' https://www.youtube-nocookie.com" in csp
+            assert "https://www.youtube.com" not in csp
+
 
 class TestMainBlueprint:
     """Test main blueprint routes."""


### PR DESCRIPTION
## Summary

Ticket 769: organisers could not embed YouTube videos in registration page HTML. The iframe reached the browser intact but was blocked by the Content Security Policy — with no `frame-src` directive set, browsers fall back to `default-src 'self'`:

> Framing 'https://www.youtube.com/' violates the following Content Security Policy directive: "default-src 'self'".

This PR adds a `frame-src` directive allowing **only YouTube's privacy-enhanced domain** (`www.youtube-nocookie.com`), plus `'self'` to preserve the previous fallback behaviour for same-origin frames.

## Why privacy-enhanced mode only

Third-party embeds are on the "needs a decision, not a commit" list in `docs/personal-data.md` — the no-cookie-banner position depends on nothing setting cookies on visitors' devices.

- **`www.youtube-nocookie.com`** sets no cookies until the visitor deliberately presses play, so merely viewing a registration page stores nothing on the device and the no-consent-banner position holds.
- **`www.youtube.com`** embeds set tracking cookies on page load, which would require prior opt-in consent under EU ePrivacy — so they remain deliberately blocked, and a test pins this.

**Consequence for organisers:** embed codes must use privacy-enhanced mode — in YouTube's Share → Embed dialog, tick "Enable privacy-enhanced mode" to get a `https://www.youtube-nocookie.com/embed/...` URL. A standard `youtube.com` embed will still be blocked by the CSP.

## Changes

- **`src/opendlp/entrypoints/flask_app.py`** — add `.frame_src("'self'", "https://www.youtube-nocookie.com")` to the CSP built in `get_secure_headers()`.
- **`tests/unit/test_flask_app.py`** — new `test_csp_allows_youtube_nocookie_frames_only` asserting the nocookie domain is allowed and plain `www.youtube.com` is not.
- **`docs/personal-data.md`** — new "Third-party embeds: the YouTube exception" section recording the decision and its reasoning, referenced from the "What would change the answer" list.
- **`docs/frontend_security.md`** — note the one sanctioned `frame-src` host in the CSP allowlist guidance.
- **`backend/.dockerignore`** — ride-along deploy fix: the entry still pointed at the pre-restructure `assets/node_modules/` path, so `COPY . /src` clobbered the image's Linux `node_modules` with the host's macOS one and `npm run build` failed on the native esbuild binary ("Exec format error"). Now excludes `node_modules/`.

## Testing

- `uv run pytest tests/unit` — 1820 passed; `uv run mypy` — clean; lint hooks pass.
- Docker `build` stage built successfully after the `.dockerignore` fix (previously failed at the esbuild step).
- Deployed successfully to the gg preview server with `just deploy-preview-gg` (which also exercises the `.dockerignore` fix end-to-end).

## Possible follow-ups (not in this PR)

- Organiser-facing help text in the registration page editor about privacy-enhanced embed codes, since a standard `youtube.com` embed fails with no visible error outside the browser console.
- Optionally auto-rewrite pasted `youtube.com/embed/...` URLs to `youtube-nocookie.com` on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
