### PR TITLE
Registration wizard: explicit edit mode, sticky footer, and discard guard

### DIFF
--- a/backend/docs/agent/800-email-fixes/code-review-findings.md
+++ b/backend/docs/agent/800-email-fixes/code-review-findings.md
@@ -21,9 +21,9 @@ Ranked by severity; items 1–3 share one root cause and one fix design.
 - [x] 2. Save now ignores the posted `template_id` entirely and operates only on the page's assigned template — the cross-assembly overwrite path no longer exists
 - [x] 3. Self-heal re-assignment and the `templates[0]` fallback removed from the save path
 - [x] 4. `_dispatch_email_action` rejects unknown/legacy actions (`enable`/`disable`) with a warning flash and no changes
-- [ ] 5. Emit `aria-selected` on the active tab in the stepper's disabled span branch
-- [ ] 6. Neutralise link navigation inside the form preview iframe (block anchor clicks like submits, or `sandbox` the iframe)
-- [ ] 7. Fix the unterminated toast `<div>` in `patterns.html`
+- [x] 5. The stepper's disabled span branch now emits `aria-selected` in tabs mode (regression test in `test_stepper_macro.py`)
+- [x] 6. The preview iframe now blocks anchor clicks in the capture phase, mirroring the submit blocker
+- [x] 7. The unterminated toast `<div>` in `patterns.html` is closed (the two sibling toasts were already correct)
 - [x] 8. `preview_registration_form`'s catch-all now uses `logger.exception`
 - [x] 9. Shared `_create_and_assign_default_template` helper extracted (create action + page seeding both use it)
 - [x] 10. `preview_registration_form` (and the email dispatch) now use `get_registration_page`, dropping the discarded HTML-source reads

--- a/backend/docs/agent/800-email-fixes/code-review-findings.md
+++ b/backend/docs/agent/800-email-fixes/code-review-findings.md
@@ -1,0 +1,130 @@
+# Code Review Findings — branch `800-email-fixes`
+
+- **Date:** 2026-07-28
+- **Diff reviewed:** `git diff main...HEAD` (24 changed files), after the branch was rebased onto `main` (post PR #213 / 768 PDF uploads)
+- **Method:** high-effort multi-agent review — 4 finder angles (3 correctness + 1 cleanup) produced 23 candidates; every distinct location was independently verified (22 confirmed, 1 refuted); duplicates merged into 15 distinct defects; the top 10 were reported.
+
+## Executive summary
+
+The most serious cluster comes from the branch's **"auto-reply is always on" product change shipping without a migration for legacy pages**. Three findings (1, 2, 3) share that root cause and should be resolved together, starting with a product decision:
+
+> **Product decision (2026-07-28):** the enable/disable toggle never shipped to production, so no deliberate OFF choice exists to honor. Auto-reply is unconditionally always-on: an irreversible data migration (`3d7f07de5b72`) backfills the template assignment for any page left unassigned, the dummy checked+disabled checkbox stays, and all remaining toggle-era functionality (self-heal, `templates[0]` fallback, posted `template_id` handling) is removed. Legacy `enable`/`disable` actions are rejected outright.
+
+The remaining confirmed issues are more contained: legacy toggle POSTs falling into the save handler, an ARIA regression on the disabled stepper, preview-iframe links navigating into frame-blocked pages, and an unterminated `<div>` on the dev patterns page.
+
+## Todo checklist
+
+Ranked by severity; items 1–3 share one root cause and one fix design.
+
+- [x] **0. Decide the legacy auto-reply migration strategy** — decided: always-on, backfill migration, no OFF state to honor (toggle never reached production)
+- [x] 1. Backfill migration `3d7f07de5b72` assigns each assembly's oldest template to its unassigned page, making the always-checked checkbox truthful
+- [x] 2. Save now ignores the posted `template_id` entirely and operates only on the page's assigned template — the cross-assembly overwrite path no longer exists
+- [x] 3. Self-heal re-assignment and the `templates[0]` fallback removed from the save path
+- [x] 4. `_dispatch_email_action` rejects unknown/legacy actions (`enable`/`disable`) with a warning flash and no changes
+- [ ] 5. Emit `aria-selected` on the active tab in the stepper's disabled span branch
+- [ ] 6. Neutralise link navigation inside the form preview iframe (block anchor clicks like submits, or `sandbox` the iframe)
+- [ ] 7. Fix the unterminated toast `<div>` in `patterns.html`
+- [x] 8. `preview_registration_form`'s catch-all now uses `logger.exception`
+- [x] 9. Shared `_create_and_assign_default_template` helper extracted (create action + page seeding both use it)
+- [x] 10. `preview_registration_form` (and the email dispatch) now use `get_registration_page`, dropping the discarded HTML-source reads
+- [ ] (Optional) lower-priority cleanups — see "Not reported" section
+
+---
+
+## Confirmed findings (reported top 10)
+
+### 1. Auto-reply checkbox lies for legacy pages (correctness, CONFIRMED)
+
+**Where:** `templates/backoffice/assembly_registration.html:391`
+
+The email step renders the "Send auto-reply email" checkbox as unconditionally `checked=true, disabled=true` ("always sent in the current version of the product"), even for legacy pages whose template was never assigned (`auto_reply_email_template_id is None`). But `email_send_service.py:96` skips sending exactly in that state, and the branch ships no migration to assign legacy templates.
+
+**Failure scenario:** A pre-deploy assembly whose organiser left the old auto-reply switch OFF (template seeded but unassigned — a state `_load_auto_reply_context`'s fallback explicitly supports) upgrades to this release. The organiser sees the checkbox checked and locked and believes auto-reply is on; real respondents register on the published form and receive nothing. The only self-heal path is someone happening to press Save.
+
+**Fix direction:** either an Alembic data migration backfilling `auto_reply_email_template_id` for pages with exactly one seeded template (making "always on" true), or render the checkbox state from the actual assignment.
+
+### 2. Cross-assembly template overwrite before ownership check (correctness, CONFIRMED)
+
+**Where:** `src/opendlp/entrypoints/blueprints/backoffice_registration.py:451` (`_handle_email_action_save`)
+
+`update_email_template` (which commits) runs on the form-posted `template_id` **before** `assign_auto_reply_template` validates that the template belongs to this assembly.
+
+**Failure scenario:** A user managing assemblies A and B posts the email-save form for assembly A with `template_id` set to B's template (stale tab or edited hidden field). `update_email_template`'s permission check passes (they manage B), B's live subject/body are overwritten and committed with A's content, then `assign_auto_reply_template` raises `EmailTemplateNotFoundError`. The user sees "The auto-reply email could not be found" while assembly B now sends A's email text to its registrants.
+
+**Fix direction:** verify the template's assembly membership (or fetch it scoped to `assembly_id`) before calling `update_email_template`; or make update+assign one transactional service operation.
+
+### 3. Save silently re-enables a deliberately disabled auto-reply (correctness, CONFIRMED)
+
+**Where:** `src/opendlp/entrypoints/blueprints/backoffice_registration.py:461` (self-heal in `_handle_email_action_save`, plus the `templates[0]` fallback in `_dispatch_email_action:489-495`)
+
+The "self-heal" re-assigns an unassigned template on any Save. For legacy pages where the organiser used the old switch to deliberately turn auto-reply OFF, editing the wording and pressing Save re-enables outbound email to the public without warning.
+
+**Fix direction:** depends on the item-0 decision. If backfilling, the self-heal becomes unnecessary; if honoring OFF, the self-heal must go or become an explicit user action.
+
+### 4. Legacy enable/disable POSTs fall through to save (correctness, CONFIRMED)
+
+**Where:** `src/opendlp/entrypoints/blueprints/backoffice_registration.py:494-496` (`_dispatch_email_action`)
+
+Dispatch is `if action == "create": ... else save`. The removed `enable`/`disable` actions from a stale pre-deploy tab (which post only csrf/action/template_id) are treated as saves with empty subject/body. Only the domain validation in `_validate()` prevents the template being blanked; the user instead gets baffling flashes ("The email template needs a subject" / "The email template body is empty") for what used to be a toggle.
+
+**Fix direction:** whitelist known actions and redirect unknown ones back to the email step with a neutral flash (or 400).
+
+### 5. Disabled stepper drops `aria-selected` (correctness / accessibility, CONFIRMED)
+
+**Where:** `templates/backoffice/components/stepper.html:87-92` (disabled span branch); reachable in tabs mode since line 71 became `disabled or (item.disabled and is_wizard)`; caller `assembly_registration.html:80-82` passes `disabled=edit_mode`
+
+In edit mode the whole tablist renders as disabled spans without `aria-selected`, so no tab is marked selected while the visible panel's `aria-labelledby` still points at the active one. Screen-reader users cannot tell which step the visible tabpanel belongs to — a regression against the tabs ARIA pattern required by `docs/agent/component_accessibility.md`.
+
+**Fix direction:** emit `aria-selected="true"` (and probably keep `tabindex="-1"`) on the active item in the span branch, mirroring the anchor branch at line 116.
+
+### 6. Preview iframe links navigate into frame-blocked pages (correctness, CONFIRMED)
+
+**Where:** `templates/register/form_preview.html:12-14`; embedding iframe at `assembly_registration.html:545-548` (no `sandbox` attribute)
+
+The preview only neutralises `submit` events. Anchor clicks (author-HTML links, or `base_public.html` footer links like "Cookies") navigate the iframe to pages outside `SAME_ORIGIN_FRAMEABLE_ENDPOINTS`, whose `X-Frame-Options`/`frame-ancestors 'none'` (or external sites' own anti-framing headers) blank the frame. The preview looks broken until the whole backoffice page is reloaded.
+
+**Fix direction:** capture-phase click handler that prevents default on anchors (matching the submit treatment), and/or open links in a new tab, and/or add a `sandbox` attribute to the iframe.
+
+### 7. Unterminated toast `<div>` blanks toast text on dev patterns page (correctness, CONFIRMED)
+
+**Where:** `templates/backoffice/patterns.html:105-109`
+
+Line 107 ends the `:style` attribute with no closing `>` for the div opened on line 105, so `<span x-text="toast.message">` is parsed as attributes of the div; the message element never exists in the DOM. Triggering any AJAX demo on `/backoffice/dev/patterns` shows an empty colored pill — the very element this branch restyled to top-center. Dev-only page, but it's the documented reference for CSP-compatible Alpine patterns.
+
+**Fix direction:** add the missing `>`.
+
+### 8. `logger.error` instead of `logger.exception` in catch-all (cleanup, CONFIRMED)
+
+**Where:** `src/opendlp/entrypoints/blueprints/backoffice_registration.py:663-664` (`preview_registration_form`)
+
+`except Exception as e: logger.error(..., error=str(e))` violates the permanent rule in `docs/agent/code_quality_rules.md` ("Use `logger.exception` in catch-all handlers"); the same file's other new catch-all handlers (e.g. line 570) follow it. Without the traceback the operator cannot locate a production preview failure, and `str(e)` may quote author-supplied form HTML, which can carry PII.
+
+### 9. Duplicated create-and-assign template sequence (cleanup, CONFIRMED)
+
+**Where:** `backoffice_registration.py:424-433` (`_handle_email_action_create`) vs `:558-567` (`_create_default_auto_reply_template`)
+
+Both contain the identical `_default_email_template_content()` → `create_email_template(...)` → `assign_auto_reply_template(...)` sequence; the diff added the assign call to the seeding helper, making them identical except for flash/error handling. The "a created template is an assigned template" invariant is enforced in two hand-synchronized places — a future change applied to one but not the other re-creates the unassigned-template legacy state this branch adds self-healing for.
+
+**Fix direction:** extract a shared `_create_and_assign_default_template` helper.
+
+### 10. Redundant HTML-source DB read on the preview route (cleanup, CONFIRMED)
+
+**Where:** `backoffice_registration.py:642` (`preview_registration_form`)
+
+`get_registration_page_with_source` is called but only `result[0]` is used; `render_registration_form` re-loads the same HTML source internally via `_load_html_source`. Every load of the preview step reads the full HTML source (potentially tens of KB) twice and throws one copy away. The lighter permission-checked `get_registration_page` (`registration_page_service.py:217`) exists for exactly this need.
+
+---
+
+## Confirmed but not reported (lower-severity cleanups, 5 merged-out items)
+
+Verified as real but ranked below the reporting cut. Worth folding into future cleanup passes:
+
+- **Hand-rolled confirm dialogs** — `assembly_registration.html:977-1013` (close-registration) and `:1018-1051` (discard-changes) duplicate each other's backdrop/positioner/panel markup and re-implement the existing `alert_dialog` macro in `templates/backoffice/components/modal.html:36`.
+- **Four hand-copied sticky wizard footers** — identical `<div class="wizard-footer"> / <div class="wizard-footer-box">` wrappers at `assembly_registration.html:294, 353, 502, 626`, with the edit-mode hint string byte-identical in two of them; a macro would remove the copies.
+- **Toast markup triplicated** — the positioning class string `fixed top-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg shadow-lg` plus near-identical type-conditional `:style` bindings appear in `assembly_registration.html:1062`, `patterns.html:106`, and `service_docs.html:101`.
+- **Unscoped `body { overflow-x: clip }`** — `static/backoffice/src/main.css:1101-1103`, added outside any `@layer` solely to absorb the stuck wizard footer's `100vw` breakout (`margin-inline: calc(50% - 50vw)` at line 1085). Global side effect for a component-local problem (verdict: PLAUSIBLE).
+- One further duplication/efficiency item merged into finding 9's root cause.
+
+## Refuted (for the record)
+
+- **CSP string surgery in `flask_app.py:292-295`** — the same-origin-frameable relaxation does `.replace("frame-ancestors 'none'", "frame-ancestors 'self'")` on the serialized header. The verifier confirmed the mechanism is fragile-looking but refuted the claimed failure: the byte form is produced by this codebase's own `.frame_ancestors("'none'")` policy two functions up, so the replace cannot silently no-op under current code. Style concern only; no defect.

--- a/backend/features/backoffice-registration-editor.feature
+++ b/backend/features/backoffice-registration-editor.feature
@@ -37,6 +37,14 @@ Feature: Backoffice registration HTML editor
     And I click the Cancel button in the editor header
     Then I should be on the read-only registration form view
 
+  Scenario: Entering edit mode preserves the scroll position
+    Given I am logged in as an admin user
+    And there is an assembly called "Scroll Edit Assembly" with a registration page
+    When I visit the read-only registration form view for "Scroll Edit Assembly"
+    And I scroll down the page
+    And I click the Edit button in the editor header
+    Then the editor should be in edit mode with the page still scrolled down
+
   Scenario: Cancelling with unsaved changes asks for confirmation
     Given I am logged in as an admin user
     And there is an assembly called "Guard Assembly" with a registration page

--- a/backend/features/backoffice-registration-editor.feature
+++ b/backend/features/backoffice-registration-editor.feature
@@ -37,6 +37,13 @@ Feature: Backoffice registration HTML editor
     And I click the Cancel button in the editor header
     Then I should be on the read-only registration form view
 
+  Scenario: The preview step embeds a read-only preview of the registration form
+    Given I am logged in as an admin user
+    And there is an assembly called "Form Preview Assembly" with a saved registration form
+    When I visit the registration preview step for "Form Preview Assembly"
+    Then I should see the embedded registration form preview
+    And submitting the embedded preview form does not leave the page
+
   Scenario: Entering edit mode preserves the scroll position
     Given I am logged in as an admin user
     And there is an assembly called "Scroll Edit Assembly" with a registration page

--- a/backend/features/backoffice-registration-editor.feature
+++ b/backend/features/backoffice-registration-editor.feature
@@ -29,6 +29,7 @@ Feature: Backoffice registration HTML editor
     And there is an assembly called "Locked Nav Assembly" with a registration page
     When I visit the registration form editor for "Locked Nav Assembly"
     Then the wizard Next button should be disabled
+    And the stepper navigation should be disabled
 
   Scenario: Cancelling without changes returns straight to the read-only view
     Given I am logged in as an admin user

--- a/backend/features/backoffice-registration-editor.feature
+++ b/backend/features/backoffice-registration-editor.feature
@@ -23,3 +23,30 @@ Feature: Backoffice registration HTML editor
     When I visit the registration form editor for "Skeleton Assembly"
     And I open the form skeleton preview
     Then the form skeleton should be shown in a read-only code editor
+
+  Scenario: Wizard navigation is locked while editing
+    Given I am logged in as an admin user
+    And there is an assembly called "Locked Nav Assembly" with a registration page
+    When I visit the registration form editor for "Locked Nav Assembly"
+    Then the wizard Next button should be disabled
+
+  Scenario: Cancelling without changes returns straight to the read-only view
+    Given I am logged in as an admin user
+    And there is an assembly called "Clean Cancel Assembly" with a registration page
+    When I visit the registration form editor for "Clean Cancel Assembly"
+    And I click the Cancel button in the editor header
+    Then I should be on the read-only registration form view
+
+  Scenario: Cancelling with unsaved changes asks for confirmation
+    Given I am logged in as an admin user
+    And there is an assembly called "Guard Assembly" with a registration page
+    When I visit the registration form editor for "Guard Assembly"
+    And I type "UNSAVED-MARKER-7719" into the HTML content code editor
+    And I click the Cancel button in the editor header
+    Then I should see the discard changes confirmation
+    When I choose to keep editing
+    Then the discard changes confirmation should be closed
+    When I click the Cancel button in the editor header
+    And I choose to discard my changes
+    Then I should be on the read-only registration form view
+    And the saved registration HTML should not contain "UNSAVED-MARKER-7719"

--- a/backend/features/backoffice-registration-editor.feature
+++ b/backend/features/backoffice-registration-editor.feature
@@ -44,6 +44,25 @@ Feature: Backoffice registration HTML editor
     Then I should see the embedded registration form preview
     And submitting the embedded preview form does not leave the page
 
+  Scenario: Unpublishing a published registration returns it to test mode
+    Given I am logged in as an admin user
+    And there is an assembly called "Unpublish Assembly" with a published registration form
+    When I visit the registration preview step for "Unpublish Assembly"
+    And I click the Unpublish button
+    Then the registration should be shown as in test mode
+
+  Scenario: Closing a published registration asks for confirmation
+    Given I am logged in as an admin user
+    And there is an assembly called "Close Guard Assembly" with a published registration form
+    When I visit the registration preview step for "Close Guard Assembly"
+    And I click the Close registration button
+    Then I should see the close registration confirmation
+    When I choose to keep the registration open
+    Then the close registration confirmation should be closed
+    When I click the Close registration button
+    And I confirm closing the registration
+    Then the registration should be shown as closed
+
   Scenario: Entering edit mode preserves the scroll position
     Given I am logged in as an admin user
     And there is an assembly called "Scroll Edit Assembly" with a registration page

--- a/backend/migrations/versions/3d7f07de5b72_backfill_auto_reply_template_assignment_.py
+++ b/backend/migrations/versions/3d7f07de5b72_backfill_auto_reply_template_assignment_.py
@@ -1,0 +1,50 @@
+"""backfill auto reply template assignment always on
+
+Revision ID: 3d7f07de5b72
+Revises: 62e37f3ab7e8
+Create Date: 2026-07-28 11:02:19.650130
+
+The auto-reply is always-on: the enable/disable toggle (which worked by
+clearing registration_pages.auto_reply_email_template_id) has been removed, so
+a page whose assembly has a template must have that template assigned. This
+backfills the assignment for any page left unassigned by the old toggle,
+picking the assembly's oldest template (the seeded default). The toggle never
+shipped to production, so no deliberate "off" choice is being overridden.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3d7f07de5b72"
+down_revision: str | Sequence[str] | None = "62e37f3ab7e8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Assign each assembly's oldest email template to its unassigned registration page."""
+    op.execute(
+        sa.text(
+            """
+            UPDATE registration_pages AS rp
+            SET auto_reply_email_template_id = t.id
+            FROM (
+                SELECT DISTINCT ON (assembly_id) id, assembly_id
+                FROM email_templates
+                ORDER BY assembly_id, created_at
+            ) AS t
+            WHERE rp.auto_reply_email_template_id IS NULL
+              AND t.assembly_id = rp.assembly_id
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Irreversible data migration: the pre-backfill NULLs are not recorded, so
+    there is nothing to restore — and the always-on rule makes the old state
+    invalid anyway."""
+    pass

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -231,7 +231,10 @@ preview = true
 source = ["src", "tests"]
 plugins = ["covdefaults"]
 # The dev blueprint is not even registered in production configs, so we can ignore it.
-omit = ["src/opendlp/entrypoints/blueprints/dev.py"]
+# The BDD suite is omitted because the coverage-measured runs use --ignore tests/bdd
+# (BDD tests run separately, without coverage), so its files would always be
+# reported as 0%-covered dead weight.
+omit = ["src/opendlp/entrypoints/blueprints/dev.py", "tests/bdd/*"]
 sigterm = true
 
 [tool.coverage.report]

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -57,6 +57,7 @@ from opendlp.service_layer.registration_page_service import (
     generate_starter_form_html,
     get_registration_page_with_source,
     publish_registration_page,
+    render_registration_form,
     reopen_registration_page,
     unpublish_registration_page,
     update_registration_page_html,
@@ -610,6 +611,49 @@ def get_registration_skeleton(assembly_id: uuid.UUID) -> ResponseReturnValue:
     except Exception as e:
         logger.error("Generate skeleton error for assembly", assembly_id=str(assembly_id), error=str(e))
         return jsonify({"error": _("An error occurred while generating the form skeleton")}), 500
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/form-preview")
+@login_required
+def preview_registration_form(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Read-only render of the saved registration form, embedded in the preview step.
+
+    Renders the last saved HTML through the same pipeline as the public route, so
+    organisers see exactly what visitors will see without opening the public URL.
+    Submission is neutralised twice over: the empty form action posts back to this
+    GET-only route (405), and the preview template's script blocks submit events so
+    interactions (dropdowns etc.) remain testable without ever leaving the page.
+    The security form elements (CSRF/timing/honeypot) are deliberately omitted —
+    they only exist to protect real submissions. The endpoint is exempted from the
+    global frame-ancestors 'none' policy (see SAME_ORIGIN_FRAMEABLE_ENDPOINTS) so
+    the backoffice can iframe it same-origin.
+    """
+    try:
+        uow = bootstrap.get_flask_uow()
+        result = get_registration_page_with_source(uow, current_user.id, assembly_id)
+        if result is None:
+            abort(404)
+        page = result[0]
+        rendered_form = render_registration_form(
+            uow,
+            page,
+            csrf_form_element="<!-- preview: submission disabled, security fields omitted -->",
+            form_action="",
+        )
+        return render_template(
+            "register/form_preview.html",
+            rendered_form=rendered_form,
+            is_test=page.status == RegistrationPageStatus.TEST,
+        )
+    except HTTPException:
+        raise
+    except InsufficientPermissions:
+        abort(403)
+    except NotFoundError:
+        abort(404)
+    except Exception as e:
+        logger.error("Registration form preview error", assembly_id=str(assembly_id), error=str(e))
+        abort(500)
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/qr-code.png")

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -236,6 +236,18 @@ def _handle_registration_action(action: str, user_id: uuid.UUID, assembly_id: uu
 
 
 _SAVE_ACTIONS = frozenset({"save", "save_and_next"})
+_LIFECYCLE_ACTIONS = frozenset({"publish", "unpublish", "close", "reopen"})
+
+
+def _post_action_section(action: str) -> str:
+    """Where to land after a successful action: save_and_next advances to the email
+    step, lifecycle actions return to the preview step (where their buttons live),
+    and plain save returns to the form step."""
+    if action == "save_and_next":
+        return "email"
+    if action in _LIFECYCLE_ACTIONS:
+        return "preview"
+    return "form"
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/save", methods=["POST"])
@@ -247,18 +259,19 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
       - save            → update HTML; land back in read-only on the form step.
       - save_and_next   → update HTML; advance to the auto-reply email step.
       - publish         → transition TEST → PUBLISHED. No HTML update.
-      - unpublish / close / reopen — deprecated lifecycle transitions kept for
-                          backwards compatibility with older POSTs; the UI no
-                          longer offers them.
+      - unpublish       → transition PUBLISHED → TEST (back to test mode).
+      - close           → transition to CLOSED. Terminal from the UI's point of
+                          view: reopen exists only for backwards compatibility
+                          with older POSTs and is not offered anywhere.
     """
     action = request.form.get("action", "save")
     # On failure of a save action, land back in edit mode of the form step so the
-    # user can fix and retry. Non-save actions (publish/etc) come from the read-only
-    # preview step, so failure just lands them back on the preview step.
+    # user can fix and retry. Lifecycle actions come from the read-only preview
+    # step, so failure just lands them back on the preview step.
     error_kwargs: dict[str, Any] = {"assembly_id": assembly_id, "section": "form"}
     if action in _SAVE_ACTIONS:
         error_kwargs["edit"] = "1"
-    elif action == "publish":
+    elif action in _LIFECYCLE_ACTIONS:
         error_kwargs["section"] = "preview"
     error_redirect_url = url_for("backoffice_registration.view_assembly_registration", **error_kwargs)
     try:
@@ -278,8 +291,7 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
 
         flash_message = _handle_registration_action(action, current_user.id, assembly_id)
         flash(flash_message, "success")
-        # save_and_next advances to the email step; everything else lands back on the form step.
-        next_section = "email" if action == "save_and_next" else "form"
+        next_section = _post_action_section(action)
         return redirect_preserving_scroll(
             url_for(
                 "backoffice_registration.view_assembly_registration",

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -162,9 +162,7 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             active_section = "form"
 
         # Auto-reply email data — the template (if assigned) plus readiness problems.
-        email_template, auto_reply_enabled, email_readiness_problems = _load_auto_reply_context(
-            registration_page, assembly_id
-        )
+        email_template, email_readiness_problems = _load_auto_reply_context(registration_page, assembly_id)
 
         return render_template(
             "backoffice/assembly_registration.html",
@@ -188,7 +186,6 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             edit_mode=edit_mode,
             active_section=active_section,
             email_template=email_template,
-            auto_reply_enabled=auto_reply_enabled,
             email_readiness_problems=email_readiness_problems,
         ), 200
     except InsufficientPermissions as e:
@@ -329,25 +326,23 @@ def save_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
         return redirect_preserving_scroll(error_redirect_url)
 
 
-def _load_auto_reply_context(registration_page: Any, assembly_id: uuid.UUID) -> tuple[Any, bool, list[dict[str, str]]]:
+def _load_auto_reply_context(registration_page: Any, assembly_id: uuid.UUID) -> tuple[Any, list[dict[str, str]]]:
     """Load the auto-reply template and readiness problems for the view route.
 
     Prefers the template currently assigned to the page. When nothing is assigned
-    (either because the switch is off, or the template was auto-created and not
-    yet turned on) falls back to the first template stored for the assembly, so
-    the editor still shows the pre-created copy for the manager to work on.
+    (a legacy state from before the auto-reply became always-on) falls back to the
+    first template stored for the assembly, so the editor still shows the
+    pre-created copy for the manager to work on.
     """
     email_template = None
-    auto_reply_enabled = False
     email_readiness_problems: list[dict[str, str]] = []
     if registration_page is None:
-        return email_template, auto_reply_enabled, email_readiness_problems
+        return email_template, email_readiness_problems
 
     template_id = registration_page.auto_reply_email_template_id
     if template_id is not None:
         try:
             email_template = get_email_template(bootstrap.get_flask_uow(), current_user.id, template_id)
-            auto_reply_enabled = True
         except EmailTemplateNotFoundError:
             logger.debug(
                 "auto_reply_template_load_failed",
@@ -382,7 +377,7 @@ def _load_auto_reply_context(registration_page: Any, assembly_id: uuid.UUID) -> 
 
     problems = auto_reply_readiness_problems(bootstrap.get_flask_uow(), assembly_id)
     email_readiness_problems = [{"severity": p.severity.value, "message": p.message} for p in problems]
-    return email_template, auto_reply_enabled, email_readiness_problems
+    return email_template, email_readiness_problems
 
 
 def _default_email_template_content() -> dict[str, str]:
@@ -428,25 +423,14 @@ def _handle_email_action_create(assembly_id: uuid.UUID) -> str:
     return _email_section_url(assembly_id, edit=True)
 
 
-def _handle_email_action_enable(assembly_id: uuid.UUID, current_template_id: uuid.UUID | None) -> str:
-    if current_template_id is None:
-        flash(_("Please set up the auto-reply email first."), "warning")
-        return _email_section_url(assembly_id)
-    assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, current_template_id)
-    flash(_("Auto-reply enabled. Respondents will now receive this email after registering."), "success")
-    return _email_section_url(assembly_id)
-
-
-def _handle_email_action_disable(assembly_id: uuid.UUID) -> str:
-    assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, None)
-    flash(_("Auto-reply disabled. Respondents will no longer receive this email."), "success")
-    return _email_section_url(assembly_id)
-
-
 def _handle_email_action_save(
-    assembly_id: uuid.UUID, current_template_id: uuid.UUID | None, *, advance: bool = False
+    assembly_id: uuid.UUID,
+    template_id: uuid.UUID | None,
+    *,
+    currently_assigned: uuid.UUID | None,
+    advance: bool = False,
 ) -> str:
-    if current_template_id is None:
+    if template_id is None:
         flash(_("There is no auto-reply email to save yet — set one up first."), "warning")
         return _email_section_url(assembly_id)
     # Name is intentionally not overwritten here — the UI doesn't expose it yet,
@@ -455,10 +439,15 @@ def _handle_email_action_save(
     update_email_template(
         bootstrap.get_flask_uow(),
         current_user.id,
-        current_template_id,
+        template_id,
         subject=request.form.get("template_subject", "").strip(),
         body_html=request.form.get("template_body_html", ""),
     )
+    # The auto-reply is always-on: a template that exists is a template that sends.
+    # Saving self-heals pages from before this rule, whose seeded template could be
+    # left unassigned by the old enable/disable switch.
+    if currently_assigned != template_id:
+        assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, template_id)
     flash(_("Auto-reply email saved."), "success")
     if advance:
         return url_for(
@@ -479,35 +468,42 @@ def _dispatch_email_action(action: str, assembly_id: uuid.UUID) -> str:
     if result is None:
         raise RegistrationPageNotFoundError(f"No registration page for assembly {assembly_id}")
 
-    # For enable/save we prefer the id that came in the form (from the switch or editor form) —
-    # this lets the switch turn on a template that isn't yet assigned. Fall back to what's
-    # currently assigned on the page for enable, and require it for save.
+    # Prefer the id that came in the form, then the page's current assignment, then the
+    # assembly's stored template — the last covers legacy pages whose seeded template
+    # was never assigned by the old enable/disable switch.
     posted_template_id = request.form.get("template_id", "").strip()
     posted_id = uuid.UUID(posted_template_id) if posted_template_id else None
     current_template_id = result[0].auto_reply_email_template_id
+    fallback_id = None
+    if posted_id is None and current_template_id is None:
+        templates = list_email_templates(bootstrap.get_flask_uow(), current_user.id, assembly_id)
+        fallback_id = templates[0].id if templates else None
 
     if action == "create":
         return _handle_email_action_create(assembly_id)
-    if action == "enable":
-        return _handle_email_action_enable(assembly_id, posted_id or current_template_id)
-    if action == "disable":
-        return _handle_email_action_disable(assembly_id)
-    return _handle_email_action_save(assembly_id, posted_id or current_template_id, advance=(action == "save_and_next"))
+    return _handle_email_action_save(
+        assembly_id,
+        posted_id or current_template_id or fallback_id,
+        currently_assigned=current_template_id,
+        advance=(action == "save_and_next"),
+    )
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/email/save", methods=["POST"])
 @login_required
 def save_assembly_registration_email(assembly_id: uuid.UUID) -> ResponseReturnValue:
-    """Create, update, enable or disable the auto-reply email template.
+    """Create or update the auto-reply email template.
 
     Action-based POST endpoint:
 
     - create   → create a template with default copy and assign it as the auto-reply.
                  Lands the user in edit mode so they can immediately customise it.
-    - save     → update name / subject / body_html on the existing template.
-    - enable   → assign the template as the page's auto-reply (switch on).
-    - disable  → unassign the template (switch off). The template row is kept
-                 so re-enabling later is one click.
+    - save     → update subject / body_html on the existing template (and ensure it
+                 is assigned — the auto-reply is always-on once a template exists).
+
+    There is deliberately no enable/disable: the product currently always sends the
+    auto-reply. If a real need to switch it off emerges, that gets a first-class
+    service-layer method — not the old assign/unassign-as-a-toggle trick.
     """
     action = request.form.get("action", "save")
     try:
@@ -543,12 +539,12 @@ def _create_default_auto_reply_template(assembly_id: uuid.UUID) -> None:
     """Best-effort: seed a default auto-reply email template for a new page.
 
     Not fatal — if this fails (validation, race, etc.) we log and let the manager
-    hit the "Set up auto-reply" fallback in the UI. Deliberately leaves the
-    template unassigned so the auto-reply switch defaults to OFF.
+    hit the "Set up auto-reply" fallback in the UI. The template is assigned
+    straight away: the auto-reply is always-on, so a page with a template sends it.
     """
     try:
         defaults = _default_email_template_content()
-        create_email_template(
+        template = create_email_template(
             bootstrap.get_flask_uow(),
             current_user.id,
             assembly_id,
@@ -556,6 +552,7 @@ def _create_default_auto_reply_template(assembly_id: uuid.UUID) -> None:
             subject=defaults["subject"],
             body_html=defaults["body_html"],
         )
+        assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, template.id)
     except Exception as e:
         # Non-fatal: log with traceback per code_quality_rules for catch-all blocks.
         logger.exception(

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -55,6 +55,7 @@ from opendlp.service_layer.registration_page_service import (
     close_registration_page,
     create_registration_page_with_slugs,
     generate_starter_form_html,
+    get_registration_page,
     get_registration_page_with_source,
     publish_registration_page,
     render_registration_form,
@@ -419,8 +420,12 @@ def _email_section_url(assembly_id: uuid.UUID, edit: bool = False) -> str:
     return url_for("backoffice_registration.view_assembly_registration", **kwargs)
 
 
-def _handle_email_action_create(assembly_id: uuid.UUID) -> str:
-    """Create a stub auto-reply template, assign it, and return the redirect URL (edit mode)."""
+def _create_and_assign_default_template(assembly_id: uuid.UUID) -> None:
+    """Create the default auto-reply template and assign it to the assembly's page.
+
+    The auto-reply is always-on: a created template is an assigned template, and
+    this helper is the single place that enforces that invariant.
+    """
     defaults = _default_email_template_content()
     template = create_email_template(
         bootstrap.get_flask_uow(),
@@ -431,6 +436,11 @@ def _handle_email_action_create(assembly_id: uuid.UUID) -> str:
         body_html=defaults["body_html"],
     )
     assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, template.id)
+
+
+def _handle_email_action_create(assembly_id: uuid.UUID) -> str:
+    """Create a stub auto-reply template, assign it, and return the redirect URL (edit mode)."""
+    _create_and_assign_default_template(assembly_id)
     flash(_("Auto-reply email created. Edit it below and click Save."), "success")
     return _email_section_url(assembly_id, edit=True)
 
@@ -439,7 +449,6 @@ def _handle_email_action_save(
     assembly_id: uuid.UUID,
     template_id: uuid.UUID | None,
     *,
-    currently_assigned: uuid.UUID | None,
     advance: bool = False,
 ) -> str:
     if template_id is None:
@@ -455,11 +464,6 @@ def _handle_email_action_save(
         subject=request.form.get("template_subject", "").strip(),
         body_html=request.form.get("template_body_html", ""),
     )
-    # The auto-reply is always-on: a template that exists is a template that sends.
-    # Saving self-heals pages from before this rule, whose seeded template could be
-    # left unassigned by the old enable/disable switch.
-    if currently_assigned != template_id:
-        assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, template_id)
     flash(_("Auto-reply email saved."), "success")
     if advance:
         return url_for(
@@ -476,27 +480,21 @@ def _dispatch_email_action(action: str, assembly_id: uuid.UUID) -> str:
     Raises the service-layer exceptions the caller handles centrally.
     """
     get_assembly_nav_context(bootstrap.get_flask_uow, current_user.id, assembly_id, "")
-    result = get_registration_page_with_source(bootstrap.get_flask_uow(), current_user.id, assembly_id)
-    if result is None:
+    page = get_registration_page(bootstrap.get_flask_uow(), current_user.id, assembly_id)
+    if page is None:
         raise RegistrationPageNotFoundError(f"No registration page for assembly {assembly_id}")
-
-    # Prefer the id that came in the form, then the page's current assignment, then the
-    # assembly's stored template — the last covers legacy pages whose seeded template
-    # was never assigned by the old enable/disable switch.
-    posted_template_id = request.form.get("template_id", "").strip()
-    posted_id = uuid.UUID(posted_template_id) if posted_template_id else None
-    current_template_id = result[0].auto_reply_email_template_id
-    fallback_id = None
-    if posted_id is None and current_template_id is None:
-        templates = list_email_templates(bootstrap.get_flask_uow(), current_user.id, assembly_id)
-        fallback_id = templates[0].id if templates else None
 
     if action == "create":
         return _handle_email_action_create(assembly_id)
+    if action not in ("save", "save_and_next"):
+        flash(_("Unknown action — nothing was changed."), "warning")
+        return _email_section_url(assembly_id)
+    # Save always targets the page's assigned template. The form does not choose a
+    # template, so a posted template_id is deliberately ignored — trusting it would
+    # let a request update a template belonging to a different assembly.
     return _handle_email_action_save(
         assembly_id,
-        posted_id or current_template_id or fallback_id,
-        currently_assigned=current_template_id,
+        page.auto_reply_email_template_id,
         advance=(action == "save_and_next"),
     )
 
@@ -510,8 +508,7 @@ def save_assembly_registration_email(assembly_id: uuid.UUID) -> ResponseReturnVa
 
     - create   → create a template with default copy and assign it as the auto-reply.
                  Lands the user in edit mode so they can immediately customise it.
-    - save     → update subject / body_html on the existing template (and ensure it
-                 is assigned — the auto-reply is always-on once a template exists).
+    - save     → update subject / body_html on the page's assigned template.
 
     There is deliberately no enable/disable: the product currently always sends the
     auto-reply. If a real need to switch it off emerges, that gets a first-class
@@ -555,16 +552,7 @@ def _create_default_auto_reply_template(assembly_id: uuid.UUID) -> None:
     straight away: the auto-reply is always-on, so a page with a template sends it.
     """
     try:
-        defaults = _default_email_template_content()
-        template = create_email_template(
-            bootstrap.get_flask_uow(),
-            current_user.id,
-            assembly_id,
-            name=defaults["name"],
-            subject=defaults["subject"],
-            body_html=defaults["body_html"],
-        )
-        assign_auto_reply_template(bootstrap.get_flask_uow(), current_user.id, assembly_id, template.id)
+        _create_and_assign_default_template(assembly_id)
     except Exception as e:
         # Non-fatal: log with traceback per code_quality_rules for catch-all blocks.
         logger.exception(
@@ -639,10 +627,9 @@ def preview_registration_form(assembly_id: uuid.UUID) -> ResponseReturnValue:
     """
     try:
         uow = bootstrap.get_flask_uow()
-        result = get_registration_page_with_source(uow, current_user.id, assembly_id)
-        if result is None:
+        page = get_registration_page(uow, current_user.id, assembly_id)
+        if page is None:
             abort(404)
-        page = result[0]
         rendered_form = render_registration_form(
             uow,
             page,
@@ -660,8 +647,8 @@ def preview_registration_form(assembly_id: uuid.UUID) -> ResponseReturnValue:
         abort(403)
     except NotFoundError:
         abort(404)
-    except Exception as e:
-        logger.error("Registration form preview error", assembly_id=str(assembly_id), error=str(e))
+    except Exception:
+        logger.exception("Registration form preview error", assembly_id=str(assembly_id))
         abort(500)
 
 

--- a/backend/src/opendlp/entrypoints/blueprints/registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/registration.py
@@ -433,6 +433,12 @@ def registration_closed() -> ResponseReturnValue:
 
 @registration_bp.after_request
 def add_noindex_header(response: Response) -> Response:
-    """Prevent search engines from indexing registration pages."""
-    response.headers["X-Robots-Tag"] = "noindex"
+    """Keep registration pages out of search engines entirely.
+
+    noindex keeps every route in this blueprint (form, thank-you, closed, short-url
+    redirects, images) out of the index regardless of page status; nofollow stops
+    crawlers from following any links out of author-provided form HTML. The public
+    templates carry a matching <meta name="robots"> tag as a second layer.
+    """
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
     return response

--- a/backend/src/opendlp/entrypoints/flask_app.py
+++ b/backend/src/opendlp/entrypoints/flask_app.py
@@ -289,10 +289,10 @@ def register_after_request_handlers(app: Flask) -> None:
         # for the backoffice to embed them (registration form preview).
         if request.endpoint in SAME_ORIGIN_FRAMEABLE_ENDPOINTS:
             response.headers["X-Frame-Options"] = "SAMEORIGIN"
-            if "Content-Security-Policy" in response.headers:
-                response.headers["Content-Security-Policy"] = response.headers["Content-Security-Policy"].replace(
-                    "frame-ancestors 'none'", "frame-ancestors 'self'"
-                )
+            # set_headers() above always emits the CSP, so the header is present.
+            response.headers["Content-Security-Policy"] = response.headers["Content-Security-Policy"].replace(
+                "frame-ancestors 'none'", "frame-ancestors 'self'"
+            )
 
         # Replace nonce placeholder with actual nonce for this request
         nonce = g.get("csp_nonce", "")

--- a/backend/src/opendlp/entrypoints/flask_app.py
+++ b/backend/src/opendlp/entrypoints/flask_app.py
@@ -242,6 +242,11 @@ PUBLIC_IMMUTABLE_ASSET_ENDPOINTS = frozenset({
     "registration.serve_registration_document",
 })
 
+# Endpoints that the backoffice embeds in a same-origin iframe. The global policy is
+# frame-ancestors 'none' / X-Frame-Options DENY; these endpoints relax it to
+# same-origin only — they must never become framable cross-origin.
+SAME_ORIGIN_FRAMEABLE_ENDPOINTS = frozenset({"backoffice_registration.preview_registration_form"})
+
 
 def register_after_request_handlers(app: Flask) -> None:
     """Register after request handlers."""
@@ -279,6 +284,15 @@ def register_after_request_handlers(app: Flask) -> None:
         # carry their content hash in the URL, so they are safe to cache immutably.
         if request.endpoint in PUBLIC_IMMUTABLE_ASSET_ENDPOINTS:
             response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+
+        # Same-origin-framable endpoints relax the global no-framing policy just enough
+        # for the backoffice to embed them (registration form preview).
+        if request.endpoint in SAME_ORIGIN_FRAMEABLE_ENDPOINTS:
+            response.headers["X-Frame-Options"] = "SAMEORIGIN"
+            if "Content-Security-Policy" in response.headers:
+                response.headers["Content-Security-Policy"] = response.headers["Content-Security-Policy"].replace(
+                    "frame-ancestors 'none'", "frame-ancestors 'self'"
+                )
 
         # Replace nonce placeholder with actual nonce for this request
         nonce = g.get("csp_nonce", "")

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -1044,3 +1044,60 @@
         width: 100%;
     }
 }
+
+/* ========================================
+   WIZARD STICKY FOOTER
+   ======================================== */
+
+/*
+ * In normal document flow the footer is a regular card — same border, radius
+ * and padding as the other boxes on the page. When its position:sticky engages
+ * at the viewport bottom, a CSS scroll-state container query stretches it to
+ * the full viewport width. No JavaScript involved; browsers without
+ * scroll-state support (non-Chromium, as of early 2026) simply keep the card
+ * look while stuck — a graceful degradation.
+ */
+@layer components {
+    .wizard-footer {
+        position: sticky;
+        bottom: 0;
+        z-index: 30; /* under the modal layer: backdrops are z-40, panels z-50 */
+        margin-top: 1.5rem;
+        container-type: scroll-state;
+    }
+
+    .wizard-footer-box {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.75rem;
+        padding: 1rem 1.5rem;
+        background-color: var(--color-tables-cards);
+        border: 1px solid var(--color-borders-dividers);
+        border-radius: 0.5rem;
+    }
+
+    @container scroll-state(stuck: bottom) {
+        .wizard-footer-box {
+            /* Break out of the centered content column to the full viewport
+               width; the matching padding keeps the buttons exactly where the
+               card had them, so nothing shifts at the stick/unstick moment. */
+            margin-inline: calc(50% - 50vw);
+            padding-inline: calc(50vw - 50% + 1.5rem);
+            border-radius: 0;
+            border-inline: none;
+            border-bottom: none;
+            box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.05);
+        }
+    }
+}
+
+/*
+ * The stuck footer's breakout margins are computed from 100vw, which includes
+ * the scrollbar gutter on platforms with classic scrollbars — that would add a
+ * few pixels of horizontal overflow. clip (unlike hidden) does not create a
+ * scroll container, so position:sticky keeps working.
+ */
+body {
+    overflow-x: clip;
+}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -1052,12 +1052,12 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
             <div x-cloak
                  x-show="toastVisible"
                  x-transition:enter="transition ease-out duration-200"
-                 x-transition:enter-start="opacity-0 translate-y-2"
+                 x-transition:enter-start="opacity-0 -translate-y-2"
                  x-transition:enter-end="opacity-100 translate-y-0"
                  x-transition:leave="transition ease-in duration-150"
                  x-transition:leave-start="opacity-100 translate-y-0"
-                 x-transition:leave-end="opacity-0 translate-y-2"
-                 class="fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg"
+                 x-transition:leave-end="opacity-0 -translate-y-2"
+                 class="fixed top-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg shadow-lg"
                  :style="toastType === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400); color: var(--color-error-600);'">
                 <span x-text="toastMessage"></span>
             </div>

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -120,10 +120,15 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
            right edge of the whole layout (not just the left column's edge) and the sticky assets panel
            unsticks at the flex-row's bottom rather than trailing past the CTAs. The assets buttons all
            use type="button" so they never accidentally submit the editor form. #}
+                    {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form", edit="1") %}
+                    {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form") %}
+                    {% set next_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="email") %}
+                    {% set save_label = _("Save and Republish") if registration_status == "PUBLISHED" else _("Save") %}
                     <form method="post"
                           action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
                           x-data
-                          x-preserve-scroll-on-submit>
+                          x-preserve-scroll-on-submit
+                          {% if edit_mode %}@input="markEditDirty($event)" @change="markEditDirty($event)" @submit="allowLeave()"{% endif %}>
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                         <div class="flex flex-col lg:flex-row gap-6">
                             <div class="flex-1 min-w-0">
@@ -131,7 +136,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 <section class="rounded-lg p-6" style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
                                     <div class="flex items-center justify-between mb-4">
                                         <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration Form HTML") }}</h2>
-                     {# Header right: editorial helper — status is shown globally above the stepper now. #}
+                     {# Header right: the editorial controls live here, next to the content they act on —
+                        Edit swaps in place to Cancel/Save so the eye never travels to the footer for
+                        editing concerns. The footer below is navigation only. #}
                                         <div class="flex items-center gap-2">
                                             {% set code_icon %}
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -144,6 +151,12 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             leading_icon=code_icon,
                                             attrs='@click="fetchSkeleton()" :disabled="skeletonLoading"'
                                             ) }}
+                                            {% if edit_mode %}
+                                                {{ button(_("Cancel"), variant="secondary", href=view_url, attrs='@click="guardLeave($event)"') }}
+                                                {{ button(save_label, type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                            {% elif registration_status != "CLOSED" %}
+                                                {{ button(_("Edit"), variant="secondary", href=edit_url) }}
+                                            {% endif %}
                                         </div>
                                     </div>
 
@@ -171,120 +184,119 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 </section>
                             </div>
 
-            {# Assets panel (image library). The aside carries the visual box (border/bg) so it
+            {# Assets panel (image library). Rendered only in edit mode — uploading and referencing
+               images are editing concerns, and hiding the panel keeps the read-only view a clean,
+               full-width review of the form. The aside carries the visual box (border/bg) so it
                stretches to match the left column's height (align-items: stretch is the flex default),
                and only the inner content sticks to the top on scroll. That way the box's bottom lines
                up with the editor's bottom instead of leaving the CTAs disconnected. Buttons all use
                type="button" so they never submit the parent editor form. #}
-                            <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
-                                   style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                                <div class="p-6 sticky top-4 w-full">
-                                    <div class="flex items-center justify-between mb-4">
-                                        <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
-                                        {% set upload_icon %}
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
-                                            </svg>
-                                        {% endset %}
-                                        {{ button(
-                                        _("Upload"),
-                                        variant="tertiary",
-                                        leading_icon=upload_icon,
-                                        attrs='type="button" @click="openImageUploadModal()"'
-                                        ) }}
-                                    </div>
+                            {% if edit_mode %}
+                                <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
+                                       style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                    <div class="p-6 sticky top-4 w-full">
+                                        <div class="flex items-center justify-between mb-4">
+                                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
+                                            {% set upload_icon %}
+                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
+                                                </svg>
+                                            {% endset %}
+                                            {{ button(
+                                            _("Upload"),
+                                            variant="tertiary",
+                                            leading_icon=upload_icon,
+                                            attrs='type="button" @click="openImageUploadModal()"'
+                                            ) }}
+                                        </div>
 
                     {# Format / size hint #}
-                                    <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
-                                         style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                        </svg>
-                                        <p class="text-body-sm" style="color: var(--color-info-700);">
-                                            {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
-                                        </p>
-                                    </div>
+                                        <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
+                                             style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                            </svg>
+                                            <p class="text-body-sm" style="color: var(--color-info-700);">
+                                                {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
+                                            </p>
+                                        </div>
 
                     {# Empty state #}
-                                    <template x-if="!images.length">
-                                        <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
-                                            {{ _("No images uploaded yet.") }}
-                                        </p>
-                                    </template>
+                                        <template x-if="!images.length">
+                                            <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
+                                                {{ _("No images uploaded yet.") }}
+                                            </p>
+                                        </template>
 
                     {# Image list #}
-                                    <ul class="space-y-2" x-show="images.length" x-cloak>
-                                        <template x-for="image in images" :key="image.id">
-                                            <li class="rounded-md px-3 py-2 flex items-center justify-between"
-                                                style="background-color: var(--color-subtle-background-panels);">
-                                                <a :href="image.public_url"
-                                                   :title="image.alt || image.file_name"
-                                                   target="_blank"
-                                                   rel="noopener"
-                                                   class="text-body-sm truncate flex-1 mr-2"
-                                                   style="color: var(--color-body-text);"
-                                                   x-text="image.display_name"></a>
-                                                <div class="flex items-center gap-1 flex-shrink-0">
+                                        <ul class="space-y-2" x-show="images.length" x-cloak>
+                                            <template x-for="image in images" :key="image.id">
+                                                <li class="rounded-md px-3 py-2 flex items-center justify-between"
+                                                    style="background-color: var(--color-subtle-background-panels);">
+                                                    <a :href="image.public_url"
+                                                       :title="image.alt || image.file_name"
+                                                       target="_blank"
+                                                       rel="noopener"
+                                                       class="text-body-sm truncate flex-1 mr-2"
+                                                       style="color: var(--color-body-text);"
+                                                       x-text="image.display_name"></a>
+                                                    <div class="flex items-center gap-1 flex-shrink-0">
                                     {# Image details / edit alt text #}
-                                                    <button type="button"
-                                                            @click="openImageDetailsModal(image)"
-                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                            style="color: var(--color-secondary-text);"
-                                                            :aria-label="image.aria_label_details">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                                        </svg>
-                                                    </button>
+                                                        <button type="button"
+                                                                @click="openImageDetailsModal(image)"
+                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                style="color: var(--color-secondary-text);"
+                                                                :aria-label="image.aria_label_details">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                            </svg>
+                                                        </button>
                                     {# Copy <img> snippet to clipboard #}
-                                                    <button type="button"
-                                                            @click="copyImageSnippet(image)"
-                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                            style="color: var(--color-secondary-text);"
-                                                            :aria-label="image.aria_label_copy_snippet">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                        </svg>
-                                                    </button>
+                                                        <button type="button"
+                                                                @click="copyImageSnippet(image)"
+                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                style="color: var(--color-secondary-text);"
+                                                                :aria-label="image.aria_label_copy_snippet">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                            </svg>
+                                                        </button>
                                     {# Delete #}
-                                                    <button type="button"
-                                                            @click="deleteImage(image)"
-                                                            :disabled="imageBeingDeletedId === image.id"
-                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                            style="color: var(--color-secondary-text);"
-                                                            :aria-label="image.aria_label_delete">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
-                                                        </svg>
-                                                    </button>
-                                                </div>
-                                            </li>
-                                        </template>
-                                    </ul>
-                                </div>
-                            </aside>
-                        </div>
-
-                        {# Bottom CTAs — sit below the whole two-column layout so they align to the far right
-                           of the page (past the sticky aside), not the left column's edge. Same shape across
-                           all three stepper steps. #}
-                        {% set edit_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form", edit="1") %}
-                        {% set view_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="form") %}
-                        {% set next_url = url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id, section="email") %}
-                        {% set save_label = _("Save and Republish") if registration_status == "PUBLISHED" else _("Save") %}
-                        {% set save_next_label = _("Save and Republish and next →") if registration_status == "PUBLISHED" else _("Save and next →") %}
-                        <div class="flex justify-end gap-3 mt-4">
-                            {% if edit_mode %}
-                                {{ button(_("Cancel"), variant="secondary", href=view_url) }}
-                                {{ button(save_label, type="submit", variant="secondary", attrs='name="action" value="save"') }}
-                                {{ button(save_next_label, type="submit", variant="primary", attrs='name="action" value="save_and_next"') }}
-                            {% else %}
-                                {% if registration_status != "CLOSED" %}
-                                    {{ button(_("Edit"), variant="secondary", href=edit_url) }}
-                                {% endif %}
-                                {{ button(_("Next →"), variant="primary", href=next_url) }}
+                                                        <button type="button"
+                                                                @click="deleteImage(image)"
+                                                                :disabled="imageBeingDeletedId === image.id"
+                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                style="color: var(--color-secondary-text);"
+                                                                :aria-label="image.aria_label_delete">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                                                            </svg>
+                                                        </button>
+                                                    </div>
+                                                </li>
+                                            </template>
+                                        </ul>
+                                    </div>
+                                </aside>
                             {% endif %}
                         </div>
                     </form>
+
+                    {# Sticky wizard footer — navigation only (Edit/Cancel/Save live in the card header).
+                       Sticky so clicking through the steps never requires scrolling; z-30 keeps it under
+                       the modal layer (backdrops are z-40, panels z-50). While editing, navigation is
+                       locked so the preview step can never silently lag unsaved changes. #}
+                    <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
+                         style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
+                        {% if edit_mode %}
+                            <span id="editing-nav-hint" class="mr-auto text-body-sm" style="color: var(--color-secondary-text);">
+                                {{ _("Editing in progress — save or cancel to continue") }}
+                            </span>
+                            {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
+                        {% else %}
+                            {{ button(_("Next →"), variant="primary", href=next_url) }}
+                        {% endif %}
+                    </div>
                 </div>
             {% endif %}
 
@@ -295,6 +307,10 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                      tabindex="0"
                      class="space-y-4">
                     {% set email_save_url = url_for('backoffice_registration.save_assembly_registration_email', assembly_id=assembly.id) %}
+                    {% set email_edit_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email', edit='1') %}
+                    {% set email_view_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
+                    {% set preview_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='preview') %}
+                    {% set back_to_form_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='form') %}
 
                     {# Readiness banner — surfaces problems that would stop the auto-reply from actually being delivered #}
                     {% for problem in email_readiness_problems %}
@@ -325,6 +341,14 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 {{ button(_("Set up auto-reply email"), type="submit", variant="primary") }}
                             </form>
                         </section>
+
+                        {# Sticky wizard footer — the auto-reply email is optional, so Back/Next stay
+                           available even before a template exists. #}
+                        <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
+                             style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
+                            <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
+                            {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                        </div>
                     {% else %}
                         {# Send-auto-reply toggle form. Sits as a sibling of the editor's save form (nested forms
                            are illegal HTML) and the checkbox in the section header below binds to it via the
@@ -351,7 +375,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         <form method="post"
                               action="{{ email_save_url }}"
                               x-data
-                              x-preserve-scroll-on-submit>
+                              x-preserve-scroll-on-submit
+                              {% if edit_mode %}@input="markEditDirty($event)" @change="markEditDirty($event)" @submit="allowLeave()"{% endif %}>
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                             <div class="flex flex-col lg:flex-row gap-6">
                                 <div class="flex-1 min-w-0">
@@ -360,14 +385,24 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             <h2 class="text-heading-lg" style="color: var(--color-headings);">
                                                 {{ _("Auto-reply email template") }}
                                             </h2>
-                                            {# Toggle lives in the section header, top-right; posts to the sibling
-                                               auto-reply-toggle form via the HTML5 form="" attribute. #}
-                                            {{ checkbox(
-                                            name="auto_reply_enabled",
-                                            label=_("Send auto-reply email"),
-                                            checked=auto_reply_enabled,
-                                            attrs='form="auto-reply-toggle" @change="$el.form.submit()"'
-                                            ) }}
+                                            {# Header right: the enable toggle plus the editorial controls — Edit swaps
+                                               in place to Cancel/Save, mirroring the form step. The toggle posts to the
+                                               sibling auto-reply-toggle form via the HTML5 form="" attribute (and is
+                                               excluded from dirty tracking in markEditDirty for the same reason). #}
+                                            <div class="flex items-center gap-4">
+                                                {{ checkbox(
+                                                name="auto_reply_enabled",
+                                                label=_("Send auto-reply email"),
+                                                checked=auto_reply_enabled,
+                                                attrs='form="auto-reply-toggle" @change="$el.form.submit()"'
+                                                ) }}
+                                                {% if edit_mode %}
+                                                    {{ button(_("Cancel"), variant="secondary", href=email_view_url, attrs='@click="guardLeave($event)"') }}
+                                                    {{ button(_("Save"), type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                                {% elif registration_status != "CLOSED" %}
+                                                    {{ button(_("Edit"), variant="secondary", href=email_edit_url) }}
+                                                {% endif %}
+                                            </div>
                                         </div>
 
                                         <div class="space-y-4">
@@ -403,84 +438,87 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                     </section>
                                 </div>
 
-                                {# Variables reference sidebar — the aside carries the visual box so it stretches
-                                   to match the editor's height, and only the inner content sticks on scroll
-                                   (same trick as the S1 Assets panel). #}
-                                <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
-                                       style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                                    <div class="p-6 sticky top-4 w-full">
-                                        <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
-                                            {{ _("Available variables") }}
-                                        </h2>
-                                        <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                            {{ _("Click a variable to select it, then copy and paste into the subject or body. Missing values render as an empty string.") }}
-                                        </p>
-                                        {% set variables = [
-                                        {"expr": "{{ assembly.title }}", "label": _("Assembly title")},
-                                        {"expr": "{{ assembly.question }}", "label": _("Assembly question")},
-                                        {"expr": "{{ assembly.first_assembly_date }}", "label": _("First assembly date (ISO)")},
-                                        {"expr": "{{ respondent.first_name }}", "label": _("Respondent first name")},
-                                        {"expr": "{{ respondent.first_name_or_friend }}", "label": _("First name, or 'Friend' as a fallback")},
-                                        {"expr": "{{ respondent.full_name }}", "label": _("Respondent full name")},
-                                        {"expr": "{{ respondent.email }}", "label": _("Respondent email address")}
-                                        ] %}
-                                        <ul class="space-y-3">
-                                            {% for variable in variables %}
-                                                <li>
-                                                    <label for="variable-{{ loop.index0 }}"
-                                                           class="text-body-sm font-medium block mb-1"
-                                                           style="color: var(--color-headings);">
-                                                        {{ variable.label }}
-                                                    </label>
-                                                    <div class="flex gap-2">
+                                {# Variables reference sidebar — rendered only in edit mode: it's an authoring
+                                   aid, and hiding it keeps the read-only view a clean, full-width review of the
+                                   email. The aside carries the visual box so it stretches to match the editor's
+                                   height, and only the inner content sticks on scroll (same trick as the S1
+                                   Assets panel). #}
+                                {% if edit_mode %}
+                                    <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
+                                           style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                        <div class="p-6 sticky top-4 w-full">
+                                            <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
+                                                {{ _("Available variables") }}
+                                            </h2>
+                                            <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                                {{ _("Click a variable to select it, then copy and paste into the subject or body. Missing values render as an empty string.") }}
+                                            </p>
+                                            {% set variables = [
+                                            {"expr": "{{ assembly.title }}", "label": _("Assembly title")},
+                                            {"expr": "{{ assembly.question }}", "label": _("Assembly question")},
+                                            {"expr": "{{ assembly.first_assembly_date }}", "label": _("First assembly date (ISO)")},
+                                            {"expr": "{{ respondent.first_name }}", "label": _("Respondent first name")},
+                                            {"expr": "{{ respondent.first_name_or_friend }}", "label": _("First name, or 'Friend' as a fallback")},
+                                            {"expr": "{{ respondent.full_name }}", "label": _("Respondent full name")},
+                                            {"expr": "{{ respondent.email }}", "label": _("Respondent email address")}
+                                            ] %}
+                                            <ul class="space-y-3">
+                                                {% for variable in variables %}
+                                                    <li>
+                                                        <label for="variable-{{ loop.index0 }}"
+                                                               class="text-body-sm font-medium block mb-1"
+                                                               style="color: var(--color-headings);">
+                                                            {{ variable.label }}
+                                                        </label>
+                                                        <div class="flex gap-2">
                                                         {# readonly + aria-readonly: some screen readers still announce "edit text"
                                                            for a readonly input, so we set aria-readonly explicitly. #}
-                                                        <input type="text"
-                                                               id="variable-{{ loop.index0 }}"
-                                                               readonly
-                                                               aria-readonly="true"
-                                                               value="{{ variable.expr }}"
-                                                               @click="$event.target.select()"
-                                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
-                                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
-                                                        <button type="button"
-                                                                data-copy-text="{{ variable.expr }}"
-                                                                data-copy-msg="{{ _('Variable copied to clipboard') }}"
-                                                                @click="copyToClipboard($el)"
-                                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
-                                                                aria-label="{{ _('Copy %(label)s variable', label=variable.label) }}">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                            </svg>
-                                                        </button>
-                                                    </div>
-                                                </li>
-                                            {% endfor %}
-                                        </ul>
-                                    </div>
-                                </aside>
-                            </div>
-
-                            {# Bottom CTAs — sit below both columns and align to the far right of the layout,
-                               matching the S1 pattern. Back sits on the far left (mr-auto pushes it away
-                               from the right-side group). #}
-                            {% set email_edit_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email', edit='1') %}
-                            {% set email_view_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
-                            {% set preview_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='preview') %}
-                            {% set back_to_form_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='form') %}
-                            <div class="flex justify-end gap-3 mt-4">
-                                <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
-                                {% if edit_mode %}
-                                    {{ button(_("Cancel"), variant="secondary", href=email_view_url) }}
-                                    {{ button(_("Save"), type="submit", variant="secondary", attrs='name="action" value="save"') }}
-                                    {{ button(_("Save and next →"), type="submit", variant="primary", attrs='name="action" value="save_and_next"') }}
-                                {% else %}
-                                    {{ button(_("Edit"), variant="secondary", href=email_edit_url) }}
-                                    {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                                                            <input type="text"
+                                                                   id="variable-{{ loop.index0 }}"
+                                                                   readonly
+                                                                   aria-readonly="true"
+                                                                   value="{{ variable.expr }}"
+                                                                   @click="$event.target.select()"
+                                                                   class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                                                                   style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                                            <button type="button"
+                                                                    data-copy-text="{{ variable.expr }}"
+                                                                    data-copy-msg="{{ _('Variable copied to clipboard') }}"
+                                                                    @click="copyToClipboard($el)"
+                                                                    class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                                    style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                                                    aria-label="{{ _('Copy %(label)s variable', label=variable.label) }}">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </li>
+                                                {% endfor %}
+                                            </ul>
+                                        </div>
+                                    </aside>
                                 {% endif %}
                             </div>
                         </form>
+
+                        {# Sticky wizard footer — navigation only (Edit/Cancel/Save live in the card header).
+                           While editing, navigation is locked so unsaved changes can't be silently left behind. #}
+                        <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
+                             style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
+                            {% if edit_mode %}
+                                <span class="mr-auto flex items-center gap-3">
+                                    {{ button(_("← Back"), variant="tertiary", disabled=true, aria_describedby="editing-nav-hint") }}
+                                    <span id="editing-nav-hint" class="text-body-sm" style="color: var(--color-secondary-text);">
+                                        {{ _("Editing in progress — save or cancel to continue") }}
+                                    </span>
+                                </span>
+                                {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
+                            {% else %}
+                                <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
+                                {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                            {% endif %}
+                        </div>
                     {% endif %}
                 </div>
             {% endif %}
@@ -556,7 +594,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                        action in TEST. Once PUBLISHED the badge above the stepper conveys the state;
                        CLOSED is terminal (no Reopen in the UI). #}
                     {% set back_to_email_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
-                    <div class="flex justify-end gap-3 mt-4">
+                    <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
+                         style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
                         <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_email_url) }}</span>
                         {% if registration_status == "TEST" and registration_page %}
                             <form method="post"
@@ -889,6 +928,45 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </div>
             </template>
 
+        {# Discard-changes confirmation — opened by guardLeave() when the user tries to leave
+           edit mode (Cancel or a stepper link) with unsaved changes. Only edit mode can be
+           dirty, so this is the single home of the "was leaving intentional?" decision. #}
+            <template x-if="leaveModalOpen">
+                <div x-cloak>
+                {# Backdrop overlay #}
+                    <div class="fixed inset-0 z-40"
+                         style="background-color: rgba(0, 0, 0, 0.5)"
+                         @click="closeLeaveModal()"
+                         @keydown.escape.window="closeLeaveModal()"></div>
+                {# Modal panel #}
+                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                         role="dialog"
+                         aria-modal="true"
+                         aria-labelledby="leave-modal-title">
+                        <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden"
+                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
+                             @click.stop>
+                            <div class="px-6 py-4"
+                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                <h2 id="leave-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                                    {{ _("Discard your changes?") }}
+                                </h2>
+                            </div>
+                            <div class="px-6 py-4">
+                                <p class="text-body-md" style="color: var(--color-body-text);">
+                                    {{ _("You have unsaved changes. If you leave now they will be lost and the last saved version will be kept.") }}
+                                </p>
+                            </div>
+                            <div class="px-6 py-3 flex gap-2 justify-end"
+                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+                                {{ button(_("Keep editing"), variant="secondary", attrs='type="button" x-ref="keepEditingBtn" @click="closeLeaveModal()"') }}
+                                {{ button(_("Discard changes"), variant="danger", attrs='type="button" @click="discardAndLeave()"') }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
         {# Toast notification #}
             <div x-cloak
                  x-show="toastVisible"
@@ -917,6 +995,72 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     toastVisible: false,
                     toastMessage: '',
                     toastType: 'success',
+
+                    // Unsaved-changes guard. Only edit mode can be dirty: markEditDirty() is wired
+                    // to the editor forms' input/change events (which also catch CodeMirror edits,
+                    // because .cm-content is a contenteditable inside the form and its input events
+                    // bubble). Leaving with unsaved changes goes through the discard modal for
+                    // in-app links (Cancel, stepper); beforeunload is the backstop for browser-level
+                    // navigation (close tab, reload, back button).
+                    editMode: {{ edit_mode|tojson }},
+                    editDirty: false,
+                    leaveModalOpen: false,
+                    leaveUrl: '',
+                    leaveGuardSuppressed: false,
+
+                    init() {
+                        if (!this.editMode) return;
+                        document.querySelectorAll('a.stepper-link').forEach((link) => {
+                            link.addEventListener('click', (event) => {
+                                if (!this.editDirty) return;
+                                event.preventDefault();
+                                this.openLeaveModal(link.href);
+                            });
+                        });
+                        window.addEventListener('beforeunload', (event) => {
+                            if (!this.editDirty || this.leaveGuardSuppressed) return;
+                            event.preventDefault();
+                            event.returnValue = '';
+                        });
+                    },
+
+                    markEditDirty(event) {
+                        // The auto-reply toggle posts its own form immediately; flipping it is not
+                        // part of the draft being edited.
+                        if (event.target && event.target.getAttribute('form') === 'auto-reply-toggle') return;
+                        this.editDirty = true;
+                    },
+
+                    // Called on the editor form's submit so Save never trips the beforeunload guard.
+                    allowLeave() {
+                        this.leaveGuardSuppressed = true;
+                    },
+
+                    // Attached to leave-links (Cancel). Clean state falls through to normal navigation.
+                    guardLeave(event) {
+                        if (!this.editDirty) return;
+                        event.preventDefault();
+                        this.openLeaveModal(event.currentTarget.href);
+                    },
+
+                    openLeaveModal(url) {
+                        this.leaveUrl = url;
+                        this.leaveModalOpen = true;
+                        this.$nextTick(() => {
+                            if (this.$refs.keepEditingBtn) this.$refs.keepEditingBtn.focus();
+                        });
+                    },
+
+                    closeLeaveModal() {
+                        this.leaveModalOpen = false;
+                        this.leaveUrl = '';
+                    },
+
+                    discardAndLeave() {
+                        if (!this.leaveUrl) return;
+                        this.leaveGuardSuppressed = true;
+                        window.location.assign(this.leaveUrl);
+                    },
 
                     // Assets panel state. `images` is seeded from server-side render and mutated in place
                     // so the page never reloads — uncommitted edits in the HTML editor survive.

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -615,22 +615,34 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         </aside>
                     </div>
 
-                    {# Bottom CTAs — Back on the left is always available; Publish is the primary happy-path
-                       action in TEST. Once PUBLISHED the badge above the stepper conveys the state;
-                       CLOSED is terminal (no Reopen in the UI). #}
+                    {# Bottom CTAs — Back on the left is always available. TEST offers Publish;
+                       PUBLISHED offers Unpublish (tertiary, reversible — back to test mode) and
+                       Close registration (secondary, terminal — goes through a confirmation
+                       dialog because there is no reopen). CLOSED offers nothing. #}
+                    {% set registration_save_url = url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) %}
                     {% set back_to_email_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
                     <div class="wizard-footer" x-scroll-preserve-links>
                         <div class="wizard-footer-box">
                             <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_email_url) }}</span>
                             {% if registration_status == "TEST" and registration_page %}
                                 <form method="post"
-                                      action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
+                                      action="{{ registration_save_url }}"
                                       x-data
                                       x-preserve-scroll-on-submit>
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                                     <input type="hidden" name="action" value="publish" />
                                     {{ button(_("Publish"), type="submit", variant="primary") }}
                                 </form>
+                            {% elif registration_status == "PUBLISHED" and registration_page %}
+                                <form method="post"
+                                      action="{{ registration_save_url }}"
+                                      x-data
+                                      x-preserve-scroll-on-submit>
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                    <input type="hidden" name="action" value="unpublish" />
+                                    {{ button(_("Unpublish"), type="submit", variant="tertiary") }}
+                                </form>
+                                {{ button(_("Close registration"), variant="secondary", attrs='type="button" @click="openConfirmClose()"') }}
                             {% endif %}
                         </div>
                     </div>
@@ -954,6 +966,50 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </div>
             </template>
 
+        {# Close-registration confirmation — closing is terminal (there is no reopen), so the
+           destructive action must be explicit. Same single-surface dialog style as the
+           discard confirmation: the safe action is the primary on the right and receives
+           initial focus; the destructive action is a plain red text button. Rendered only
+           where its opener exists (preview step of a published page). #}
+            {% if active_section == "preview" and registration_status == "PUBLISHED" and registration_page %}
+                <template x-if="confirmCloseOpen">
+                    <div x-cloak>
+                {# Backdrop overlay #}
+                        <div class="fixed inset-0 z-40"
+                             style="background-color: rgba(0, 0, 0, 0.5)"
+                             @click="cancelConfirmClose()"
+                             @keydown.escape.window="cancelConfirmClose()"></div>
+                {# Modal panel #}
+                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                             role="dialog"
+                             aria-modal="true"
+                             aria-labelledby="close-registration-modal-title">
+                            <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden px-6 py-5"
+                                 style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
+                                 @click.stop>
+                                <h2 id="close-registration-modal-title" class="text-heading-lg mb-2" style="color: var(--color-headings)">
+                                    {{ _("Close registration?") }}
+                                </h2>
+                                <p class="text-body-md mb-5" style="color: var(--color-body-text);">
+                                    {{ _("This permanently stops new registrations. Visitors who follow the form link will see the 'registration closed' page, and the form cannot be reopened.") }}
+                                </p>
+                                <div class="flex gap-2 justify-end items-center">
+                                    <form method="post"
+                                          action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
+                                          x-data
+                                          x-preserve-scroll-on-submit>
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                        <input type="hidden" name="action" value="close" />
+                                        {{ button(_("Close registration"), type="submit", variant="danger") }}
+                                    </form>
+                                    {{ button(_("Keep it open"), variant="primary", attrs='type="button" x-ref="keepOpenBtn" @click="cancelConfirmClose()"') }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            {% endif %}
+
         {# Discard-changes confirmation — opened by guardLeave() when the user tries to leave
            edit mode (Cancel or a stepper link) with unsaved changes. Only edit mode can be
            dirty, so this is the single home of the "was leaving intentional?" decision. #}
@@ -1051,6 +1107,20 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                     markEditDirty() {
                         this.editDirty = true;
+                    },
+
+                    // Close-registration confirmation (closing is terminal — no reopen).
+                    confirmCloseOpen: false,
+
+                    openConfirmClose() {
+                        this.confirmCloseOpen = true;
+                        this.$nextTick(() => {
+                            if (this.$refs.keepOpenBtn) this.$refs.keepOpenBtn.focus();
+                        });
+                    },
+
+                    cancelConfirmClose() {
+                        this.confirmCloseOpen = false;
                     },
 
                     // Called on the editor form's submit so Save never trips the beforeunload guard.

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -128,7 +128,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                           action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
                           x-data
                           x-preserve-scroll-on-submit
-                          {% if edit_mode %}@input="markEditDirty($event)" @change="markEditDirty($event)" @submit="allowLeave()"{% endif %}>
+                          {% if edit_mode %}@input="markEditDirty()" @change="markEditDirty()" @submit="allowLeave()"{% endif %}>
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                         <div class="flex flex-col lg:flex-row gap-6">
                             <div class="flex-1 min-w-0">
@@ -355,21 +355,6 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             {{ button(_("Next →"), variant="primary", href=preview_url) }}
                         </div>
                     {% else %}
-                        {# Send-auto-reply toggle form. Sits as a sibling of the editor's save form (nested forms
-                           are illegal HTML) and the checkbox in the section header below binds to it via the
-                           HTML5 `form="auto-reply-toggle"` attribute. The `action` field flips based on the
-                           current state, so toggling always inverts. #}
-                        <form id="auto-reply-toggle"
-                              method="post"
-                              action="{{ email_save_url }}"
-                              x-data
-                              x-preserve-scroll-on-submit
-                              style="display: none;">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                            <input type="hidden" name="action" value="{{ 'disable' if auto_reply_enabled else 'enable' }}" />
-                            <input type="hidden" name="template_id" value="{{ email_template.id }}" />
-                        </form>
-
                         {# Two-box layout mirroring the form section: editor on the left (2/3), variables reference
                            on the right (1/3, sticky). The form wraps both columns and the CTA row so the CTAs
                            align to the far right of the whole layout and the sticky aside unsticks at the
@@ -381,7 +366,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                               action="{{ email_save_url }}"
                               x-data
                               x-preserve-scroll-on-submit
-                              {% if edit_mode %}@input="markEditDirty($event)" @change="markEditDirty($event)" @submit="allowLeave()"{% endif %}>
+                              {% if edit_mode %}@input="markEditDirty()" @change="markEditDirty()" @submit="allowLeave()"{% endif %}>
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                             <div class="flex flex-col lg:flex-row gap-6">
                                 <div class="flex-1 min-w-0">
@@ -390,18 +375,19 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             <h2 class="text-heading-lg" style="color: var(--color-headings);">
                                                 {{ _("Auto-reply email template") }}
                                             </h2>
-                                            {# Header right: the enable toggle plus the editorial controls — Edit swaps
-                                               in place to Cancel/Save, mirroring the form step. The toggle posts to the
-                                               sibling auto-reply-toggle form via the HTML5 form="" attribute (and is
-                                               excluded from dirty tracking in markEditDirty for the same reason).
-                                               x-scroll-preserve-links keeps the scroll position across the Edit/Cancel
-                                               page reloads, matching the form step. #}
+                                            {# Header right: the always-on indicator plus the editorial controls — Edit
+                                               swaps in place to Cancel/Save, mirroring the form step. The checkbox is
+                                               deliberately checked and disabled: the auto-reply is always sent in the
+                                               current version of the product. When a real need to switch it off
+                                               emerges, a proper service-layer enable/disable gets built and this
+                                               checkbox gets wired to it. x-scroll-preserve-links keeps the scroll
+                                               position across the Edit/Cancel page reloads, matching the form step. #}
                                             <div class="flex items-center gap-4" x-scroll-preserve-links>
                                                 {{ checkbox(
                                                 name="auto_reply_enabled",
                                                 label=_("Send auto-reply email"),
-                                                checked=auto_reply_enabled,
-                                                attrs='form="auto-reply-toggle" @change="$el.form.submit()"'
+                                                checked=true,
+                                                disabled=true
                                                 ) }}
                                                 {% if edit_mode %}
                                                     {{ button(_("Cancel"), variant="secondary", href=email_view_url, attrs='@click="guardLeave($event)"') }}
@@ -1063,10 +1049,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         });
                     },
 
-                    markEditDirty(event) {
-                        // The auto-reply toggle posts its own form immediately; flipping it is not
-                        // part of the draft being edited.
-                        if (event.target && event.target.getAttribute('form') === 'auto-reply-toggle') return;
+                    markEditDirty() {
                         this.editDirty = true;
                     },
 

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -138,8 +138,11 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                         <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration Form HTML") }}</h2>
                      {# Header right: the editorial controls live here, next to the content they act on —
                         Edit swaps in place to Cancel/Save so the eye never travels to the footer for
-                        editing concerns. The footer below is navigation only. #}
-                                        <div class="flex items-center gap-2">
+                        editing concerns. The footer below is navigation only.
+                        x-scroll-preserve-links keeps the scroll position across the Edit/Cancel page
+                        reloads, so the editor stays in view when switching modes (the directive rewrites
+                        the href in capture phase, so the Cancel dirty-guard picks up the amended URL). #}
+                                        <div class="flex items-center gap-2" x-scroll-preserve-links>
                                             {% set code_icon %}
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                     <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
@@ -388,8 +391,10 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             {# Header right: the enable toggle plus the editorial controls — Edit swaps
                                                in place to Cancel/Save, mirroring the form step. The toggle posts to the
                                                sibling auto-reply-toggle form via the HTML5 form="" attribute (and is
-                                               excluded from dirty tracking in markEditDirty for the same reason). #}
-                                            <div class="flex items-center gap-4">
+                                               excluded from dirty tracking in markEditDirty for the same reason).
+                                               x-scroll-preserve-links keeps the scroll position across the Edit/Cancel
+                                               page reloads, matching the form step. #}
+                                            <div class="flex items-center gap-4" x-scroll-preserve-links>
                                                 {{ checkbox(
                                                 name="auto_reply_enabled",
                                                 label=_("Send auto-reply email"),

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -533,67 +533,98 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                      role="tabpanel"
                      aria-labelledby="reg-steps-tab-preview"
                      tabindex="0">
-                    <section class="rounded-lg p-6"
-                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
-                        <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
-                            {{ _("Preview and publish") }}
-                        </h2>
+                    {# Two-column layout mirroring the earlier steps: live form preview on the
+                       left (2/3), sharing links + QR on the right (1/3, sticky). #}
+                    <div class="flex flex-col lg:flex-row gap-6">
+                        <div class="flex-1 min-w-0">
+                            <section class="rounded-lg p-6"
+                                     style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                                <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">
+                                    {{ _("Form preview") }}
+                                </h2>
+                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                    {{ _("This is the last saved version of your registration form, shown exactly as visitors will see it. You can try the fields and dropdowns, but the form cannot be submitted from here.") }}
+                                </p>
 
-                        {# Status is shown globally above the stepper now, so no per-panel banner needed here. #}
-
-                        {% if registration_page %}
-                            <div class="space-y-6">
-                                {# Registration URL #}
-                                {{ readonly_url_display(
-                                label=_("Registration URL"),
-                                hint=_("The URL for your registration form"),
-                                url=registration_url
-                                ) }}
-
-                                {# Short URL — only if configured #}
-                                {% if registration_page.short_url_slug %}
-                                    {{ readonly_url_display(
-                                    label=_("Short URL"),
-                                    hint=_("A shorter URL for QR codes and paper invitations"),
-                                    url=short_url
-                                    ) }}
+                                {% if registration_page %}
+                                    {# The preview is a same-origin iframe of a dedicated backoffice route that
+                                       renders the saved form through the public pipeline with submission
+                                       disabled. The iframe keeps the author's HTML/CSS fully isolated from the
+                                       backoffice page. #}
+                                    <iframe src="{{ url_for('backoffice_registration.preview_registration_form', assembly_id=assembly.id) }}"
+                                            title="{{ _('Registration form preview') }}"
+                                            class="w-full rounded-md"
+                                            style="height: 70vh; min-height: 480px; border: 1px solid var(--color-borders-dividers); background-color: white;"></iframe>
                                 {% endif %}
+                            </section>
+                        </div>
 
-                                {# QR Code — only when short URL is configured #}
-                                {% if qr_code_data_url %}
-                                    <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers);">
-                                        <h3 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("QR Code") }}</h3>
-                                        <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                            {{ _("Use this QR code on paper invitations") }}
-                                        </p>
+                        {# Sharing sidebar — the aside carries the visual box so it stretches to match
+                           the preview's height, and only the inner content sticks on scroll (same
+                           trick as the earlier steps' sidebars). #}
+                        <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
+                               style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
+                            <div class="p-6 sticky top-4 w-full">
+                                <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">
+                                    {{ _("Share your form") }}
+                                </h2>
 
-                                        <div class="flex items-start gap-6">
-                                            <div class="flex-shrink-0 p-4 rounded-lg" style="background-color: white; border: 1px solid var(--color-borders-dividers);">
-                                                <img src="{{ qr_code_data_url }}"
-                                                     alt="{{ _('QR code for registration page') }}"
-                                                     class="w-40 h-40" />
-                                            </div>
+                                {% if registration_page %}
+                                    <div class="space-y-6">
+                                        {# Registration URL #}
+                                        {{ readonly_url_display(
+                                        label=_("Registration URL"),
+                                        hint=_("The URL for your registration form"),
+                                        url=registration_url
+                                        ) }}
 
-                                            <div class="flex flex-col gap-2">
-                                                <a href="{{ url_for('backoffice_registration.download_registration_qr_code', assembly_id=assembly.id) }}"
-                                                   class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-button-md transition-colors"
-                                                   style="background-color: var(--color-button-secondary-bg); color: var(--color-button-secondary-text); border: 1px solid var(--color-borders-dividers);"
-                                                   download>
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                                                    </svg>
-                                                    {{ _("Download QR Code") }}
-                                                </a>
-                                                <p class="text-body-sm" style="color: var(--color-secondary-text);">
-                                                    {{ _("PNG format, 400x400 pixels") }}
+                                        {# Short URL — only if configured #}
+                                        {% if registration_page.short_url_slug %}
+                                            {{ readonly_url_display(
+                                            label=_("Short URL"),
+                                            hint=_("A shorter URL for QR codes and paper invitations"),
+                                            url=short_url
+                                            ) }}
+                                        {% endif %}
+
+                                        {# QR Code — only when short URL is configured. Stacked vertically to
+                                           fit the 400px column. #}
+                                        {% if qr_code_data_url %}
+                                            <div class="pt-4" style="border-top: 1px solid var(--color-borders-dividers);">
+                                                <h3 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("QR Code") }}</h3>
+                                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                                    {{ _("Use this QR code on paper invitations") }}
                                                 </p>
+
+                                                <div class="flex flex-col items-start gap-4">
+                                                    <div class="p-4 rounded-lg" style="background-color: white; border: 1px solid var(--color-borders-dividers);">
+                                                        <img src="{{ qr_code_data_url }}"
+                                                             alt="{{ _('QR code for registration page') }}"
+                                                             class="w-40 h-40" />
+                                                    </div>
+
+                                                    <div class="flex flex-col gap-2">
+                                                        <a href="{{ url_for('backoffice_registration.download_registration_qr_code', assembly_id=assembly.id) }}"
+                                                           class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-button-md transition-colors"
+                                                           style="background-color: var(--color-button-secondary-bg); color: var(--color-button-secondary-text); border: 1px solid var(--color-borders-dividers);"
+                                                           download>
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                                            </svg>
+                                                            {{ _("Download QR Code") }}
+                                                        </a>
+                                                        <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                                                            {{ _("PNG format, 400x400 pixels") }}
+                                                        </p>
+                                                    </div>
+                                                </div>
                                             </div>
-                                        </div>
+                                        {% endif %}
                                     </div>
                                 {% endif %}
                             </div>
-                        {% endif %}
-                    </section>
+                        </aside>
+                    </div>
 
                     {# Bottom CTAs — Back on the left is always available; Publish is the primary happy-path
                        action in TEST. Once PUBLISHED the badge above the stepper conveys the state;

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -66,7 +66,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
         {% else %}
         {# Sub-navigation within the Registration tab: registration page → auto-reply email → preview & publish.
            URL contract: ?section=form|email|preview. Panels are peers (any step reachable at any time),
-           so the stepper is rendered in tabs mode. #}
+           so the stepper is rendered in tabs mode. While editing, the whole stepper is disabled —
+           navigation is locked to the card's Save/Cancel, matching the disabled footer buttons. #}
             {% set section_base = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id) %}
             {{ stepper(
             id="reg-steps",
@@ -77,7 +78,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
             ],
             aria_label=_("Registration setup steps"),
             mode="tabs",
-            preserve_scroll=true
+            preserve_scroll=true,
+            disabled=edit_mode
             ) }}
 
             {# Whole-artifact status. Sits below the stepper so it applies to all three steps —
@@ -1010,9 +1012,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </template>
             {% endif %}
 
-        {# Discard-changes confirmation — opened by guardLeave() when the user tries to leave
-           edit mode (Cancel or a stepper link) with unsaved changes. Only edit mode can be
-           dirty, so this is the single home of the "was leaving intentional?" decision. #}
+        {# Discard-changes confirmation — opened by guardLeave() when the user cancels
+           edit mode with unsaved changes. Only edit mode can be dirty, so this is the
+           single home of the "was leaving intentional?" decision. #}
             <template x-if="leaveModalOpen">
                 <div x-cloak>
                 {# Backdrop overlay #}
@@ -1080,9 +1082,9 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     // Unsaved-changes guard. Only edit mode can be dirty: markEditDirty() is wired
                     // to the editor forms' input/change events (which also catch CodeMirror edits,
                     // because .cm-content is a contenteditable inside the form and its input events
-                    // bubble). Leaving with unsaved changes goes through the discard modal for
-                    // in-app links (Cancel, stepper); beforeunload is the backstop for browser-level
-                    // navigation (close tab, reload, back button).
+                    // bubble). Cancel with unsaved changes goes through the discard modal (the
+                    // stepper and footer navigation are disabled while editing); beforeunload is
+                    // the backstop for browser-level navigation (close tab, reload, back button).
                     editMode: {{ edit_mode|tojson }},
                     editDirty: false,
                     leaveModalOpen: false,
@@ -1091,13 +1093,8 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                     init() {
                         if (!this.editMode) return;
-                        document.querySelectorAll('a.stepper-link').forEach((link) => {
-                            link.addEventListener('click', (event) => {
-                                if (!this.editDirty) return;
-                                event.preventDefault();
-                                this.openLeaveModal(link.href);
-                            });
-                        });
+                        // The stepper and footer navigation are fully disabled while editing,
+                        // so in-app leave paths funnel through the Cancel button's guardLeave().
                         window.addEventListener('beforeunload', (event) => {
                             if (!this.editDirty || this.leaveGuardSuppressed) return;
                             event.preventDefault();

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -290,6 +290,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                        the modal layer (backdrops are z-40, panels z-50). While editing, navigation is
                        locked so the preview step can never silently lag unsaved changes. #}
                     <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
+                         x-scroll-preserve-links
                          style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
                         {% if edit_mode %}
                             <span id="editing-nav-hint" class="mr-auto text-body-sm" style="color: var(--color-secondary-text);">
@@ -348,6 +349,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         {# Sticky wizard footer — the auto-reply email is optional, so Back/Next stay
                            available even before a template exists. #}
                         <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
+                             x-scroll-preserve-links
                              style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
                             <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
                             {{ button(_("Next →"), variant="primary", href=preview_url) }}
@@ -510,6 +512,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         {# Sticky wizard footer — navigation only (Edit/Cancel/Save live in the card header).
                            While editing, navigation is locked so unsaved changes can't be silently left behind. #}
                         <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
+                             x-scroll-preserve-links
                              style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
                             {% if edit_mode %}
                                 <span class="mr-auto flex items-center gap-3">
@@ -631,6 +634,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                        CLOSED is terminal (no Reopen in the UI). #}
                     {% set back_to_email_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
                     <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
+                         x-scroll-preserve-links
                          style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
                         <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_email_url) }}</span>
                         {% if registration_status == "TEST" and registration_page %}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -289,17 +289,17 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                        Sticky so clicking through the steps never requires scrolling; z-30 keeps it under
                        the modal layer (backdrops are z-40, panels z-50). While editing, navigation is
                        locked so the preview step can never silently lag unsaved changes. #}
-                    <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
-                         x-scroll-preserve-links
-                         style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
-                        {% if edit_mode %}
-                            <span id="editing-nav-hint" class="mr-auto text-body-sm" style="color: var(--color-secondary-text);">
-                                {{ _("Editing in progress — save or cancel to continue") }}
-                            </span>
-                            {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
-                        {% else %}
-                            {{ button(_("Next →"), variant="primary", href=next_url) }}
-                        {% endif %}
+                    <div class="wizard-footer" x-scroll-preserve-links>
+                        <div class="wizard-footer-box">
+                            {% if edit_mode %}
+                                <span id="editing-nav-hint" class="mr-auto text-body-sm" style="color: var(--color-secondary-text);">
+                                    {{ _("Editing in progress — save or cancel to continue") }}
+                                </span>
+                                {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
+                            {% else %}
+                                {{ button(_("Next →"), variant="primary", href=next_url) }}
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             {% endif %}
@@ -348,11 +348,11 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                         {# Sticky wizard footer — the auto-reply email is optional, so Back/Next stay
                            available even before a template exists. #}
-                        <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
-                             x-scroll-preserve-links
-                             style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
-                            <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
-                            {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                        <div class="wizard-footer" x-scroll-preserve-links>
+                            <div class="wizard-footer-box">
+                                <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
+                                {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                            </div>
                         </div>
                     {% else %}
                         {# Two-box layout mirroring the form section: editor on the left (2/3), variables reference
@@ -497,21 +497,21 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
                         {# Sticky wizard footer — navigation only (Edit/Cancel/Save live in the card header).
                            While editing, navigation is locked so unsaved changes can't be silently left behind. #}
-                        <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
-                             x-scroll-preserve-links
-                             style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
-                            {% if edit_mode %}
-                                <span class="mr-auto flex items-center gap-3">
-                                    {{ button(_("← Back"), variant="tertiary", disabled=true, aria_describedby="editing-nav-hint") }}
-                                    <span id="editing-nav-hint" class="text-body-sm" style="color: var(--color-secondary-text);">
-                                        {{ _("Editing in progress — save or cancel to continue") }}
+                        <div class="wizard-footer" x-scroll-preserve-links>
+                            <div class="wizard-footer-box">
+                                {% if edit_mode %}
+                                    <span class="mr-auto flex items-center gap-3">
+                                        {{ button(_("← Back"), variant="tertiary", disabled=true, aria_describedby="editing-nav-hint") }}
+                                        <span id="editing-nav-hint" class="text-body-sm" style="color: var(--color-secondary-text);">
+                                            {{ _("Editing in progress — save or cancel to continue") }}
+                                        </span>
                                     </span>
-                                </span>
-                                {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
-                            {% else %}
-                                <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
-                                {{ button(_("Next →"), variant="primary", href=preview_url) }}
-                            {% endif %}
+                                    {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
+                                {% else %}
+                                    <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
+                                    {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                                {% endif %}
+                            </div>
                         </div>
                     {% endif %}
                 </div>
@@ -619,20 +619,20 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                        action in TEST. Once PUBLISHED the badge above the stepper conveys the state;
                        CLOSED is terminal (no Reopen in the UI). #}
                     {% set back_to_email_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id, section='email') %}
-                    <div class="sticky bottom-0 z-30 flex items-center justify-end gap-3 mt-6 py-3"
-                         x-scroll-preserve-links
-                         style="background-color: var(--color-page-background); border-top: 1px solid var(--color-borders-dividers);">
-                        <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_email_url) }}</span>
-                        {% if registration_status == "TEST" and registration_page %}
-                            <form method="post"
-                                  action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
-                                  x-data
-                                  x-preserve-scroll-on-submit>
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                                <input type="hidden" name="action" value="publish" />
-                                {{ button(_("Publish"), type="submit", variant="primary") }}
-                            </form>
-                        {% endif %}
+                    <div class="wizard-footer" x-scroll-preserve-links>
+                        <div class="wizard-footer-box">
+                            <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_email_url) }}</span>
+                            {% if registration_status == "TEST" and registration_page %}
+                                <form method="post"
+                                      action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id) }}"
+                                      x-data
+                                      x-preserve-scroll-on-submit>
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                    <input type="hidden" name="action" value="publish" />
+                                    {{ button(_("Publish"), type="submit", variant="primary") }}
+                                </form>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             {% endif %}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -948,24 +948,23 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                          role="dialog"
                          aria-modal="true"
                          aria-labelledby="leave-modal-title">
-                        <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden"
+                        {# Single-surface dialog (no header/footer dividers, per the Figma design):
+                           title, body, and actions share one padded panel. Keep editing is the
+                           primary (safe) action on the right and receives initial focus; Discard
+                           changes is a plain text button so the destructive path never looks like
+                           the default. #}
+                        <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden px-6 py-5"
                              style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
                              @click.stop>
-                            <div class="px-6 py-4"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="leave-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
-                                    {{ _("Discard your changes?") }}
-                                </h2>
-                            </div>
-                            <div class="px-6 py-4">
-                                <p class="text-body-md" style="color: var(--color-body-text);">
-                                    {{ _("You have unsaved changes. If you leave now they will be lost and the last saved version will be kept.") }}
-                                </p>
-                            </div>
-                            <div class="px-6 py-3 flex gap-2 justify-end"
-                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
-                                {{ button(_("Keep editing"), variant="secondary", attrs='type="button" x-ref="keepEditingBtn" @click="closeLeaveModal()"') }}
-                                {{ button(_("Discard changes"), variant="danger", attrs='type="button" @click="discardAndLeave()"') }}
+                            <h2 id="leave-modal-title" class="text-heading-lg mb-2" style="color: var(--color-headings)">
+                                {{ _("Discard changes?") }}
+                            </h2>
+                            <p class="text-body-md mb-5" style="color: var(--color-body-text);">
+                                {{ _("You have unsaved changes. If you leave this page, your changes will be lost.") }}
+                            </p>
+                            <div class="flex gap-2 justify-end items-center">
+                                {{ button(_("Discard changes"), variant="tertiary", attrs='type="button" @click="discardAndLeave()"') }}
+                                {{ button(_("Keep editing"), variant="primary", attrs='type="button" x-ref="keepEditingBtn" @click="closeLeaveModal()"') }}
                             </div>
                         </div>
                     </div>

--- a/backend/templates/backoffice/components/floating_alerts.html
+++ b/backend/templates/backoffice/components/floating_alerts.html
@@ -1,15 +1,15 @@
 {#
-ABOUTME: Floating alert component for flash messages at bottom-right of viewport
+ABOUTME: Floating alert component for flash messages at the top-center of the viewport
 ABOUTME: Provides accessible notifications that don't require scrolling to top
 #}
 {% from "backoffice/components/alert.html" import alert %}
 
 {% macro floating_alerts() %}
     {#
-    Renders Flask flash messages in a fixed-position container at bottom-right.
+    Renders Flask flash messages in a fixed-position container at the top-center.
 
     Features:
-    - Fixed position at bottom-right of viewport
+    - Fixed position at the top-center of the viewport
     - z-30: Below modals (z-40/z-50) but above page content
     - aria-live="polite": Screen readers announce new alerts
     - All alerts are dismissible
@@ -22,7 +22,7 @@ ABOUTME: Provides accessible notifications that don't require scrolling to top
     {% set messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
         <div id="floating-alerts"
-             class="fixed bottom-6 right-6 z-30 flex flex-col gap-3 max-w-md"
+             class="fixed top-6 left-1/2 -translate-x-1/2 z-30 flex flex-col gap-3 w-full max-w-md px-4"
              aria-live="polite">
             {% for category, message in messages %}
                 {% if category == "success" %}

--- a/backend/templates/backoffice/components/stepper.html
+++ b/backend/templates/backoffice/components/stepper.html
@@ -2,7 +2,7 @@
 ABOUTME: Stepper component macro — numbered step navigation with tabs or wizard semantics
 ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="step"
 #}
-{% macro stepper(items=[], aria_label="", id="", mode="tabs", preserve_scroll=false) %}
+{% macro stepper(items=[], aria_label="", id="", mode="tabs", preserve_scroll=false, disabled=false) %}
     {#
     Numbered step navigation with two semantic modes.
 
@@ -31,6 +31,12 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                      (registered in `static/js/alpine-scroll-manager.js`, loaded by
                      `backoffice/base.html`). Silently no-ops if used from a base
                      template that doesn't load that script.
+    disabled: disable the WHOLE stepper (default false). Works in both modes: every
+              step renders as a non-focusable span with aria-disabled="true" instead
+              of a link, so there is nothing to click or tab to. Use when the page is
+              in a state where navigating away must be locked — e.g. while an edit is
+              in progress — typically together with disabling any other navigation
+              controls on the page.
 
     Panel convention (same as tabs macro):
         <div id="{{ id }}-panel-{{ key }}" role="tabpanel"
@@ -62,7 +68,7 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                 {% set panel_id = id ~ "-panel-" ~ item_key %}
                 {% set is_active = item.active or item.state == "active" %}
                 {% set state = item.state | default("active" if is_active else "inactive") %}
-                {% set is_disabled = item.disabled and is_wizard %}
+                {% set is_disabled = disabled or (item.disabled and is_wizard) %}
                 {% set step_role = "step" if is_wizard else "tab" %}
 
                 {# Pass-through attributes for anything not consumed above.

--- a/backend/templates/backoffice/components/stepper.html
+++ b/backend/templates/backoffice/components/stepper.html
@@ -88,7 +88,7 @@ ABOUTME: mode="tabs" uses tablist ARIA; mode="wizard" uses list + aria-current="
                               role="{{ step_role }}"
                               id="{{ tab_id }}"
                               aria-disabled="true"
-                              {% if not is_wizard %}aria-controls="{{ panel_id }}" tabindex="-1"{% endif %}
+                              {% if not is_wizard %}aria-controls="{{ panel_id }}" aria-selected="{{ 'true' if is_active else 'false' }}" tabindex="-1"{% endif %}
                               {{ extra_attrs | join(" ") | safe }}>
                             <span class="stepper-number" aria-hidden="true">
                                 {% if state == "done" %}

--- a/backend/templates/backoffice/patterns.html
+++ b/backend/templates/backoffice/patterns.html
@@ -103,7 +103,7 @@ ABOUTME: Documents Alpine.js patterns, form handling, and AJAX with live example
 
         {# Toast Notification #}
         <div x-cloak x-show="toast.show" x-transition
-             class="fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg"
+             class="fixed top-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg shadow-lg"
              :style="toast.type === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-info-100); border: 1px solid var(--color-info-400); color: var(--color-info-600);'"
              <span x-text="toast.message"></span>
     </div>

--- a/backend/templates/backoffice/patterns.html
+++ b/backend/templates/backoffice/patterns.html
@@ -104,9 +104,9 @@ ABOUTME: Documents Alpine.js patterns, form handling, and AJAX with live example
         {# Toast Notification #}
         <div x-cloak x-show="toast.show" x-transition
              class="fixed top-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg shadow-lg"
-             :style="toast.type === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-info-100); border: 1px solid var(--color-info-400); color: var(--color-info-600);'"
-             <span x-text="toast.message"></span>
-    </div>
+             :style="toast.type === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-info-100); border: 1px solid var(--color-info-400); color: var(--color-info-600);'">
+            <span x-text="toast.message"></span>
+        </div>
     </div>
 
     <script nonce="{{ csp_nonce }}">

--- a/backend/templates/backoffice/patterns/_stepper.html
+++ b/backend/templates/backoffice/patterns/_stepper.html
@@ -88,6 +88,39 @@ ABOUTME: Documents states (active/inactive/done/error), URL contract, and panel 
         {% endcall %}
     {% endcall %}
 
+    {# ===== whole stepper disabled ===== #}
+    {% call card(title="Disabling the whole stepper", composed=true) %}
+        {% call card_body() %}
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Pass disabled=true to lock every step in either mode: steps render as non-focusable spans with aria-disabled='true', so there is nothing to click or tab to. Use it when navigating away must be blocked — e.g. while an edit is in progress — together with disabling the page's other navigation controls (see the registration wizard, which pairs it with the disabled footer Back/Next in edit mode).") }}
+            </p>
+
+            <div class="mb-6">
+                {{ stepper(
+                id="showcase-disabled",
+                items=[
+                {"key": "one", "label": _("Registration page"), "href": "?tab=stepper&mode=disabled&step=one", "state": "done"},
+                {"key": "two", "label": _("Auto-reply email"), "href": "?tab=stepper&mode=disabled&step=two", "active": true},
+                {"key": "three", "label": _("Preview and publish"), "href": "?tab=stepper&mode=disabled&step=three"}
+                ],
+                aria_label=_("Example stepper (disabled)"),
+                mode="tabs",
+                disabled=true
+                ) }}
+            </div>
+
+            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Code") }}</h4>
+            <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto"
+                 style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">{% raw %}{{ stepper(
+    id="reg-steps",
+    items=[...],
+    aria_label="Registration setup steps",
+    mode="tabs",
+    disabled=edit_mode
+) }}{% endraw %}</pre>
+        {% endcall %}
+    {% endcall %}
+
     {# ===== State reference ===== #}
     {% call card(title="States", composed=true) %}
         {% call card_body() %}
@@ -142,7 +175,7 @@ ABOUTME: Documents states (active/inactive/done/error), URL contract, and panel 
         {% call card_body() %}
             <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Signature") }}</h4>
             <pre class="text-body-sm font-mono p-3 rounded-lg overflow-x-auto mb-4"
-                 style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">stepper(items=[], aria_label="", id="", mode="tabs", preserve_scroll=false)</pre>
+                 style="background-color: var(--color-subtle-background-panels); color: var(--color-body-text);">stepper(items=[], aria_label="", id="", mode="tabs", preserve_scroll=false, disabled=false)</pre>
 
             <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Item keys") }}</h4>
             <ul class="text-body-sm font-mono mb-4" style="color: var(--color-body-text);">
@@ -151,7 +184,13 @@ ABOUTME: Documents states (active/inactive/done/error), URL contract, and panel 
                 <li>href: str ✅</li>
                 <li>state: "active" | "inactive" | "done" | "error" ❌ ({{ _("derived from `active` if omitted") }})</li>
                 <li>active: bool ❌ ({{ _("shortcut for state='active'") }})</li>
-                <li>disabled: bool ❌ ({{ _("only meaningful in wizard mode") }})</li>
+                <li>disabled: bool ❌ ({{ _("per-item lock, only meaningful in wizard mode") }})</li>
+            </ul>
+
+            <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Macro-level flags") }}</h4>
+            <ul class="text-body-sm font-mono mb-4" style="color: var(--color-body-text);">
+                <li>disabled: bool ❌ ({{ _("locks the WHOLE stepper in either mode — steps render as aria-disabled spans") }})</li>
+                <li>preserve_scroll: bool ❌ ({{ _("keep scroll position across step navigation") }})</li>
             </ul>
 
             <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Panel convention (same as tabs macro)") }}</h4>

--- a/backend/templates/backoffice/service_docs.html
+++ b/backend/templates/backoffice/service_docs.html
@@ -98,7 +98,7 @@ ABOUTME: Provides testing console with code references, sample data, and executi
         <div x-cloak
              x-show="toast.show"
              x-transition
-             class="fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg"
+             class="fixed top-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg shadow-lg"
              :style="toast.type === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-info-100); border: 1px solid var(--color-info-400); color: var(--color-info-600);'">
             <span x-text="toast.message"></span>
         </div>

--- a/backend/templates/backoffice/showcase/stepper_component.html
+++ b/backend/templates/backoffice/showcase/stepper_component.html
@@ -8,7 +8,7 @@ ABOUTME: Pure visual showcase — no route wiring, no scroll preservation
 {% macro stepper_section() %}
     {% call showcase_section() %}
         {{ showcase_title("Stepper Component") }}
-        {{ showcase_description("Numbered step navigation with two semantic modes. Tabs mode uses tablist ARIA and lets any step be reached; wizard mode marks the active step with aria-current='step' and can lock later steps until earlier ones are done. Per-step state: active, inactive, done, or error.") }}
+        {{ showcase_description("Numbered step navigation with two semantic modes. Tabs mode uses tablist ARIA and lets any step be reached; wizard mode marks the active step with aria-current='step' and can lock later steps until earlier ones are done. Per-step state: active, inactive, done, or error. disabled=true locks the whole stepper in either mode.") }}
 
         {% call showcase_example('{% from "backoffice/components/stepper.html" import stepper %}
 
@@ -51,6 +51,26 @@ ABOUTME: Pure visual showcase — no route wiring, no scroll preservation
                     aria_label="Example stepper - wizard mode",
                     mode="wizard"
                     ) }}
+                </div>
+
+                {# Whole stepper disabled #}
+                <div class="flex flex-col gap-2">
+                    <span class="text-label-md" style="color: var(--color-secondary-text);">disabled=true — whole stepper locked (e.g. while an edit is in progress)</span>
+                    {{ stepper(
+                    id="showcase-stepper-disabled",
+                    items=[
+                    {"key": "form", "label": "Registration page", "href": "#", "state": "done"},
+                    {"key": "email", "label": "Auto-reply email", "href": "#", "active": true},
+                    {"key": "preview", "label": "Preview and publish", "href": "#"}
+                    ],
+                    aria_label="Example stepper - disabled",
+                    mode="tabs",
+                    disabled=true
+                    ) }}
+                    <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                        Every step renders as a non-focusable span with aria-disabled="true" — nothing to click or tab to.
+                        Pair it with disabling the page's other navigation (e.g. the wizard footer's Back/Next).
+                    </p>
                 </div>
 
                 {# State reference #}

--- a/backend/templates/register/closed.html
+++ b/backend/templates/register/closed.html
@@ -1,4 +1,5 @@
 {% extends "base_public.html" %}
+{% block extra_head %}<meta name="robots" content="noindex, nofollow">{% endblock %}
 {% block title %}{{ _("Registration Closed") }} - OpenDLP{% endblock %}
 {% block content %}
     <div class="govuk-grid-row">

--- a/backend/templates/register/form.html
+++ b/backend/templates/register/form.html
@@ -19,4 +19,5 @@
         </div>
     {% endif %}
     {{ rendered_form | safe }}
+    {% block form_extras %}{% endblock %}
 {% endblock %}

--- a/backend/templates/register/form.html
+++ b/backend/templates/register/form.html
@@ -1,5 +1,5 @@
 {% extends "base_public.html" %}
-{% block extra_head %}<meta name="robots" content="noindex">{% endblock %}
+{% block extra_head %}<meta name="robots" content="noindex, nofollow">{% endblock %}
 {% block title %}{{ _("Register") }} - OpenDLP{% endblock %}
 {% block content %}
     {% if is_test %}

--- a/backend/templates/register/form_preview.html
+++ b/backend/templates/register/form_preview.html
@@ -1,0 +1,16 @@
+{#
+ABOUTME: Read-only preview of the public registration form, embedded in the backoffice preview step
+ABOUTME: Renders exactly like the public form but blocks submission (interactions still work)
+#}
+{% extends "register/form.html" %}
+{% block form_extras %}
+    <script nonce="{{ csp_nonce }}">
+        // Preview only: the form can be interacted with (dropdowns, inputs) but never
+        // submitted. Capture phase so author HTML cannot re-enable submission. If JS is
+        // unavailable, the form's empty action posts back to the GET-only preview route,
+        // which rejects it with 405 — no registration can be created either way.
+        document.addEventListener('submit', function (event) {
+            event.preventDefault();
+        }, true);
+    </script>
+{% endblock %}

--- a/backend/templates/register/form_preview.html
+++ b/backend/templates/register/form_preview.html
@@ -12,5 +12,13 @@ ABOUTME: Renders exactly like the public form but blocks submission (interaction
         document.addEventListener('submit', function (event) {
             event.preventDefault();
         }, true);
+        // Links are neutralised too: navigating the iframe away (author-HTML links,
+        // footer links) would hit pages whose frame-ancestors/X-Frame-Options block
+        // framing, leaving the preview pane blank until a full page reload.
+        document.addEventListener('click', function (event) {
+            if (event.target.closest('a')) {
+                event.preventDefault();
+            }
+        }, true);
     </script>
 {% endblock %}

--- a/backend/templates/register/thank_you.html
+++ b/backend/templates/register/thank_you.html
@@ -1,5 +1,5 @@
 {% extends "base_public.html" %}
-{% block extra_head %}<meta name="robots" content="noindex">{% endblock %}
+{% block extra_head %}<meta name="robots" content="noindex, nofollow">{% endblock %}
 {% block title %}{{ _("Thank You") }} - OpenDLP{% endblock %}
 {% block content %}
     {{ custom_html | safe }}

--- a/backend/templates/register/thank_you_default.html
+++ b/backend/templates/register/thank_you_default.html
@@ -1,5 +1,5 @@
 {% extends "base_public.html" %}
-{% block extra_head %}<meta name="robots" content="noindex">{% endblock %}
+{% block extra_head %}<meta name="robots" content="noindex, nofollow">{% endblock %}
 {% block title %}{{ _("Thank You") }} - OpenDLP{% endblock %}
 {% block content %}
     <div class="govuk-grid-row">

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -15,6 +15,7 @@ from opendlp.domain.value_objects import AssemblyRole
 from opendlp.service_layer.assembly_service import add_assembly_gsheet, create_assembly
 from opendlp.service_layer.registration_page_service import (
     create_registration_page_with_slugs,
+    publish_registration_page,
     update_registration_page_html,
 )
 from opendlp.service_layer.unit_of_work import SqlAlchemyUnitOfWork
@@ -438,10 +439,8 @@ def saved_registration_html_contains(page: Page, text: str):
     expect(editor).to_contain_text(text, timeout=PLAYWRIGHT_TIMEOUT)
 
 
-@given(parsers.parse('there is an assembly called "{title}" with a saved registration form'))
-def create_test_assembly_with_saved_form(title: str, admin_user, test_database):
-    """Create an assembly whose registration page already has saved, previewable form HTML."""
-    session_factory = test_database
+def _create_assembly_with_saved_form(title: str, admin_user, session_factory):
+    """Create an assembly whose registration page has saved, publishable form HTML."""
     assembly = create_assembly(
         uow=SqlAlchemyUnitOfWork(session_factory),
         title=title,
@@ -466,6 +465,68 @@ def create_test_assembly_with_saved_form(title: str, admin_user, test_database):
             "</form>"
         ),
     )
+    return assembly
+
+
+@given(parsers.parse('there is an assembly called "{title}" with a saved registration form'))
+def create_test_assembly_with_saved_form(title: str, admin_user, test_database):
+    """Create an assembly whose registration page already has saved, previewable form HTML."""
+    _create_assembly_with_saved_form(title, admin_user, test_database)
+
+
+@given(parsers.parse('there is an assembly called "{title}" with a published registration form'))
+def create_test_assembly_with_published_form(title: str, admin_user, test_database):
+    """Create an assembly whose saved registration form has been published."""
+    assembly = _create_assembly_with_saved_form(title, admin_user, test_database)
+    publish_registration_page(
+        uow=SqlAlchemyUnitOfWork(test_database),
+        user_id=admin_user.id,
+        assembly_id=assembly.id,
+    )
+
+
+@when("I click the Unpublish button")
+def click_unpublish(page: Page):
+    page.get_by_role("button", name="Unpublish", exact=True).click()
+
+
+@when("I click the Close registration button")
+def click_close_registration(page: Page):
+    """The footer's Close opener — outside the dialog it is the only button with this name."""
+    page.get_by_role("button", name="Close registration", exact=True).click()
+
+
+@then("I should see the close registration confirmation")
+def see_close_confirmation(page: Page):
+    expect(page.locator('[aria-labelledby="close-registration-modal-title"]')).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+
+
+@when("I choose to keep the registration open")
+def choose_keep_open(page: Page):
+    page.get_by_role("button", name="Keep it open").click()
+
+
+@then("the close registration confirmation should be closed")
+def close_confirmation_closed(page: Page):
+    """The dialog is inside a template x-if, so closing removes it from the DOM."""
+    expect(page.locator('[aria-labelledby="close-registration-modal-title"]')).to_have_count(0)
+
+
+@when("I confirm closing the registration")
+def confirm_close_registration(page: Page):
+    """The destructive submit inside the dialog (same label as the opener)."""
+    dialog = page.locator('[aria-labelledby="close-registration-modal-title"]')
+    dialog.get_by_role("button", name="Close registration", exact=True).click()
+
+
+@then("the registration should be shown as closed")
+def registration_shown_as_closed(page: Page):
+    expect(page.get_by_role("alert").filter(has_text="Registration closed")).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+
+
+@then("the registration should be shown as in test mode")
+def registration_shown_as_test_mode(page: Page):
+    expect(page.get_by_role("alert").filter(has_text="Test mode")).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
 
 
 @when(parsers.parse('I visit the registration preview step for "{title}"'))

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -435,6 +435,55 @@ def saved_registration_html_contains(page: Page, text: str):
     expect(editor).to_contain_text(text, timeout=PLAYWRIGHT_TIMEOUT)
 
 
+@then("the wizard Next button should be disabled")
+def wizard_next_button_disabled(page: Page):
+    """While editing, the sticky footer's navigation is locked."""
+    expect(page.get_by_role("button", name="Next →")).to_be_disabled()
+
+
+@when("I click the Cancel button in the editor header")
+def click_editor_cancel(page: Page):
+    """Cancel renders as a link-button in the editor card header."""
+    page.get_by_role("button", name="Cancel", exact=True).click()
+
+
+@then("I should see the discard changes confirmation")
+def see_discard_confirmation(page: Page):
+    """Cancelling with unsaved changes opens the discard-confirmation dialog."""
+    expect(page.locator('[aria-labelledby="leave-modal-title"]')).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+
+
+@when("I choose to keep editing")
+def choose_keep_editing(page: Page):
+    page.get_by_role("button", name="Keep editing").click()
+
+
+@then("the discard changes confirmation should be closed")
+def discard_confirmation_closed(page: Page):
+    """The dialog is inside a template x-if, so closing removes it from the DOM."""
+    expect(page.locator('[aria-labelledby="leave-modal-title"]')).to_have_count(0)
+
+
+@when("I choose to discard my changes")
+def choose_discard_changes(page: Page):
+    page.get_by_role("button", name="Discard changes").click()
+
+
+@then("I should be on the read-only registration form view")
+def on_read_only_form_view(page: Page):
+    """Leaving edit mode lands on the view URL (no edit=1) with a non-editable editor."""
+    page.wait_for_url(lambda url: "edit=1" not in url, timeout=PLAYWRIGHT_TIMEOUT)
+    content = page.locator("textarea[name='html_content'] + .cm-editor .cm-content")
+    expect(content).to_have_attribute("contenteditable", "false", timeout=PLAYWRIGHT_TIMEOUT)
+
+
+@then(parsers.parse('the saved registration HTML should not contain "{text}"'))
+def saved_registration_html_not_contains(page: Page, text: str):
+    """Discarded edits must not be persisted."""
+    editor = page.locator("textarea[name='html_content'] + .cm-editor")
+    expect(editor).not_to_contain_text(text, timeout=PLAYWRIGHT_TIMEOUT)
+
+
 @when("I open the form skeleton preview")
 def open_form_skeleton_preview(page: Page):
     """Click the 'Show Form Skeleton' button to fetch the skeleton and open its modal."""

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -588,6 +588,13 @@ def wizard_next_button_disabled(page: Page):
     expect(page.get_by_role("button", name="Next →")).to_be_disabled()
 
 
+@then("the stepper navigation should be disabled")
+def stepper_navigation_disabled(page: Page):
+    """While editing, the stepper renders aria-disabled spans instead of links."""
+    expect(page.locator("a.stepper-link")).to_have_count(0)
+    expect(page.locator('span.stepper-link[aria-disabled="true"]')).to_have_count(3)
+
+
 @when("I click the Cancel button in the editor header")
 def click_editor_cancel(page: Page):
     """Cancel renders as a link-button in the editor card header."""

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -435,6 +435,32 @@ def saved_registration_html_contains(page: Page, text: str):
     expect(editor).to_contain_text(text, timeout=PLAYWRIGHT_TIMEOUT)
 
 
+@when(parsers.parse('I visit the read-only registration form view for "{title}"'))
+def visit_registration_form_view(page: Page, title: str, test_database):
+    """Open the registration form step in its default read-only mode."""
+    assembly_id = _assembly_name_id_cache.find_title(title, test_database)
+    page.goto(f"{Urls.base}/backoffice/assembly/{assembly_id}/registration?section=form")
+
+
+@when("I scroll down the page")
+def scroll_down_the_page(page: Page):
+    page.evaluate("window.scrollTo(0, 400)")
+    page.wait_for_function("window.scrollY > 0")
+
+
+@when("I click the Edit button in the editor header")
+def click_editor_edit(page: Page):
+    """Edit renders as a link-button in the editor card header."""
+    page.get_by_role("button", name="Edit", exact=True).click()
+
+
+@then("the editor should be in edit mode with the page still scrolled down")
+def edit_mode_with_scroll_preserved(page: Page):
+    """x-scroll-preserve-links carries the scroll position across the Edit reload."""
+    page.wait_for_url(lambda url: "edit=1" in url, timeout=PLAYWRIGHT_TIMEOUT)
+    page.wait_for_function("window.scrollY > 0", timeout=PLAYWRIGHT_TIMEOUT)
+
+
 @then("the wizard Next button should be disabled")
 def wizard_next_button_disabled(page: Page):
     """While editing, the sticky footer's navigation is locked."""

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -13,7 +13,10 @@ from opendlp.domain.respondents import Respondent
 from opendlp.domain.targets import TargetCategory, TargetValue
 from opendlp.domain.value_objects import AssemblyRole
 from opendlp.service_layer.assembly_service import add_assembly_gsheet, create_assembly
-from opendlp.service_layer.registration_page_service import create_registration_page_with_slugs
+from opendlp.service_layer.registration_page_service import (
+    create_registration_page_with_slugs,
+    update_registration_page_html,
+)
 from opendlp.service_layer.unit_of_work import SqlAlchemyUnitOfWork
 from opendlp.service_layer.user_service import grant_user_assembly_role
 
@@ -433,6 +436,63 @@ def saved_registration_html_contains(page: Page, text: str):
     """After saving we land on the read-only form view, whose editor shows the persisted HTML."""
     editor = page.locator("textarea[name='html_content'] + .cm-editor")
     expect(editor).to_contain_text(text, timeout=PLAYWRIGHT_TIMEOUT)
+
+
+@given(parsers.parse('there is an assembly called "{title}" with a saved registration form'))
+def create_test_assembly_with_saved_form(title: str, admin_user, test_database):
+    """Create an assembly whose registration page already has saved, previewable form HTML."""
+    session_factory = test_database
+    assembly = create_assembly(
+        uow=SqlAlchemyUnitOfWork(session_factory),
+        title=title,
+        created_by_user_id=admin_user.id,
+    )
+    _assembly_name_id_cache.add_existing(title, assembly)
+    create_registration_page_with_slugs(
+        uow=SqlAlchemyUnitOfWork(session_factory),
+        user_id=admin_user.id,
+        assembly_id=assembly.id,
+    )
+    update_registration_page_html(
+        uow=SqlAlchemyUnitOfWork(session_factory),
+        user_id=admin_user.id,
+        assembly_id=assembly.id,
+        form_html=(
+            '<form action="{{ form_action }}" method="post">'
+            "{{ csrf_form_element }}"
+            '<label for="colour">Favourite colour</label>'
+            '<select id="colour" name="colour"><option>Red</option><option>Blue</option></select>'
+            '<button type="submit">Register</button>'
+            "</form>"
+        ),
+    )
+
+
+@when(parsers.parse('I visit the registration preview step for "{title}"'))
+def visit_registration_preview_step(page: Page, title: str, test_database):
+    """Open the preview-and-publish step of the registration wizard."""
+    assembly_id = _assembly_name_id_cache.find_title(title, test_database)
+    page.goto(f"{Urls.base}/backoffice/assembly/{assembly_id}/registration?section=preview")
+
+
+@then("I should see the embedded registration form preview")
+def see_embedded_form_preview(page: Page):
+    """The preview step iframes the saved form, rendered through the public pipeline."""
+    frame = page.frame_locator('iframe[title="Registration form preview"]')
+    expect(frame.locator("form")).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+
+
+@then("submitting the embedded preview form does not leave the page")
+def submitting_preview_form_does_nothing(page: Page):
+    """The preview form is interactive but its submission is blocked."""
+    frame = page.frame_locator('iframe[title="Registration form preview"]')
+    # Interactions work: pick a dropdown option before trying to submit.
+    frame.locator('select[name="colour"]').select_option("Blue")
+    frame.locator('form button[type="submit"]').click()
+    # The iframe still shows the form (no navigation, no thank-you page)...
+    expect(frame.locator("form")).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+    # ...and the backoffice page itself has not navigated away.
+    assert "section=preview" in page.url
 
 
 @when(parsers.parse('I visit the read-only registration form view for "{title}"'))

--- a/backend/tests/component/test_backoffice_registration_email.py
+++ b/backend/tests/component/test_backoffice_registration_email.py
@@ -179,8 +179,9 @@ class TestSaveAction:
         assert saved.subject == "Updated subject"
 
     def test_save_uses_posted_template_id_when_none_assigned(self, logged_in_admin, fake_store, assembly_id):
-        # Template exists for the assembly but auto-reply is off. The editor form
-        # posts template_id so save/enable work on the currently-displayed template.
+        # Template exists for the assembly but was never assigned (legacy state from
+        # the old enable/disable switch). A posted template_id targets it directly,
+        # and saving self-heals the assignment — the auto-reply is always-on.
         template = _seed_template(fake_store, assembly_id)
         _seed_page(fake_store, assembly_id, auto_reply_template_id=None)
 
@@ -197,6 +198,8 @@ class TestSaveAction:
         assert response.status_code == 302
         saved = _get_template(fake_store, template.id)
         assert saved.subject == "Subject via form-supplied id"
+        page = _get_page(fake_store, assembly_id)
+        assert page.auto_reply_email_template_id == template.id
 
     def test_save_with_no_template_flashes_warning(self, logged_in_admin, fake_store, assembly_id):
         # Page exists but no email template exists yet — save is a no-op with a hint.
@@ -216,50 +219,44 @@ class TestSaveAction:
         assert _list_templates(fake_store, assembly_id) == []
 
 
-class TestEnableDisableActions:
-    """The switch above the editor posts action=enable/disable to flip the assignment FK."""
+class TestAlwaysOnAutoReply:
+    """The auto-reply cannot be switched off: no enable/disable actions, and the
+    checkbox renders as a checked, disabled indicator."""
 
-    def test_enable_assigns_the_posted_template(self, logged_in_admin, fake_store, assembly_id):
+    def test_save_self_heals_unassigned_legacy_template(self, logged_in_admin, fake_store, assembly_id):
+        # Legacy state from the old switch: template exists but is unassigned, and
+        # nothing posts a template_id. Save falls back to the assembly's template
+        # and assigns it, so the always-on promise becomes true again.
         template = _seed_template(fake_store, assembly_id)
         _seed_page(fake_store, assembly_id, auto_reply_template_id=None)
 
         response = logged_in_admin.post(
             f"/backoffice/assembly/{assembly_id}/registration/email/save",
-            data={"action": "enable", "template_id": str(template.id)},
+            data={
+                "action": "save",
+                "template_subject": "Healed subject",
+                "template_body_html": "<p>Healed body</p>",
+            },
         )
 
         assert response.status_code == 302
-        assert "section=email" in response.location
+        saved = _get_template(fake_store, template.id)
+        assert saved.subject == "Healed subject"
         page = _get_page(fake_store, assembly_id)
         assert page.auto_reply_email_template_id == template.id
 
-    def test_enable_without_template_id_or_assignment_flashes_warning(self, logged_in_admin, fake_store, assembly_id):
-        _seed_page(fake_store, assembly_id, auto_reply_template_id=None)
-
-        response = logged_in_admin.post(
-            f"/backoffice/assembly/{assembly_id}/registration/email/save",
-            data={"action": "enable"},
-        )
-
-        assert response.status_code == 302
-        page = _get_page(fake_store, assembly_id)
-        # Nothing to enable, nothing gets assigned.
-        assert page.auto_reply_email_template_id is None
-
-    def test_disable_unassigns_current_template(self, logged_in_admin, fake_store, assembly_id):
+    def test_checkbox_renders_checked_and_disabled_with_no_toggle_form(self, logged_in_admin, fake_store, assembly_id):
         template = _seed_template(fake_store, assembly_id)
         _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
 
-        response = logged_in_admin.post(
-            f"/backoffice/assembly/{assembly_id}/registration/email/save",
-            data={"action": "disable"},
-        )
+        response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration?section=email")
 
-        assert response.status_code == 302
-        page = _get_page(fake_store, assembly_id)
-        assert page.auto_reply_email_template_id is None
-        # The template itself is kept so re-enabling later is one click.
-        assert _get_template(fake_store, template.id) is not None
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert 'id="auto-reply-toggle"' not in html
+        checkbox = html.split('name="auto_reply_enabled"', 1)[1].split(">", 1)[0]
+        assert "checked" in checkbox
+        assert "disabled" in checkbox
 
 
 class TestErrorHandling:
@@ -328,16 +325,15 @@ class TestErrorHandling:
 class TestLoadAutoReplyContext:
     """The view route falls back to list_email_templates()[0] when nothing is assigned."""
 
-    def test_returns_assigned_template_and_enabled_true(self, app, fake_store, admin_user, existing_assembly):
+    def test_returns_assigned_template(self, app, fake_store, admin_user, existing_assembly):
         template = _seed_template(fake_store, existing_assembly.id)
         _seed_page(fake_store, existing_assembly.id, auto_reply_template_id=template.id)
         page = _get_page(fake_store, existing_assembly.id)
 
         with app.test_request_context(), _patch_current_user(admin_user.id):
-            loaded, enabled, problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
+            loaded, problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
 
         assert loaded.id == template.id
-        assert enabled is True
         assert isinstance(problems, list)
 
     def test_falls_back_to_first_template_when_none_assigned(self, app, fake_store, admin_user, existing_assembly):
@@ -346,16 +342,14 @@ class TestLoadAutoReplyContext:
         page = _get_page(fake_store, existing_assembly.id)
 
         with app.test_request_context(), _patch_current_user(admin_user.id):
-            loaded, enabled, problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
+            loaded, problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
 
         assert loaded.id == template.id
-        assert enabled is False
         assert isinstance(problems, list)
 
     def test_returns_none_when_no_registration_page(self, fake_store, existing_assembly):
-        loaded, enabled, problems = be_reg._load_auto_reply_context(None, existing_assembly.id)
+        loaded, problems = be_reg._load_auto_reply_context(None, existing_assembly.id)
         assert loaded is None
-        assert enabled is False
         assert problems == []
 
     def test_falls_back_to_first_template_when_assigned_template_lookup_fails(
@@ -376,10 +370,9 @@ class TestLoadAutoReplyContext:
                 side_effect=EmailTemplateNotFoundError("gone"),
             ),
         ):
-            loaded, enabled, _problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
+            loaded, _problems = be_reg._load_auto_reply_context(page, existing_assembly.id)
 
         assert loaded.id == fallback.id
-        assert enabled is False
 
 
 class TestCreateDefaultAutoReplyTemplate:
@@ -410,6 +403,6 @@ class TestPageCreationSeedsDefaultTemplate:
         assert response.status_code == 302
         templates = _list_templates(fake_store, assembly_id)
         assert len(templates) == 1
-        # Not assigned — the switch starts OFF; the manager can review before enabling.
+        # Assigned straight away — the auto-reply is always-on once a template exists.
         page = _get_page(fake_store, assembly_id)
-        assert page.auto_reply_email_template_id is None
+        assert page.auto_reply_email_template_id == templates[0].id

--- a/backend/tests/component/test_backoffice_registration_email.py
+++ b/backend/tests/component/test_backoffice_registration_email.py
@@ -178,28 +178,27 @@ class TestSaveAction:
         saved = _get_template(fake_store, template.id)
         assert saved.subject == "Updated subject"
 
-    def test_save_uses_posted_template_id_when_none_assigned(self, logged_in_admin, fake_store, assembly_id):
-        # Template exists for the assembly but was never assigned (legacy state from
-        # the old enable/disable switch). A posted template_id targets it directly,
-        # and saving self-heals the assignment — the auto-reply is always-on.
-        template = _seed_template(fake_store, assembly_id)
-        _seed_page(fake_store, assembly_id, auto_reply_template_id=None)
+    def test_save_ignores_posted_template_id(self, logged_in_admin, fake_store, assembly_id):
+        # Save always targets the page's assigned template. A posted template_id is
+        # never trusted — honouring it would let a request update a template that
+        # belongs to a different assembly.
+        assigned = _seed_template(fake_store, assembly_id)
+        other = _seed_template(fake_store, assembly_id, name="Other", subject="Other subject")
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=assigned.id)
 
         response = logged_in_admin.post(
             f"/backoffice/assembly/{assembly_id}/registration/email/save",
             data={
                 "action": "save",
-                "template_id": str(template.id),
-                "template_subject": "Subject via form-supplied id",
-                "template_body_html": "<p>Body via form-supplied id</p>",
+                "template_id": str(other.id),
+                "template_subject": "Updated subject",
+                "template_body_html": "<p>Updated body</p>",
             },
         )
 
         assert response.status_code == 302
-        saved = _get_template(fake_store, template.id)
-        assert saved.subject == "Subject via form-supplied id"
-        page = _get_page(fake_store, assembly_id)
-        assert page.auto_reply_email_template_id == template.id
+        assert _get_template(fake_store, assigned.id).subject == "Updated subject"
+        assert _get_template(fake_store, other.id).subject == "Other subject"
 
     def test_save_with_no_template_flashes_warning(self, logged_in_admin, fake_store, assembly_id):
         # Page exists but no email template exists yet — save is a no-op with a hint.
@@ -223,10 +222,10 @@ class TestAlwaysOnAutoReply:
     """The auto-reply cannot be switched off: no enable/disable actions, and the
     checkbox renders as a checked, disabled indicator."""
 
-    def test_save_self_heals_unassigned_legacy_template(self, logged_in_admin, fake_store, assembly_id):
-        # Legacy state from the old switch: template exists but is unassigned, and
-        # nothing posts a template_id. Save falls back to the assembly's template
-        # and assigns it, so the always-on promise becomes true again.
+    def test_save_does_not_assign_an_unassigned_template(self, logged_in_admin, fake_store, assembly_id):
+        # An unassigned template can only mean a partially-failed create (the data
+        # migration backfilled everything else). Save must not quietly repair it —
+        # it redirects with the set-one-up-first hint and changes nothing.
         template = _seed_template(fake_store, assembly_id)
         _seed_page(fake_store, assembly_id, auto_reply_template_id=None)
 
@@ -234,16 +233,34 @@ class TestAlwaysOnAutoReply:
             f"/backoffice/assembly/{assembly_id}/registration/email/save",
             data={
                 "action": "save",
-                "template_subject": "Healed subject",
-                "template_body_html": "<p>Healed body</p>",
+                "template_subject": "Should not be saved",
+                "template_body_html": "<p>Should not be saved</p>",
             },
         )
 
         assert response.status_code == 302
-        saved = _get_template(fake_store, template.id)
-        assert saved.subject == "Healed subject"
-        page = _get_page(fake_store, assembly_id)
-        assert page.auto_reply_email_template_id == template.id
+        assert "section=email" in response.location
+        assert _get_template(fake_store, template.id).subject != "Should not be saved"
+        assert _get_page(fake_store, assembly_id).auto_reply_email_template_id is None
+
+    def test_legacy_toggle_actions_are_rejected_without_changes(self, logged_in_admin, fake_store, assembly_id):
+        # The removed enable/disable actions (or any unknown action) must not fall
+        # through to the save handler — they redirect back with nothing changed.
+        template = _seed_template(fake_store, assembly_id)
+        _seed_page(fake_store, assembly_id, auto_reply_template_id=template.id)
+
+        for action in ("disable", "enable"):
+            response = logged_in_admin.post(
+                f"/backoffice/assembly/{assembly_id}/registration/email/save",
+                data={"action": action, "template_id": str(template.id)},
+            )
+
+            assert response.status_code == 302
+            assert "section=email" in response.location
+            assert _get_page(fake_store, assembly_id).auto_reply_email_template_id == template.id
+            saved = _get_template(fake_store, template.id)
+            assert saved.subject == template.subject
+            assert saved.body_html == template.body_html
 
     def test_checkbox_renders_checked_and_disabled_with_no_toggle_form(self, logged_in_admin, fake_store, assembly_id):
         template = _seed_template(fake_store, assembly_id)

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -111,6 +111,22 @@ class TestEditModeRendersExpectedHtml:
         assert f"/backoffice/assembly/{assembly_id}/registration" in anchor
         assert "edit=1" not in anchor
 
+    def test_edit_mode_disables_the_stepper_navigation(self, logged_in_admin, fake_store, assembly_id):
+        """While editing, the stepper renders aria-disabled spans instead of links."""
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST)
+
+        view_body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+        edit_body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1").get_data(
+            as_text=True
+        )
+
+        def stepper_markup(body: str) -> str:
+            return body.split('class="stepper"', 1)[1].split("</ol>", 1)[0]
+
+        assert "<a href" in stepper_markup(view_body)
+        assert "<a href" not in stepper_markup(edit_body)
+        assert stepper_markup(edit_body).count('aria-disabled="true"') == 3
+
     def test_view_mode_hides_assets_panel_and_edit_mode_shows_it(self, logged_in_admin, fake_store, assembly_id):
         """The Assets panel is an editing tool, so it only renders in edit mode."""
         _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST)

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -309,3 +309,71 @@ class TestFormPreviewRoute:
         body = response.get_data(as_text=True)
         assert "<iframe" in body
         assert f"/backoffice/assembly/{assembly_id}/registration/form-preview" in body
+
+
+class TestLifecycleFooterControls:
+    """The preview step's footer offers the lifecycle actions for the current status:
+    TEST → Publish; PUBLISHED → Unpublish + Close registration; CLOSED → nothing."""
+
+    def _preview_body(self, logged_in_admin, assembly_id) -> str:
+        response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration?section=preview")
+        assert response.status_code == 200
+        return response.get_data(as_text=True)
+
+    def test_test_status_offers_publish_only(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST)
+
+        body = self._preview_body(logged_in_admin, assembly_id)
+
+        assert 'value="publish"' in body
+        assert 'value="unpublish"' not in body
+        assert "Close registration" not in body
+
+    def test_published_status_offers_unpublish_and_close(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.PUBLISHED)
+
+        body = self._preview_body(logged_in_admin, assembly_id)
+
+        assert 'value="publish"' not in body
+        assert 'value="unpublish"' in body
+        assert "Unpublish</button>" in body
+        assert "Close registration</button>" in body
+        # Close goes through the confirmation dialog (terminal action, no reopen).
+        assert "Close registration?" in body
+
+    def test_closed_status_offers_no_lifecycle_actions(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.CLOSED)
+
+        body = self._preview_body(logged_in_admin, assembly_id)
+
+        assert 'value="publish"' not in body
+        assert 'value="unpublish"' not in body
+        assert "Close registration" not in body
+
+    def test_unpublish_returns_page_to_test_and_lands_on_preview(self, logged_in_admin, fake_store, assembly_id):
+        page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.PUBLISHED)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/save",
+            data={"action": "unpublish"},
+        )
+
+        assert response.status_code == 302
+        assert "section=preview" in response.location
+        with FakeUnitOfWork(store=fake_store) as uow:
+            stored = uow.registration_pages.get(page.id)
+        assert stored.status == RegistrationPageStatus.TEST
+
+    def test_close_closes_the_page_and_lands_on_preview(self, logged_in_admin, fake_store, assembly_id):
+        page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.PUBLISHED)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/save",
+            data={"action": "close"},
+        )
+
+        assert response.status_code == 302
+        assert "section=preview" in response.location
+        with FakeUnitOfWork(store=fake_store) as uow:
+            stored = uow.registration_pages.get(page.id)
+        assert stored.status == RegistrationPageStatus.CLOSED

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -250,3 +250,62 @@ class TestCodeEditorEnhancement:
 
         assert response.status_code == 200
         assert "backoffice/js/dist/html-editor.js" in response.get_data(as_text=True)
+
+
+_PREVIEWABLE_FORM = (
+    '<form action="{{ form_action }}" method="post">'
+    "{{ csrf_form_element }}"
+    '<label for="fn">First name</label><input id="fn" name="first_name" />'
+    '<button type="submit">Register</button>'
+    "</form>"
+)
+
+
+class TestFormPreviewRoute:
+    """The embedded read-only preview of the saved registration form (preview step)."""
+
+    def test_preview_renders_saved_form_with_submission_disabled(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, form_html=_PREVIEWABLE_FORM)
+
+        response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration/form-preview")
+
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # The saved form renders through the public pipeline...
+        assert 'name="first_name"' in body
+        assert ">Register</button>" in body
+        # ...but submission is neutralised: empty action, blocking script, no security fields
+        assert 'action=""' in body
+        assert "preview: submission disabled" in body
+        assert 'name="csrf_token"' not in body
+        assert "_opendlp_ttoken_" not in body
+
+    def test_preview_is_framable_by_same_origin_only(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, form_html=_PREVIEWABLE_FORM)
+
+        response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration/form-preview")
+
+        assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+        assert "frame-ancestors 'self'" in response.headers.get("Content-Security-Policy", "")
+
+    def test_preview_404_without_registration_page(self, logged_in_admin, assembly_id):
+        response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration/form-preview")
+
+        assert response.status_code == 404
+
+    def test_preview_403_for_non_member(self, logged_in_user, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, form_html=_PREVIEWABLE_FORM)
+
+        response = logged_in_user.get(f"/backoffice/assembly/{assembly_id}/registration/form-preview")
+
+        assert response.status_code == 403
+
+    def test_preview_section_embeds_the_preview_iframe(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, form_html=_PREVIEWABLE_FORM)
+
+        response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration?section=preview")
+
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert "<iframe" in body
+        assert f"/backoffice/assembly/{assembly_id}/registration/form-preview" in body

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -352,8 +352,8 @@ class TestLifecycleFooterControls:
 
         assert 'value="publish"' not in body
         assert 'value="unpublish"' in body
-        assert "Unpublish</button>" in body
-        assert "Close registration</button>" in body
+        assert "Unpublish</span></button>" in body
+        assert "Close registration</span></button>" in body
         # Close goes through the confirmation dialog (terminal action, no reopen).
         assert "Close registration?" in body
 

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -92,7 +92,7 @@ class TestEditModeRendersExpectedHtml:
         assert f"/backoffice/assembly/{assembly_id}/registration?section=email" in body
         assert "Cancel</a>" not in body
 
-    def test_test_status_edit_mode_shows_save_and_next_buttons(self, logged_in_admin, fake_store, assembly_id):
+    def test_test_status_edit_mode_shows_header_save_controls(self, logged_in_admin, fake_store, assembly_id):
         _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST)
 
         response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1")
@@ -102,12 +102,26 @@ class TestEditModeRendersExpectedHtml:
         assert "readonly" not in _extract_textarea(body)
         assert "Cancel</span></a>" in body
         assert "Save</span></button>" in body
-        assert "Save and next →</span></button>" in body
+        # Save-and-next is gone: the footer is navigation only, and it locks while editing
+        assert "Save and next" not in body
+        assert "Editing in progress" in body
         # Cancel returns to read-only on the form step
         cancel_block = body.split("Cancel</span></a>", 1)[0]
         anchor = cancel_block.rsplit("<a", 1)[1]
         assert f"/backoffice/assembly/{assembly_id}/registration" in anchor
         assert "edit=1" not in anchor
+
+    def test_view_mode_hides_assets_panel_and_edit_mode_shows_it(self, logged_in_admin, fake_store, assembly_id):
+        """The Assets panel is an editing tool, so it only renders in edit mode."""
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST)
+
+        view_body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+        edit_body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration?edit=1").get_data(
+            as_text=True
+        )
+
+        assert ">Assets</h2>" not in view_body
+        assert ">Assets</h2>" in edit_body
 
     def test_published_status_edit_mode_uses_save_and_republish_label(self, logged_in_admin, fake_store, assembly_id):
         _seed_page(fake_store, assembly_id, RegistrationPageStatus.PUBLISHED)

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -1,6 +1,7 @@
 # ABOUTME: Component tests for the backoffice registration view's read-only / edit-mode toggle
 # ABOUTME: Drives the real Flask route + services over a FakeUnitOfWork via a logged-in client
 
+import uuid
 from unittest.mock import patch
 
 import pytest
@@ -309,6 +310,22 @@ class TestFormPreviewRoute:
 
         assert response.status_code == 404
 
+    def test_preview_404_for_unknown_assembly(self, logged_in_admin):
+        response = logged_in_admin.get(f"/backoffice/assembly/{uuid.uuid4()}/registration/form-preview")
+
+        assert response.status_code == 404
+
+    def test_preview_500_when_rendering_fails(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, form_html=_PREVIEWABLE_FORM)
+
+        with patch(
+            "opendlp.entrypoints.blueprints.backoffice_registration.render_registration_form",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration/form-preview")
+
+        assert response.status_code == 500
+
     def test_preview_403_for_non_member(self, logged_in_user, fake_store, assembly_id):
         _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, form_html=_PREVIEWABLE_FORM)
 
@@ -393,3 +410,21 @@ class TestLifecycleFooterControls:
         with FakeUnitOfWork(store=fake_store) as uow:
             stored = uow.registration_pages.get(page.id)
         assert stored.status == RegistrationPageStatus.CLOSED
+
+    def test_unknown_action_is_a_plain_save_landing_on_the_form_step(self, logged_in_admin, fake_store, assembly_id):
+        # An action outside the save/lifecycle sets carries no HTML and triggers no
+        # transition: it falls through to the plain-save path and lands read-only
+        # on the form step (no edit=1), leaving the page untouched.
+        page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.PUBLISHED)
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/save",
+            data={"action": "bogus"},
+        )
+
+        assert response.status_code == 302
+        assert "section=form" in response.location
+        assert "edit=1" not in response.location
+        with FakeUnitOfWork(store=fake_store) as uow:
+            stored = uow.registration_pages.get(page.id)
+        assert stored.status == RegistrationPageStatus.PUBLISHED

--- a/backend/tests/component/test_registration_bot_protection.py
+++ b/backend/tests/component/test_registration_bot_protection.py
@@ -440,15 +440,15 @@ class TestSubmissionRecording:
 
 class TestNoindexHeader:
     def test_get_form_has_noindex_header(self, client: FlaskClient, fake_store, admin_user: User) -> None:
-        """GET /register/<slug> includes X-Robots-Tag: noindex."""
+        """GET /register/<slug> includes X-Robots-Tag: noindex, nofollow."""
         page = _seed_published_page(fake_store, admin_user)
 
         response = client.get(f"/register/{page.url_slug}")
 
-        assert response.headers.get("X-Robots-Tag") == "noindex"
+        assert response.headers.get("X-Robots-Tag") == "noindex, nofollow"
 
     def test_post_form_has_noindex_header(self, client: FlaskClient, fake_store, admin_user: User) -> None:
-        """POST /register/<slug> includes X-Robots-Tag: noindex."""
+        """POST /register/<slug> includes X-Robots-Tag: noindex, nofollow."""
         page = _seed_published_page(fake_store, admin_user)
 
         response = client.post(
@@ -456,26 +456,40 @@ class TestNoindexHeader:
             data={"name": "User", "email": "user@example.com"},
         )
 
-        assert response.headers.get("X-Robots-Tag") == "noindex"
+        assert response.headers.get("X-Robots-Tag") == "noindex, nofollow"
 
     def test_thank_you_has_noindex_header(self, client: FlaskClient, fake_store, admin_user: User) -> None:
-        """GET /register/<slug>/thank-you includes X-Robots-Tag: noindex."""
+        """GET /register/<slug>/thank-you includes X-Robots-Tag: noindex, nofollow."""
         page = _seed_published_page(fake_store, admin_user)
 
         response = client.get(f"/register/{page.url_slug}/thank-you")
 
-        assert response.headers.get("X-Robots-Tag") == "noindex"
+        assert response.headers.get("X-Robots-Tag") == "noindex, nofollow"
 
     def test_short_url_redirect_has_noindex_header(self, client: FlaskClient, fake_store, admin_user: User) -> None:
-        """GET /r/<short_slug> includes X-Robots-Tag: noindex."""
+        """GET /r/<short_slug> includes X-Robots-Tag: noindex, nofollow."""
         page = _seed_published_page(fake_store, admin_user)
 
         response = client.get(f"/r/{page.short_url_slug}")
 
-        assert response.headers.get("X-Robots-Tag") == "noindex"
+        assert response.headers.get("X-Robots-Tag") == "noindex, nofollow"
 
     def test_closed_page_has_noindex_header(self, client: FlaskClient) -> None:
-        """GET /registration-closed includes X-Robots-Tag: noindex."""
+        """GET /registration-closed includes X-Robots-Tag: noindex, nofollow."""
         response = client.get("/registration-closed")
 
-        assert response.headers.get("X-Robots-Tag") == "noindex"
+        assert response.headers.get("X-Robots-Tag") == "noindex, nofollow"
+
+    def test_form_page_has_robots_meta_tag(self, client: FlaskClient, fake_store, admin_user: User) -> None:
+        """The rendered form carries the matching meta tag as a second layer."""
+        page = _seed_published_page(fake_store, admin_user)
+
+        response = client.get(f"/register/{page.url_slug}")
+
+        assert '<meta name="robots" content="noindex, nofollow">' in response.get_data(as_text=True)
+
+    def test_closed_page_has_robots_meta_tag(self, client: FlaskClient) -> None:
+        """The closed page carries the matching meta tag as a second layer."""
+        response = client.get("/registration-closed")
+
+        assert '<meta name="robots" content="noindex, nofollow">' in response.get_data(as_text=True)

--- a/backend/tests/e2e/test_registration_stepper_journey.py
+++ b/backend/tests/e2e/test_registration_stepper_journey.py
@@ -76,16 +76,16 @@ def test_admin_walks_form_email_preview_and_publishes(logged_in_admin, admin_use
     assembly_id = _seed_assembly_with_required_email(postgres_session_factory, admin_user.id)
 
     # Step 0: create the registration page. Route seeds a default email template
-    # as a side effect (unassigned — the switch defaults to OFF).
+    # as a side effect and assigns it — the auto-reply is always-on.
     response = logged_in_admin.post(f"/backoffice/assembly/{assembly_id}/registration/create")
     assert response.status_code == 302
 
     with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
         page = uow.registration_pages.get_by_assembly_id(assembly_id)
         assert page is not None, "page should have been created"
-        assert page.auto_reply_email_template_id is None, "seeded template starts unassigned"
         seeded = uow.email_templates.list_by_assembly(assembly_id)
         assert len(seeded) == 1, "creation should seed exactly one default template"
+        assert page.auto_reply_email_template_id == seeded[0].id, "seeded template is assigned (always-on)"
 
     # Step 1: save the form HTML with save_and_next. Redirects to the email section.
     response = logged_in_admin.post(
@@ -100,15 +100,8 @@ def test_admin_walks_form_email_preview_and_publishes(logged_in_admin, admin_use
         html = uow.registration_page_html_sources.get_by_page_id(page.id).create_detached_copy()
     assert "Email" in html.form_html
 
-    # Step 2: enable the auto-reply and save updated copy with save_and_next.
-    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
-        template = uow.email_templates.list_by_assembly(assembly_id)[0].create_detached_copy()
-    response = logged_in_admin.post(
-        f"/backoffice/assembly/{assembly_id}/registration/email/save",
-        data={"action": "enable", "template_id": str(template.id)},
-    )
-    assert response.status_code == 302
-
+    # Step 2: save updated auto-reply copy with save_and_next (it is already
+    # assigned and always-on — there is no enable step).
     response = logged_in_admin.post(
         f"/backoffice/assembly/{assembly_id}/registration/email/save",
         data={

--- a/backend/tests/unit/test_floating_alerts.py
+++ b/backend/tests/unit/test_floating_alerts.py
@@ -132,10 +132,12 @@ class TestFloatingAlertsMacro:
         assert "Please review settings" in html
 
     def test_floating_alerts_has_fixed_positioning(self) -> None:
+        """Alerts float at the top-center of the viewport."""
         html = _render_floating_alerts_with_flash([("info", "Test")])
         assert "fixed" in html
-        assert "bottom-6" in html
-        assert "right-6" in html
+        assert "top-6" in html
+        assert "left-1/2" in html
+        assert "-translate-x-1/2" in html
 
     def test_floating_alerts_has_z_index(self) -> None:
         html = _render_floating_alerts_with_flash([("info", "Test")])

--- a/backend/tests/unit/test_stepper_macro.py
+++ b/backend/tests/unit/test_stepper_macro.py
@@ -83,6 +83,14 @@ class TestStepperAriaByMode:
         )
         assert 'aria-disabled="true"' in html
 
+    def test_fully_disabled_tabs_still_mark_the_selected_tab(self):
+        # A tablist must always have a selected tab, even while the whole stepper
+        # is locked (edit mode): the visible panel's aria-labelledby points at it.
+        html = _render(f'{{{{ stepper(id="s", aria_label="Steps", mode="tabs", disabled=true, {_TABS_ITEMS}) }}}}')
+        assert 'aria-disabled="true"' in html
+        assert 'aria-selected="true"' in html
+        assert 'aria-selected="false"' in html
+
 
 class TestStepperExtraAttrsEscaping:
     """Pass-through attribute values must be HTML-escaped, because the macro joins

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-21 13:31+0200\n"
+"POT-Creation-Date: 2026-07-22 08:35+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1047,7 +1047,7 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:168
 #: src/opendlp/entrypoints/blueprints/backoffice.py:430
 #: src/opendlp/entrypoints/blueprints/backoffice.py:485
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:200
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:198
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:82
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:94
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:129
@@ -1086,15 +1086,15 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:325
 #: src/opendlp/entrypoints/blueprints/backoffice.py:421
 #: src/opendlp/entrypoints/blueprints/backoffice.py:476
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:206
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:317
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:528
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:585
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:609
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:661
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:722
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:749
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:773
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:204
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:315
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:525
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:583
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:607
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:702
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:763
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:790
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:814
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:407
@@ -1253,92 +1253,92 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:102
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:103
 #, fuzzy, python-format
 msgid "Details for %(name)s"
 msgstr "Hiba részletei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:103
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:104
 #, python-format
 msgid "Copy <img> snippet for %(name)s"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:104
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:105
 #, fuzzy, python-format
 msgid "Delete %(name)s"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:212
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:210
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:223
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:221
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:224
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:222
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:227
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:225
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:230
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:228
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:233
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:231
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:236
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:234
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:237
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:235
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:302
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:522
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:718
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:300
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:519
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:759
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:311
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:525
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:582
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:720
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:747
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:771
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:309
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:522
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:580
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:761
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:788
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:812
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:327
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:325
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:396
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:392
 #, fuzzy
 msgid "Registration auto-reply"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:397
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:393
 msgid "Thanks for registering for {{ assembly.title }}"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:399
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:395
 msgid ""
 "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
 "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
@@ -1347,111 +1347,97 @@ msgid ""
 "<p>Best wishes,<br>The team</p>"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:426
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:422
 msgid "Auto-reply email created. Edit it below and click Save."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:432
-msgid "Please set up the auto-reply email first."
-msgstr ""
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:435
-msgid ""
-"Auto-reply enabled. Respondents will now receive this email after "
-"registering."
-msgstr ""
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:441
-msgid "Auto-reply disabled. Respondents will no longer receive this email."
-msgstr ""
-
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:449
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:434
 msgid "There is no auto-reply email to save yet — set one up first."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:461
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:451
 msgid "Auto-reply email saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:519
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:516
 msgid "The auto-reply email could not be found."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:537
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:534
 #, fuzzy
 msgid "An error occurred while saving the auto-reply email"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:577
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:575
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:590
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:588
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:594
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:592
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:607
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:655
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:605
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:696
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:612
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:610
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:665
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:706
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:692
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:733
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:698
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:739
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:702
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:737
-#: templates/backoffice/assembly_registration.html:1169
-#: templates/backoffice/assembly_registration.html:1308
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:743
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:778
+#: templates/backoffice/assembly_registration.html:1187
+#: templates/backoffice/assembly_registration.html:1326
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:725
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:766
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:743
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:767
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:784
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:808
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:745
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:769
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:786
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:810
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:752
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:793
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:776
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:817
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -3364,9 +3350,9 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
 #: templates/backoffice/assembly_registration.html:158
-#: templates/backoffice/assembly_registration.html:405
-#: templates/backoffice/assembly_registration.html:766
-#: templates/backoffice/assembly_registration.html:927
+#: templates/backoffice/assembly_registration.html:393
+#: templates/backoffice/assembly_registration.html:787
+#: templates/backoffice/assembly_registration.html:948
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:40
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -3408,7 +3394,7 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:548
+#: templates/backoffice/assembly_registration.html:565
 #: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Registration URL"
@@ -3744,7 +3730,7 @@ msgstr "Módosítsa a számot."
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
 #: templates/backoffice/assembly_edit_respondent.html:21
 #: templates/backoffice/assembly_registration.html:161
-#: templates/backoffice/assembly_registration.html:408
+#: templates/backoffice/assembly_registration.html:396
 #: templates/backoffice/assembly_respondents.html:148
 #: templates/backoffice/assembly_selection.html:81
 #: templates/backoffice/assembly_selection.html:299
@@ -4507,7 +4493,7 @@ msgstr ""
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
 #: templates/backoffice/assembly_registration.html:209
-#: templates/backoffice/assembly_registration.html:767
+#: templates/backoffice/assembly_registration.html:788
 msgid "Upload"
 msgstr ""
 
@@ -4620,46 +4606,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:549
+#: templates/backoffice/assembly_registration.html:566
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:556
+#: templates/backoffice/assembly_registration.html:573
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:557
+#: templates/backoffice/assembly_registration.html:574
 #: templates/backoffice/edit_assembly.html:112
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:565
+#: templates/backoffice/assembly_registration.html:583
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:567
+#: templates/backoffice/assembly_registration.html:585
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:573
+#: templates/backoffice/assembly_registration.html:591
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:585
+#: templates/backoffice/assembly_registration.html:603
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:588
+#: templates/backoffice/assembly_registration.html:606
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4813,14 +4799,13 @@ msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_registration.html:75
-#: templates/backoffice/assembly_registration.html:336
+#: templates/backoffice/assembly_registration.html:337
 #: templates/backoffice/patterns/_stepper.html:29
 #, fuzzy
 msgid "Auto-reply email"
 msgstr "Hiba részletei"
 
 #: templates/backoffice/assembly_registration.html:76
-#: templates/backoffice/assembly_registration.html:539
 #: templates/backoffice/patterns/_stepper.html:30
 #, fuzzy
 msgid "Preview and publish"
@@ -4861,7 +4846,7 @@ msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
 #: templates/backoffice/assembly_registration.html:126
-#: templates/backoffice/assembly_registration.html:406
+#: templates/backoffice/assembly_registration.html:394
 #: templates/backoffice/components/edit_number_to_select_modal.html:41
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4905,139 +4890,159 @@ msgstr ""
 msgid "No images uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:296
-#: templates/backoffice/assembly_registration.html:518
+#: templates/backoffice/assembly_registration.html:297
+#: templates/backoffice/assembly_registration.html:507
 msgid "Editing in progress — save or cancel to continue"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:298
-#: templates/backoffice/assembly_registration.html:300
-#: templates/backoffice/assembly_registration.html:353
-#: templates/backoffice/assembly_registration.html:521
-#: templates/backoffice/assembly_registration.html:524
+#: templates/backoffice/assembly_registration.html:299
+#: templates/backoffice/assembly_registration.html:301
+#: templates/backoffice/assembly_registration.html:355
+#: templates/backoffice/assembly_registration.html:510
+#: templates/backoffice/assembly_registration.html:513
 #, fuzzy
 msgid "Next →"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:325
+#: templates/backoffice/assembly_registration.html:326
 #, fuzzy
 msgid "Auto-reply cannot be sent"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:325
+#: templates/backoffice/assembly_registration.html:326
 msgid "Heads up"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:339
+#: templates/backoffice/assembly_registration.html:340
 msgid ""
 "Automatically send a confirmation email to people after they register. "
 "Templates support variables like the respondent's first name and the "
 "assembly title."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:344
+#: templates/backoffice/assembly_registration.html:345
 msgid "Set up auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:352
-#: templates/backoffice/assembly_registration.html:516
-#: templates/backoffice/assembly_registration.html:523
-#: templates/backoffice/assembly_registration.html:604
+#: templates/backoffice/assembly_registration.html:354
+#: templates/backoffice/assembly_registration.html:505
+#: templates/backoffice/assembly_registration.html:512
+#: templates/backoffice/assembly_registration.html:625
 msgid "← Back"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:389
+#: templates/backoffice/assembly_registration.html:376
 msgid "Auto-reply email template"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:400
+#: templates/backoffice/assembly_registration.html:388
 msgid "Send auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:421
+#: templates/backoffice/assembly_registration.html:409
 msgid "Email subject"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:423
+#: templates/backoffice/assembly_registration.html:411
 msgid "Jinja variables allowed, e.g. {{ assembly.title }}."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:433
+#: templates/backoffice/assembly_registration.html:421
 msgid "HTML body"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:435
+#: templates/backoffice/assembly_registration.html:423
 msgid ""
 "Jinja + HTML. A plain-text version is generated automatically for email "
 "clients that need it."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:456
+#: templates/backoffice/assembly_registration.html:444
 #, fuzzy
 msgid "Available variables"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:459
+#: templates/backoffice/assembly_registration.html:447
 msgid ""
 "Click a variable to select it, then copy and paste into the subject or "
 "body. Missing values render as an empty string."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:462
+#: templates/backoffice/assembly_registration.html:450
 #, fuzzy
 msgid "Assembly title"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/assembly_registration.html:463
+#: templates/backoffice/assembly_registration.html:451
 #, fuzzy
 msgid "Assembly question"
 msgstr "A gyűlés fő témája"
 
-#: templates/backoffice/assembly_registration.html:464
+#: templates/backoffice/assembly_registration.html:452
 #, fuzzy
 msgid "First assembly date (ISO)"
 msgstr "Első gyűlés időpontja"
 
-#: templates/backoffice/assembly_registration.html:465
+#: templates/backoffice/assembly_registration.html:453
 #, fuzzy
 msgid "Respondent first name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:466
+#: templates/backoffice/assembly_registration.html:454
 msgid "First name, or 'Friend' as a fallback"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:467
+#: templates/backoffice/assembly_registration.html:455
 #, fuzzy
 msgid "Respondent full name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:468
+#: templates/backoffice/assembly_registration.html:456
 #, fuzzy
 msgid "Respondent email address"
 msgstr "Email cím hiányzik"
 
-#: templates/backoffice/assembly_registration.html:491
+#: templates/backoffice/assembly_registration.html:479
 msgid "Variable copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:495
+#: templates/backoffice/assembly_registration.html:483
 #, python-format
 msgid "Copy %(label)s variable"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:612
+#: templates/backoffice/assembly_registration.html:532
+msgid "Form preview"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:535
+msgid ""
+"This is the last saved version of your registration form, shown exactly "
+"as visitors will see it. You can try the fields and dropdowns, but the "
+"form cannot be submitted from here."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:544
+#, fuzzy
+msgid "Registration form preview"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/assembly_registration.html:558
+msgid "Share your form"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:633
 msgid "Publish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:641
+#: templates/backoffice/assembly_registration.html:662
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:647
-#: templates/backoffice/assembly_registration.html:710
-#: templates/backoffice/assembly_registration.html:801
+#: templates/backoffice/assembly_registration.html:668
+#: templates/backoffice/assembly_registration.html:731
+#: templates/backoffice/assembly_registration.html:822
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:54
@@ -5048,202 +5053,202 @@ msgstr "Rétegzett kiválasztás"
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:656
+#: templates/backoffice/assembly_registration.html:677
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:660
+#: templates/backoffice/assembly_registration.html:681
 msgid "Form skeleton preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:676
+#: templates/backoffice/assembly_registration.html:697
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:703
+#: templates/backoffice/assembly_registration.html:724
 #, fuzzy
 msgid "Upload image"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:719
+#: templates/backoffice/assembly_registration.html:740
 #, python-format
 msgid ""
 "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
 "Files are downscaled and re-encoded to PNG on upload."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:725
+#: templates/backoffice/assembly_registration.html:746
 msgid "Image file"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:741
-#: templates/backoffice/assembly_registration.html:900
+#: templates/backoffice/assembly_registration.html:762
+#: templates/backoffice/assembly_registration.html:921
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:753
-#: templates/backoffice/assembly_registration.html:912
+#: templates/backoffice/assembly_registration.html:774
+#: templates/backoffice/assembly_registration.html:933
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:794
+#: templates/backoffice/assembly_registration.html:815
 #, fuzzy
 msgid "Image details"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:820
+#: templates/backoffice/assembly_registration.html:841
 msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:827
+#: templates/backoffice/assembly_registration.html:848
 msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:832
+#: templates/backoffice/assembly_registration.html:853
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:837
+#: templates/backoffice/assembly_registration.html:858
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:840
+#: templates/backoffice/assembly_registration.html:861
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:848
+#: templates/backoffice/assembly_registration.html:869
 #, fuzzy
 msgid "File name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:861
+#: templates/backoffice/assembly_registration.html:882
 msgid "File name copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:865
+#: templates/backoffice/assembly_registration.html:886
 #, fuzzy
 msgid "Copy file name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:876
+#: templates/backoffice/assembly_registration.html:897
 #, fuzzy
 msgid "Image snippet"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:890
+#: templates/backoffice/assembly_registration.html:911
 msgid "Copy image snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:925
+#: templates/backoffice/assembly_registration.html:946
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:928
+#: templates/backoffice/assembly_registration.html:949
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:960
+#: templates/backoffice/assembly_registration.html:981
 #, fuzzy
 msgid "Discard changes?"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:963
+#: templates/backoffice/assembly_registration.html:984
 msgid ""
 "You have unsaved changes. If you leave this page, your changes will be "
 "lost."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:966
+#: templates/backoffice/assembly_registration.html:987
 #, fuzzy
 msgid "Discard changes"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:967
+#: templates/backoffice/assembly_registration.html:988
 #, fuzzy
 msgid "Keep editing"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1118
+#: templates/backoffice/assembly_registration.html:1136
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:1129
-#: templates/backoffice/assembly_registration.html:1254
+#: templates/backoffice/assembly_registration.html:1147
+#: templates/backoffice/assembly_registration.html:1272
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1132
-#: templates/backoffice/assembly_registration.html:1242
-#: templates/backoffice/assembly_registration.html:1255
+#: templates/backoffice/assembly_registration.html:1150
+#: templates/backoffice/assembly_registration.html:1260
+#: templates/backoffice/assembly_registration.html:1273
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1187
+#: templates/backoffice/assembly_registration.html:1205
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1198
+#: templates/backoffice/assembly_registration.html:1216
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1201
+#: templates/backoffice/assembly_registration.html:1219
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1210
+#: templates/backoffice/assembly_registration.html:1228
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1221
-#: templates/backoffice/assembly_registration.html:1287
+#: templates/backoffice/assembly_registration.html:1239
+#: templates/backoffice/assembly_registration.html:1305
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1225
-#: templates/backoffice/assembly_registration.html:1294
+#: templates/backoffice/assembly_registration.html:1243
+#: templates/backoffice/assembly_registration.html:1312
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1228
-#: templates/backoffice/assembly_registration.html:1297
+#: templates/backoffice/assembly_registration.html:1246
+#: templates/backoffice/assembly_registration.html:1315
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1237
+#: templates/backoffice/assembly_registration.html:1255
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1241
+#: templates/backoffice/assembly_registration.html:1259
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1324
+#: templates/backoffice/assembly_registration.html:1342
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1332
+#: templates/backoffice/assembly_registration.html:1350
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1335
+#: templates/backoffice/assembly_registration.html:1353
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -13746,4 +13751,15 @@ msgstr ""
 #~ "leave now they will be lost and"
 #~ " the last saved version will be "
 #~ "kept."
+#~ msgstr ""
+
+#~ msgid "Please set up the auto-reply email first."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Auto-reply enabled. Respondents will now"
+#~ " receive this email after registering."
+#~ msgstr ""
+
+#~ msgid "Auto-reply disabled. Respondents will no longer receive this email."
 #~ msgstr ""

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-22 08:35+0200\n"
+"POT-Creation-Date: 2026-07-22 13:54+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1087,14 +1087,14 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:421
 #: src/opendlp/entrypoints/blueprints/backoffice.py:476
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:204
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:315
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:525
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:583
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:607
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:702
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:763
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:790
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:814
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:323
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:533
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:591
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:615
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:710
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:771
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:798
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:822
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:407
@@ -1308,37 +1308,37 @@ msgstr "Vissza a regisztrációhoz"
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:300
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:519
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:759
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:308
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:527
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:767
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:309
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:522
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:580
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:761
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:788
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:812
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:317
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:530
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:588
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:769
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:796
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:820
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:325
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:333
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:392
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:400
 #, fuzzy
 msgid "Registration auto-reply"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:393
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:401
 msgid "Thanks for registering for {{ assembly.title }}"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:395
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:403
 msgid ""
 "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
 "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
@@ -1347,97 +1347,97 @@ msgid ""
 "<p>Best wishes,<br>The team</p>"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:422
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:430
 msgid "Auto-reply email created. Edit it below and click Save."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:434
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:442
 msgid "There is no auto-reply email to save yet — set one up first."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:451
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:459
 msgid "Auto-reply email saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:516
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:524
 msgid "The auto-reply email could not be found."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:534
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:542
 #, fuzzy
 msgid "An error occurred while saving the auto-reply email"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:575
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:583
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:588
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:596
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:592
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:600
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:605
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:696
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:613
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:704
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:610
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:618
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:706
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:714
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:733
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:741
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:739
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:747
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:743
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:778
-#: templates/backoffice/assembly_registration.html:1187
-#: templates/backoffice/assembly_registration.html:1326
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:751
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:786
+#: templates/backoffice/assembly_registration.html:1257
+#: templates/backoffice/assembly_registration.html:1396
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:766
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:774
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:784
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:808
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:792
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:816
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:786
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:810
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:794
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:818
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:793
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:801
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:817
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:825
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -3351,8 +3351,8 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_form.html:96
 #: templates/backoffice/assembly_registration.html:158
 #: templates/backoffice/assembly_registration.html:393
-#: templates/backoffice/assembly_registration.html:787
-#: templates/backoffice/assembly_registration.html:948
+#: templates/backoffice/assembly_registration.html:799
+#: templates/backoffice/assembly_registration.html:960
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:40
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -4493,7 +4493,7 @@ msgstr ""
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
 #: templates/backoffice/assembly_registration.html:209
-#: templates/backoffice/assembly_registration.html:788
+#: templates/backoffice/assembly_registration.html:800
 msgid "Upload"
 msgstr ""
 
@@ -4890,16 +4890,16 @@ msgstr ""
 msgid "No images uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:297
-#: templates/backoffice/assembly_registration.html:507
+#: templates/backoffice/assembly_registration.html:296
+#: templates/backoffice/assembly_registration.html:506
 msgid "Editing in progress — save or cancel to continue"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:299
-#: templates/backoffice/assembly_registration.html:301
-#: templates/backoffice/assembly_registration.html:355
-#: templates/backoffice/assembly_registration.html:510
-#: templates/backoffice/assembly_registration.html:513
+#: templates/backoffice/assembly_registration.html:298
+#: templates/backoffice/assembly_registration.html:300
+#: templates/backoffice/assembly_registration.html:354
+#: templates/backoffice/assembly_registration.html:509
+#: templates/backoffice/assembly_registration.html:512
 #, fuzzy
 msgid "Next →"
 msgstr "Kezdés dátuma"
@@ -4924,10 +4924,10 @@ msgstr ""
 msgid "Set up auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:354
-#: templates/backoffice/assembly_registration.html:505
-#: templates/backoffice/assembly_registration.html:512
-#: templates/backoffice/assembly_registration.html:625
+#: templates/backoffice/assembly_registration.html:353
+#: templates/backoffice/assembly_registration.html:504
+#: templates/backoffice/assembly_registration.html:511
+#: templates/backoffice/assembly_registration.html:626
 msgid "← Back"
 msgstr ""
 
@@ -5031,18 +5031,28 @@ msgstr "Vissza a regisztrációhoz"
 msgid "Share your form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:633
+#: templates/backoffice/assembly_registration.html:634
 msgid "Publish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:662
+#: templates/backoffice/assembly_registration.html:643
+msgid "Unpublish"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:645
+#: templates/backoffice/assembly_registration.html:1003
+#, fuzzy
+msgid "Close registration"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/assembly_registration.html:674
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:668
-#: templates/backoffice/assembly_registration.html:731
-#: templates/backoffice/assembly_registration.html:822
+#: templates/backoffice/assembly_registration.html:680
+#: templates/backoffice/assembly_registration.html:743
+#: templates/backoffice/assembly_registration.html:834
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:54
@@ -5053,202 +5063,219 @@ msgstr "Rétegzett kiválasztás"
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:677
+#: templates/backoffice/assembly_registration.html:689
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:681
+#: templates/backoffice/assembly_registration.html:693
 msgid "Form skeleton preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:697
+#: templates/backoffice/assembly_registration.html:709
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:724
+#: templates/backoffice/assembly_registration.html:736
 #, fuzzy
 msgid "Upload image"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:740
+#: templates/backoffice/assembly_registration.html:752
 #, python-format
 msgid ""
 "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
 "Files are downscaled and re-encoded to PNG on upload."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:746
+#: templates/backoffice/assembly_registration.html:758
 msgid "Image file"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:762
-#: templates/backoffice/assembly_registration.html:921
+#: templates/backoffice/assembly_registration.html:774
+#: templates/backoffice/assembly_registration.html:933
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:774
-#: templates/backoffice/assembly_registration.html:933
+#: templates/backoffice/assembly_registration.html:786
+#: templates/backoffice/assembly_registration.html:945
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:815
+#: templates/backoffice/assembly_registration.html:827
 #, fuzzy
 msgid "Image details"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:841
+#: templates/backoffice/assembly_registration.html:853
 msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:848
+#: templates/backoffice/assembly_registration.html:860
 msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:853
+#: templates/backoffice/assembly_registration.html:865
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:858
+#: templates/backoffice/assembly_registration.html:870
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:861
+#: templates/backoffice/assembly_registration.html:873
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:869
+#: templates/backoffice/assembly_registration.html:881
 #, fuzzy
 msgid "File name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:882
+#: templates/backoffice/assembly_registration.html:894
 msgid "File name copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:886
+#: templates/backoffice/assembly_registration.html:898
 #, fuzzy
 msgid "Copy file name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:897
+#: templates/backoffice/assembly_registration.html:909
 #, fuzzy
 msgid "Image snippet"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:911
+#: templates/backoffice/assembly_registration.html:923
 msgid "Copy image snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:946
+#: templates/backoffice/assembly_registration.html:958
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:949
+#: templates/backoffice/assembly_registration.html:961
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:981
+#: templates/backoffice/assembly_registration.html:991
+#, fuzzy
+msgid "Close registration?"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/assembly_registration.html:994
+msgid ""
+"This permanently stops new registrations. Visitors who follow the form "
+"link will see the 'registration closed' page, and the form cannot be "
+"reopened."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:1005
+#, fuzzy
+msgid "Keep it open"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/assembly_registration.html:1037
 #, fuzzy
 msgid "Discard changes?"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:984
+#: templates/backoffice/assembly_registration.html:1040
 msgid ""
 "You have unsaved changes. If you leave this page, your changes will be "
 "lost."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:987
+#: templates/backoffice/assembly_registration.html:1043
 #, fuzzy
 msgid "Discard changes"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:988
+#: templates/backoffice/assembly_registration.html:1044
 #, fuzzy
 msgid "Keep editing"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1136
+#: templates/backoffice/assembly_registration.html:1206
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:1147
-#: templates/backoffice/assembly_registration.html:1272
+#: templates/backoffice/assembly_registration.html:1217
+#: templates/backoffice/assembly_registration.html:1342
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1150
-#: templates/backoffice/assembly_registration.html:1260
-#: templates/backoffice/assembly_registration.html:1273
+#: templates/backoffice/assembly_registration.html:1220
+#: templates/backoffice/assembly_registration.html:1330
+#: templates/backoffice/assembly_registration.html:1343
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1205
+#: templates/backoffice/assembly_registration.html:1275
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1216
+#: templates/backoffice/assembly_registration.html:1286
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1219
+#: templates/backoffice/assembly_registration.html:1289
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1228
+#: templates/backoffice/assembly_registration.html:1298
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1239
-#: templates/backoffice/assembly_registration.html:1305
+#: templates/backoffice/assembly_registration.html:1309
+#: templates/backoffice/assembly_registration.html:1375
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1243
-#: templates/backoffice/assembly_registration.html:1312
+#: templates/backoffice/assembly_registration.html:1313
+#: templates/backoffice/assembly_registration.html:1382
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1246
-#: templates/backoffice/assembly_registration.html:1315
+#: templates/backoffice/assembly_registration.html:1316
+#: templates/backoffice/assembly_registration.html:1385
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1255
+#: templates/backoffice/assembly_registration.html:1325
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1259
+#: templates/backoffice/assembly_registration.html:1329
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1342
+#: templates/backoffice/assembly_registration.html:1412
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1350
+#: templates/backoffice/assembly_registration.html:1420
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1353
+#: templates/backoffice/assembly_registration.html:1423
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -10225,17 +10252,17 @@ msgstr ""
 msgid "Back to dashboard"
 msgstr "Vissza az irányító pulthoz"
 
-#: templates/register/closed.html:2 templates/register/closed.html:6
+#: templates/register/closed.html:3 templates/register/closed.html:7
 #, fuzzy
 msgid "Registration Closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/register/closed.html:7
+#: templates/register/closed.html:8
 #, fuzzy
 msgid "Sorry, registration for this event is now closed."
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/register/closed.html:8
+#: templates/register/closed.html:9
 msgid "If you have any questions, please contact the event organisers."
 msgstr ""
 

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-21 09:59+0200\n"
+"POT-Creation-Date: 2026-07-21 13:31+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1424,8 +1424,8 @@ msgstr ""
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:702
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:737
-#: templates/backoffice/assembly_registration.html:1165
-#: templates/backoffice/assembly_registration.html:1304
+#: templates/backoffice/assembly_registration.html:1169
+#: templates/backoffice/assembly_registration.html:1308
 msgid "Alt text is required for accessibility"
 msgstr ""
 
@@ -3363,10 +3363,10 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_data.html:508
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
-#: templates/backoffice/assembly_registration.html:155
-#: templates/backoffice/assembly_registration.html:400
-#: templates/backoffice/assembly_registration.html:761
-#: templates/backoffice/assembly_registration.html:922
+#: templates/backoffice/assembly_registration.html:158
+#: templates/backoffice/assembly_registration.html:405
+#: templates/backoffice/assembly_registration.html:766
+#: templates/backoffice/assembly_registration.html:927
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:40
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -3408,7 +3408,7 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:543
+#: templates/backoffice/assembly_registration.html:548
 #: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Registration URL"
@@ -3743,8 +3743,8 @@ msgstr "Módosítsa a számot."
 
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
 #: templates/backoffice/assembly_edit_respondent.html:21
-#: templates/backoffice/assembly_registration.html:158
-#: templates/backoffice/assembly_registration.html:403
+#: templates/backoffice/assembly_registration.html:161
+#: templates/backoffice/assembly_registration.html:408
 #: templates/backoffice/assembly_respondents.html:148
 #: templates/backoffice/assembly_selection.html:81
 #: templates/backoffice/assembly_selection.html:299
@@ -4506,8 +4506,8 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
-#: templates/backoffice/assembly_registration.html:206
-#: templates/backoffice/assembly_registration.html:762
+#: templates/backoffice/assembly_registration.html:209
+#: templates/backoffice/assembly_registration.html:767
 msgid "Upload"
 msgstr ""
 
@@ -4620,46 +4620,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:544
+#: templates/backoffice/assembly_registration.html:549
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:551
+#: templates/backoffice/assembly_registration.html:556
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:552
+#: templates/backoffice/assembly_registration.html:557
 #: templates/backoffice/edit_assembly.html:112
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:560
+#: templates/backoffice/assembly_registration.html:565
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:562
+#: templates/backoffice/assembly_registration.html:567
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:568
+#: templates/backoffice/assembly_registration.html:573
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:580
+#: templates/backoffice/assembly_registration.html:585
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:583
+#: templates/backoffice/assembly_registration.html:588
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4813,14 +4813,14 @@ msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_registration.html:75
-#: templates/backoffice/assembly_registration.html:333
+#: templates/backoffice/assembly_registration.html:336
 #: templates/backoffice/patterns/_stepper.html:29
 #, fuzzy
 msgid "Auto-reply email"
 msgstr "Hiba részletei"
 
 #: templates/backoffice/assembly_registration.html:76
-#: templates/backoffice/assembly_registration.html:534
+#: templates/backoffice/assembly_registration.html:539
 #: templates/backoffice/patterns/_stepper.html:30
 #, fuzzy
 msgid "Preview and publish"
@@ -4861,7 +4861,7 @@ msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
 #: templates/backoffice/assembly_registration.html:126
-#: templates/backoffice/assembly_registration.html:401
+#: templates/backoffice/assembly_registration.html:406
 #: templates/backoffice/components/edit_number_to_select_modal.html:41
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4879,165 +4879,165 @@ msgstr ""
 msgid "Registration Form HTML"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:149
+#: templates/backoffice/assembly_registration.html:152
 msgid "Show Form Skeleton"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:165
+#: templates/backoffice/assembly_registration.html:168
 msgid ""
 "Paste your HTML form code below. The only required placeholders are {{ "
 "form_action }} for the form's action attribute and {{ csrf_form_element "
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:199
+#: templates/backoffice/assembly_registration.html:202
 #, fuzzy
 msgid "Assets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:220
+#: templates/backoffice/assembly_registration.html:223
 #, python-format
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:227
+#: templates/backoffice/assembly_registration.html:230
 #, fuzzy
 msgid "No images uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:293
-#: templates/backoffice/assembly_registration.html:513
+#: templates/backoffice/assembly_registration.html:296
+#: templates/backoffice/assembly_registration.html:518
 msgid "Editing in progress — save or cancel to continue"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:295
-#: templates/backoffice/assembly_registration.html:297
-#: templates/backoffice/assembly_registration.html:350
-#: templates/backoffice/assembly_registration.html:516
-#: templates/backoffice/assembly_registration.html:519
+#: templates/backoffice/assembly_registration.html:298
+#: templates/backoffice/assembly_registration.html:300
+#: templates/backoffice/assembly_registration.html:353
+#: templates/backoffice/assembly_registration.html:521
+#: templates/backoffice/assembly_registration.html:524
 #, fuzzy
 msgid "Next →"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:322
+#: templates/backoffice/assembly_registration.html:325
 #, fuzzy
 msgid "Auto-reply cannot be sent"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:322
+#: templates/backoffice/assembly_registration.html:325
 msgid "Heads up"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:336
+#: templates/backoffice/assembly_registration.html:339
 msgid ""
 "Automatically send a confirmation email to people after they register. "
 "Templates support variables like the respondent's first name and the "
 "assembly title."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:341
+#: templates/backoffice/assembly_registration.html:344
 msgid "Set up auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:349
-#: templates/backoffice/assembly_registration.html:511
-#: templates/backoffice/assembly_registration.html:518
-#: templates/backoffice/assembly_registration.html:599
+#: templates/backoffice/assembly_registration.html:352
+#: templates/backoffice/assembly_registration.html:516
+#: templates/backoffice/assembly_registration.html:523
+#: templates/backoffice/assembly_registration.html:604
 msgid "← Back"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:386
+#: templates/backoffice/assembly_registration.html:389
 msgid "Auto-reply email template"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:395
+#: templates/backoffice/assembly_registration.html:400
 msgid "Send auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:416
+#: templates/backoffice/assembly_registration.html:421
 msgid "Email subject"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:418
+#: templates/backoffice/assembly_registration.html:423
 msgid "Jinja variables allowed, e.g. {{ assembly.title }}."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:428
+#: templates/backoffice/assembly_registration.html:433
 msgid "HTML body"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:430
+#: templates/backoffice/assembly_registration.html:435
 msgid ""
 "Jinja + HTML. A plain-text version is generated automatically for email "
 "clients that need it."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:451
+#: templates/backoffice/assembly_registration.html:456
 #, fuzzy
 msgid "Available variables"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:454
+#: templates/backoffice/assembly_registration.html:459
 msgid ""
 "Click a variable to select it, then copy and paste into the subject or "
 "body. Missing values render as an empty string."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:457
+#: templates/backoffice/assembly_registration.html:462
 #, fuzzy
 msgid "Assembly title"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/assembly_registration.html:458
+#: templates/backoffice/assembly_registration.html:463
 #, fuzzy
 msgid "Assembly question"
 msgstr "A gyűlés fő témája"
 
-#: templates/backoffice/assembly_registration.html:459
+#: templates/backoffice/assembly_registration.html:464
 #, fuzzy
 msgid "First assembly date (ISO)"
 msgstr "Első gyűlés időpontja"
 
-#: templates/backoffice/assembly_registration.html:460
+#: templates/backoffice/assembly_registration.html:465
 #, fuzzy
 msgid "Respondent first name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:461
+#: templates/backoffice/assembly_registration.html:466
 msgid "First name, or 'Friend' as a fallback"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:462
+#: templates/backoffice/assembly_registration.html:467
 #, fuzzy
 msgid "Respondent full name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:463
+#: templates/backoffice/assembly_registration.html:468
 #, fuzzy
 msgid "Respondent email address"
 msgstr "Email cím hiányzik"
 
-#: templates/backoffice/assembly_registration.html:486
+#: templates/backoffice/assembly_registration.html:491
 msgid "Variable copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:490
+#: templates/backoffice/assembly_registration.html:495
 #, python-format
 msgid "Copy %(label)s variable"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:607
+#: templates/backoffice/assembly_registration.html:612
 msgid "Publish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:636
+#: templates/backoffice/assembly_registration.html:641
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:642
-#: templates/backoffice/assembly_registration.html:705
-#: templates/backoffice/assembly_registration.html:796
+#: templates/backoffice/assembly_registration.html:647
+#: templates/backoffice/assembly_registration.html:710
+#: templates/backoffice/assembly_registration.html:801
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:54
@@ -5048,202 +5048,202 @@ msgstr "Rétegzett kiválasztás"
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:651
+#: templates/backoffice/assembly_registration.html:656
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:655
+#: templates/backoffice/assembly_registration.html:660
 msgid "Form skeleton preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:671
+#: templates/backoffice/assembly_registration.html:676
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:698
+#: templates/backoffice/assembly_registration.html:703
 #, fuzzy
 msgid "Upload image"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:714
+#: templates/backoffice/assembly_registration.html:719
 #, python-format
 msgid ""
 "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
 "Files are downscaled and re-encoded to PNG on upload."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:720
+#: templates/backoffice/assembly_registration.html:725
 msgid "Image file"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:736
-#: templates/backoffice/assembly_registration.html:895
+#: templates/backoffice/assembly_registration.html:741
+#: templates/backoffice/assembly_registration.html:900
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:748
-#: templates/backoffice/assembly_registration.html:907
+#: templates/backoffice/assembly_registration.html:753
+#: templates/backoffice/assembly_registration.html:912
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:789
+#: templates/backoffice/assembly_registration.html:794
 #, fuzzy
 msgid "Image details"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:815
+#: templates/backoffice/assembly_registration.html:820
 msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:822
+#: templates/backoffice/assembly_registration.html:827
 msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:827
+#: templates/backoffice/assembly_registration.html:832
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:832
+#: templates/backoffice/assembly_registration.html:837
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:835
+#: templates/backoffice/assembly_registration.html:840
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:843
+#: templates/backoffice/assembly_registration.html:848
 #, fuzzy
 msgid "File name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:856
+#: templates/backoffice/assembly_registration.html:861
 msgid "File name copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:860
+#: templates/backoffice/assembly_registration.html:865
 #, fuzzy
 msgid "Copy file name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:871
+#: templates/backoffice/assembly_registration.html:876
 #, fuzzy
 msgid "Image snippet"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:885
+#: templates/backoffice/assembly_registration.html:890
 msgid "Copy image snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:920
+#: templates/backoffice/assembly_registration.html:925
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:923
+#: templates/backoffice/assembly_registration.html:928
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:952
+#: templates/backoffice/assembly_registration.html:960
 #, fuzzy
-msgid "Discard your changes?"
-msgstr "ID (azonosító) oszlop"
-
-#: templates/backoffice/assembly_registration.html:957
-msgid ""
-"You have unsaved changes. If you leave now they will be lost and the last"
-" saved version will be kept."
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:962
-#, fuzzy
-msgid "Keep editing"
-msgstr "Kieső emberek pótlása új kiválasztással"
+msgid "Discard changes?"
+msgstr "Módosítások mentése"
 
 #: templates/backoffice/assembly_registration.html:963
+msgid ""
+"You have unsaved changes. If you leave this page, your changes will be "
+"lost."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:966
 #, fuzzy
 msgid "Discard changes"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1114
+#: templates/backoffice/assembly_registration.html:967
+#, fuzzy
+msgid "Keep editing"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/assembly_registration.html:1118
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:1125
-#: templates/backoffice/assembly_registration.html:1250
+#: templates/backoffice/assembly_registration.html:1129
+#: templates/backoffice/assembly_registration.html:1254
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1128
-#: templates/backoffice/assembly_registration.html:1238
-#: templates/backoffice/assembly_registration.html:1251
+#: templates/backoffice/assembly_registration.html:1132
+#: templates/backoffice/assembly_registration.html:1242
+#: templates/backoffice/assembly_registration.html:1255
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1183
+#: templates/backoffice/assembly_registration.html:1187
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1194
+#: templates/backoffice/assembly_registration.html:1198
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1197
+#: templates/backoffice/assembly_registration.html:1201
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1206
+#: templates/backoffice/assembly_registration.html:1210
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1217
-#: templates/backoffice/assembly_registration.html:1283
+#: templates/backoffice/assembly_registration.html:1221
+#: templates/backoffice/assembly_registration.html:1287
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1221
-#: templates/backoffice/assembly_registration.html:1290
+#: templates/backoffice/assembly_registration.html:1225
+#: templates/backoffice/assembly_registration.html:1294
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1224
-#: templates/backoffice/assembly_registration.html:1293
+#: templates/backoffice/assembly_registration.html:1228
+#: templates/backoffice/assembly_registration.html:1297
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1233
+#: templates/backoffice/assembly_registration.html:1237
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1237
+#: templates/backoffice/assembly_registration.html:1241
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1320
+#: templates/backoffice/assembly_registration.html:1324
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1328
+#: templates/backoffice/assembly_registration.html:1332
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1331
+#: templates/backoffice/assembly_registration.html:1335
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -13736,4 +13736,14 @@ msgstr ""
 #~ "Submissions made via these URLs are "
 #~ "recorded as test submissions and will"
 #~ " not enter the selection pool."
+#~ msgstr ""
+
+#~ msgid "Discard your changes?"
+#~ msgstr "ID (azonosító) oszlop"
+
+#~ msgid ""
+#~ "You have unsaved changes. If you "
+#~ "leave now they will be lost and"
+#~ " the last saved version will be "
+#~ "kept."
 #~ msgstr ""

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-22 13:54+0200\n"
+"POT-Creation-Date: 2026-07-23 10:13+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1087,14 +1087,14 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:421
 #: src/opendlp/entrypoints/blueprints/backoffice.py:476
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:204
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:323
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:533
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:591
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:615
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:710
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:771
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:798
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:822
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:327
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:537
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:595
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:619
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:714
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:775
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:802
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:826
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:407
@@ -1308,37 +1308,37 @@ msgstr "Vissza a regisztrációhoz"
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:308
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:527
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:767
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:312
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:531
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:771
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:317
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:530
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:588
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:769
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:796
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:820
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:321
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:534
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:592
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:773
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:800
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:824
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:333
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:337
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:400
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:404
 #, fuzzy
 msgid "Registration auto-reply"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:401
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:405
 msgid "Thanks for registering for {{ assembly.title }}"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:403
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:407
 msgid ""
 "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
 "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
@@ -1347,97 +1347,97 @@ msgid ""
 "<p>Best wishes,<br>The team</p>"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:430
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:434
 msgid "Auto-reply email created. Edit it below and click Save."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:442
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:446
 msgid "There is no auto-reply email to save yet — set one up first."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:459
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:463
 msgid "Auto-reply email saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:524
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:528
 msgid "The auto-reply email could not be found."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:542
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:546
 #, fuzzy
 msgid "An error occurred while saving the auto-reply email"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:583
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:587
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:596
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:600
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:600
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:604
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:613
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:704
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:617
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:708
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:618
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:622
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:714
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:718
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:741
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:745
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:747
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:751
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:751
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:786
-#: templates/backoffice/assembly_registration.html:1257
-#: templates/backoffice/assembly_registration.html:1396
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:755
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:790
+#: templates/backoffice/assembly_registration.html:1254
+#: templates/backoffice/assembly_registration.html:1393
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:774
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:778
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:792
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:816
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:796
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:820
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:794
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:818
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:798
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:822
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:801
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:805
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:825
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:829
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -3349,10 +3349,10 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_data.html:508
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
-#: templates/backoffice/assembly_registration.html:158
-#: templates/backoffice/assembly_registration.html:393
-#: templates/backoffice/assembly_registration.html:799
-#: templates/backoffice/assembly_registration.html:960
+#: templates/backoffice/assembly_registration.html:160
+#: templates/backoffice/assembly_registration.html:395
+#: templates/backoffice/assembly_registration.html:801
+#: templates/backoffice/assembly_registration.html:962
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:40
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -3394,7 +3394,7 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:565
+#: templates/backoffice/assembly_registration.html:567
 #: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Registration URL"
@@ -3580,6 +3580,7 @@ msgstr ""
 #: templates/backoffice/patterns/_scroll.html:212
 #: templates/backoffice/patterns/_stepper.html:38
 #: templates/backoffice/patterns/_stepper.html:76
+#: templates/backoffice/patterns/_stepper.html:112
 msgid "Code"
 msgstr ""
 
@@ -3729,8 +3730,8 @@ msgstr "Módosítsa a számot."
 
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
 #: templates/backoffice/assembly_edit_respondent.html:21
-#: templates/backoffice/assembly_registration.html:161
-#: templates/backoffice/assembly_registration.html:396
+#: templates/backoffice/assembly_registration.html:163
+#: templates/backoffice/assembly_registration.html:398
 #: templates/backoffice/assembly_respondents.html:148
 #: templates/backoffice/assembly_selection.html:81
 #: templates/backoffice/assembly_selection.html:299
@@ -4492,8 +4493,8 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
-#: templates/backoffice/assembly_registration.html:209
-#: templates/backoffice/assembly_registration.html:800
+#: templates/backoffice/assembly_registration.html:211
+#: templates/backoffice/assembly_registration.html:802
 msgid "Upload"
 msgstr ""
 
@@ -4606,46 +4607,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:566
+#: templates/backoffice/assembly_registration.html:568
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:573
+#: templates/backoffice/assembly_registration.html:575
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:574
+#: templates/backoffice/assembly_registration.html:576
 #: templates/backoffice/edit_assembly.html:112
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:583
+#: templates/backoffice/assembly_registration.html:585
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:585
+#: templates/backoffice/assembly_registration.html:587
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:591
+#: templates/backoffice/assembly_registration.html:593
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:603
+#: templates/backoffice/assembly_registration.html:605
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:606
+#: templates/backoffice/assembly_registration.html:608
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4792,61 +4793,64 @@ msgstr ""
 msgid "Go to Details tab"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_registration.html:74
+#: templates/backoffice/assembly_registration.html:75
 #: templates/backoffice/patterns/_stepper.html:28
+#: templates/backoffice/patterns/_stepper.html:102
 #, fuzzy
 msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:75
-#: templates/backoffice/assembly_registration.html:337
+#: templates/backoffice/assembly_registration.html:76
+#: templates/backoffice/assembly_registration.html:339
 #: templates/backoffice/patterns/_stepper.html:29
+#: templates/backoffice/patterns/_stepper.html:103
 #, fuzzy
 msgid "Auto-reply email"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/assembly_registration.html:76
+#: templates/backoffice/assembly_registration.html:77
 #: templates/backoffice/patterns/_stepper.html:30
+#: templates/backoffice/patterns/_stepper.html:104
 #, fuzzy
 msgid "Preview and publish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:78
+#: templates/backoffice/assembly_registration.html:79
 #, fuzzy
 msgid "Registration setup steps"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:90
+#: templates/backoffice/assembly_registration.html:92
 #, fuzzy
 msgid "Test mode"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:91
+#: templates/backoffice/assembly_registration.html:93
 msgid ""
 "Submissions are recorded as test entries and don't enter the selection "
 "pool. Publish the registration when you're ready to go live."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:99
+#: templates/backoffice/assembly_registration.html:101
 #, fuzzy
 msgid "Registration closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:100
+#: templates/backoffice/assembly_registration.html:102
 msgid "Visitors who follow the form URL are redirected to the closed page."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:108
+#: templates/backoffice/assembly_registration.html:110
 msgid "Published"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:126
+#: templates/backoffice/assembly_registration.html:128
 #, fuzzy
 msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:126
-#: templates/backoffice/assembly_registration.html:394
+#: templates/backoffice/assembly_registration.html:128
+#: templates/backoffice/assembly_registration.html:396
 #: templates/backoffice/components/edit_number_to_select_modal.html:41
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4859,200 +4863,200 @@ msgstr "Módosítások mentése"
 msgid "Save"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:138
+#: templates/backoffice/assembly_registration.html:140
 #, fuzzy
 msgid "Registration Form HTML"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:152
+#: templates/backoffice/assembly_registration.html:154
 msgid "Show Form Skeleton"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:168
+#: templates/backoffice/assembly_registration.html:170
 msgid ""
 "Paste your HTML form code below. The only required placeholders are {{ "
 "form_action }} for the form's action attribute and {{ csrf_form_element "
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:202
+#: templates/backoffice/assembly_registration.html:204
 #, fuzzy
 msgid "Assets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:223
+#: templates/backoffice/assembly_registration.html:225
 #, python-format
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:230
+#: templates/backoffice/assembly_registration.html:232
 #, fuzzy
 msgid "No images uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:296
-#: templates/backoffice/assembly_registration.html:506
+#: templates/backoffice/assembly_registration.html:298
+#: templates/backoffice/assembly_registration.html:508
 msgid "Editing in progress — save or cancel to continue"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:298
 #: templates/backoffice/assembly_registration.html:300
-#: templates/backoffice/assembly_registration.html:354
-#: templates/backoffice/assembly_registration.html:509
-#: templates/backoffice/assembly_registration.html:512
+#: templates/backoffice/assembly_registration.html:302
+#: templates/backoffice/assembly_registration.html:356
+#: templates/backoffice/assembly_registration.html:511
+#: templates/backoffice/assembly_registration.html:514
 #, fuzzy
 msgid "Next →"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:326
+#: templates/backoffice/assembly_registration.html:328
 #, fuzzy
 msgid "Auto-reply cannot be sent"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:326
+#: templates/backoffice/assembly_registration.html:328
 msgid "Heads up"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:340
+#: templates/backoffice/assembly_registration.html:342
 msgid ""
 "Automatically send a confirmation email to people after they register. "
 "Templates support variables like the respondent's first name and the "
 "assembly title."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:345
+#: templates/backoffice/assembly_registration.html:347
 msgid "Set up auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:353
-#: templates/backoffice/assembly_registration.html:504
-#: templates/backoffice/assembly_registration.html:511
-#: templates/backoffice/assembly_registration.html:626
+#: templates/backoffice/assembly_registration.html:355
+#: templates/backoffice/assembly_registration.html:506
+#: templates/backoffice/assembly_registration.html:513
+#: templates/backoffice/assembly_registration.html:628
 msgid "← Back"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:376
+#: templates/backoffice/assembly_registration.html:378
 msgid "Auto-reply email template"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:388
+#: templates/backoffice/assembly_registration.html:390
 msgid "Send auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:409
+#: templates/backoffice/assembly_registration.html:411
 msgid "Email subject"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:411
+#: templates/backoffice/assembly_registration.html:413
 msgid "Jinja variables allowed, e.g. {{ assembly.title }}."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:421
+#: templates/backoffice/assembly_registration.html:423
 msgid "HTML body"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:423
+#: templates/backoffice/assembly_registration.html:425
 msgid ""
 "Jinja + HTML. A plain-text version is generated automatically for email "
 "clients that need it."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:444
+#: templates/backoffice/assembly_registration.html:446
 #, fuzzy
 msgid "Available variables"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:447
+#: templates/backoffice/assembly_registration.html:449
 msgid ""
 "Click a variable to select it, then copy and paste into the subject or "
 "body. Missing values render as an empty string."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:450
+#: templates/backoffice/assembly_registration.html:452
 #, fuzzy
 msgid "Assembly title"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/assembly_registration.html:451
+#: templates/backoffice/assembly_registration.html:453
 #, fuzzy
 msgid "Assembly question"
 msgstr "A gyűlés fő témája"
 
-#: templates/backoffice/assembly_registration.html:452
+#: templates/backoffice/assembly_registration.html:454
 #, fuzzy
 msgid "First assembly date (ISO)"
 msgstr "Első gyűlés időpontja"
 
-#: templates/backoffice/assembly_registration.html:453
+#: templates/backoffice/assembly_registration.html:455
 #, fuzzy
 msgid "Respondent first name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:454
+#: templates/backoffice/assembly_registration.html:456
 msgid "First name, or 'Friend' as a fallback"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:455
+#: templates/backoffice/assembly_registration.html:457
 #, fuzzy
 msgid "Respondent full name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:456
+#: templates/backoffice/assembly_registration.html:458
 #, fuzzy
 msgid "Respondent email address"
 msgstr "Email cím hiányzik"
 
-#: templates/backoffice/assembly_registration.html:479
+#: templates/backoffice/assembly_registration.html:481
 msgid "Variable copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:483
+#: templates/backoffice/assembly_registration.html:485
 #, python-format
 msgid "Copy %(label)s variable"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:532
+#: templates/backoffice/assembly_registration.html:534
 msgid "Form preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:535
+#: templates/backoffice/assembly_registration.html:537
 msgid ""
 "This is the last saved version of your registration form, shown exactly "
 "as visitors will see it. You can try the fields and dropdowns, but the "
 "form cannot be submitted from here."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:544
+#: templates/backoffice/assembly_registration.html:546
 #, fuzzy
 msgid "Registration form preview"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:558
+#: templates/backoffice/assembly_registration.html:560
 msgid "Share your form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:634
+#: templates/backoffice/assembly_registration.html:636
 msgid "Publish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:643
+#: templates/backoffice/assembly_registration.html:645
 msgid "Unpublish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:645
-#: templates/backoffice/assembly_registration.html:1003
+#: templates/backoffice/assembly_registration.html:647
+#: templates/backoffice/assembly_registration.html:1005
 #, fuzzy
 msgid "Close registration"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:674
+#: templates/backoffice/assembly_registration.html:676
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:680
-#: templates/backoffice/assembly_registration.html:743
-#: templates/backoffice/assembly_registration.html:834
+#: templates/backoffice/assembly_registration.html:682
+#: templates/backoffice/assembly_registration.html:745
+#: templates/backoffice/assembly_registration.html:836
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:54
@@ -5063,219 +5067,219 @@ msgstr "Rétegzett kiválasztás"
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:689
+#: templates/backoffice/assembly_registration.html:691
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:693
+#: templates/backoffice/assembly_registration.html:695
 msgid "Form skeleton preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:709
+#: templates/backoffice/assembly_registration.html:711
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:736
+#: templates/backoffice/assembly_registration.html:738
 #, fuzzy
 msgid "Upload image"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:752
+#: templates/backoffice/assembly_registration.html:754
 #, python-format
 msgid ""
 "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
 "Files are downscaled and re-encoded to PNG on upload."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:758
+#: templates/backoffice/assembly_registration.html:760
 msgid "Image file"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:774
-#: templates/backoffice/assembly_registration.html:933
+#: templates/backoffice/assembly_registration.html:776
+#: templates/backoffice/assembly_registration.html:935
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:786
-#: templates/backoffice/assembly_registration.html:945
+#: templates/backoffice/assembly_registration.html:788
+#: templates/backoffice/assembly_registration.html:947
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:827
+#: templates/backoffice/assembly_registration.html:829
 #, fuzzy
 msgid "Image details"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:853
+#: templates/backoffice/assembly_registration.html:855
 msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:860
+#: templates/backoffice/assembly_registration.html:862
 msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:865
+#: templates/backoffice/assembly_registration.html:867
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:870
+#: templates/backoffice/assembly_registration.html:872
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:873
+#: templates/backoffice/assembly_registration.html:875
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:881
+#: templates/backoffice/assembly_registration.html:883
 #, fuzzy
 msgid "File name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:894
+#: templates/backoffice/assembly_registration.html:896
 msgid "File name copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:898
+#: templates/backoffice/assembly_registration.html:900
 #, fuzzy
 msgid "Copy file name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:909
+#: templates/backoffice/assembly_registration.html:911
 #, fuzzy
 msgid "Image snippet"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:923
+#: templates/backoffice/assembly_registration.html:925
 msgid "Copy image snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:958
+#: templates/backoffice/assembly_registration.html:960
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:961
+#: templates/backoffice/assembly_registration.html:963
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:991
+#: templates/backoffice/assembly_registration.html:993
 #, fuzzy
 msgid "Close registration?"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:994
+#: templates/backoffice/assembly_registration.html:996
 msgid ""
 "This permanently stops new registrations. Visitors who follow the form "
 "link will see the 'registration closed' page, and the form cannot be "
 "reopened."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1005
+#: templates/backoffice/assembly_registration.html:1007
 #, fuzzy
 msgid "Keep it open"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1037
+#: templates/backoffice/assembly_registration.html:1039
 #, fuzzy
 msgid "Discard changes?"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1040
+#: templates/backoffice/assembly_registration.html:1042
 msgid ""
 "You have unsaved changes. If you leave this page, your changes will be "
 "lost."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1043
+#: templates/backoffice/assembly_registration.html:1045
 #, fuzzy
 msgid "Discard changes"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1044
+#: templates/backoffice/assembly_registration.html:1046
 #, fuzzy
 msgid "Keep editing"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1206
+#: templates/backoffice/assembly_registration.html:1203
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:1217
-#: templates/backoffice/assembly_registration.html:1342
+#: templates/backoffice/assembly_registration.html:1214
+#: templates/backoffice/assembly_registration.html:1339
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1220
-#: templates/backoffice/assembly_registration.html:1330
-#: templates/backoffice/assembly_registration.html:1343
+#: templates/backoffice/assembly_registration.html:1217
+#: templates/backoffice/assembly_registration.html:1327
+#: templates/backoffice/assembly_registration.html:1340
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1275
+#: templates/backoffice/assembly_registration.html:1272
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1286
+#: templates/backoffice/assembly_registration.html:1283
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1289
+#: templates/backoffice/assembly_registration.html:1286
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1298
+#: templates/backoffice/assembly_registration.html:1295
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1309
-#: templates/backoffice/assembly_registration.html:1375
+#: templates/backoffice/assembly_registration.html:1306
+#: templates/backoffice/assembly_registration.html:1372
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1313
-#: templates/backoffice/assembly_registration.html:1382
+#: templates/backoffice/assembly_registration.html:1310
+#: templates/backoffice/assembly_registration.html:1379
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1316
-#: templates/backoffice/assembly_registration.html:1385
+#: templates/backoffice/assembly_registration.html:1313
+#: templates/backoffice/assembly_registration.html:1382
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1325
+#: templates/backoffice/assembly_registration.html:1322
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1329
+#: templates/backoffice/assembly_registration.html:1326
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1412
+#: templates/backoffice/assembly_registration.html:1409
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1420
+#: templates/backoffice/assembly_registration.html:1417
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1423
+#: templates/backoffice/assembly_registration.html:1420
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -6464,14 +6468,14 @@ msgstr "Az oldal nem elérhető"
 msgid "More actions"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/components/stepper.html:100
-#: templates/backoffice/components/stepper.html:129
+#: templates/backoffice/components/stepper.html:106
+#: templates/backoffice/components/stepper.html:135
 #, fuzzy
 msgid "completed"
 msgstr "Befejezve"
 
-#: templates/backoffice/components/stepper.html:102
-#: templates/backoffice/components/stepper.html:131
+#: templates/backoffice/components/stepper.html:108
+#: templates/backoffice/components/stepper.html:137
 #, fuzzy
 msgid "has errors"
 msgstr "Hiba történt"
@@ -7726,75 +7730,103 @@ msgstr ""
 
 #: templates/backoffice/patterns/_stepper.html:95
 msgid ""
+"Pass disabled=true to lock every step in either mode: steps render as "
+"non-focusable spans with aria-disabled='true', so there is nothing to "
+"click or tab to. Use it when navigating away must be blocked — e.g. while"
+" an edit is in progress — together with disabling the page's other "
+"navigation controls (see the registration wizard, which pairs it with the"
+" disabled footer Back/Next in edit mode)."
+msgstr ""
+
+#: templates/backoffice/patterns/_stepper.html:106
+msgid "Example stepper (disabled)"
+msgstr ""
+
+#: templates/backoffice/patterns/_stepper.html:128
+msgid ""
 "Set per item via the `state` key, or let it default from the `active` "
 "bool. Each state has its own colour treatment."
 msgstr ""
 
-#: templates/backoffice/patterns/_stepper.html:102
+#: templates/backoffice/patterns/_stepper.html:135
 #, fuzzy
 msgid "Active step"
 msgstr "Aktív gyűlések"
 
-#: templates/backoffice/patterns/_stepper.html:103
+#: templates/backoffice/patterns/_stepper.html:136
 #, fuzzy
 msgid "Active state"
 msgstr "Aktív gyűlések"
 
-#: templates/backoffice/patterns/_stepper.html:112
+#: templates/backoffice/patterns/_stepper.html:145
 #, fuzzy
 msgid "Inactive step"
 msgstr "Aktív gyűlések"
 
-#: templates/backoffice/patterns/_stepper.html:113
+#: templates/backoffice/patterns/_stepper.html:146
 #, fuzzy
 msgid "Inactive state"
 msgstr "Aktív gyűlések"
 
-#: templates/backoffice/patterns/_stepper.html:122
+#: templates/backoffice/patterns/_stepper.html:155
 #, fuzzy
 msgid "Completed step"
 msgstr "Befejezve"
 
-#: templates/backoffice/patterns/_stepper.html:123
+#: templates/backoffice/patterns/_stepper.html:156
 #, fuzzy
 msgid "Done state"
 msgstr "Keresztnév"
 
-#: templates/backoffice/patterns/_stepper.html:132
+#: templates/backoffice/patterns/_stepper.html:165
 msgid "Step with an error"
 msgstr ""
 
-#: templates/backoffice/patterns/_stepper.html:133
+#: templates/backoffice/patterns/_stepper.html:166
 #, fuzzy
 msgid "Error state"
 msgstr "Keresztnév"
 
-#: templates/backoffice/patterns/_stepper.html:143
+#: templates/backoffice/patterns/_stepper.html:176
 msgid "Signature"
 msgstr ""
 
-#: templates/backoffice/patterns/_stepper.html:147
+#: templates/backoffice/patterns/_stepper.html:180
 #, fuzzy
 msgid "Item keys"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/patterns/_stepper.html:149
+#: templates/backoffice/patterns/_stepper.html:182
 msgid "unique per stepper — used for tab/panel ids"
 msgstr ""
 
-#: templates/backoffice/patterns/_stepper.html:152
+#: templates/backoffice/patterns/_stepper.html:185
 msgid "derived from `active` if omitted"
 msgstr ""
 
-#: templates/backoffice/patterns/_stepper.html:153
+#: templates/backoffice/patterns/_stepper.html:186
 msgid "shortcut for state='active'"
 msgstr ""
 
-#: templates/backoffice/patterns/_stepper.html:154
-msgid "only meaningful in wizard mode"
+#: templates/backoffice/patterns/_stepper.html:187
+msgid "per-item lock, only meaningful in wizard mode"
 msgstr ""
 
-#: templates/backoffice/patterns/_stepper.html:157
+#: templates/backoffice/patterns/_stepper.html:190
+msgid "Macro-level flags"
+msgstr ""
+
+#: templates/backoffice/patterns/_stepper.html:192
+msgid ""
+"locks the WHOLE stepper in either mode — steps render as aria-disabled "
+"spans"
+msgstr ""
+
+#: templates/backoffice/patterns/_stepper.html:193
+msgid "keep scroll position across step navigation"
+msgstr ""
+
+#: templates/backoffice/patterns/_stepper.html:196
 msgid "Panel convention (same as tabs macro)"
 msgstr ""
 
@@ -13789,4 +13821,7 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Auto-reply disabled. Respondents will no longer receive this email."
+#~ msgstr ""
+
+#~ msgid "only meaningful in wizard mode"
 #~ msgstr ""

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-27 11:07+0200\n"
+"POT-Creation-Date: 2026-07-28 11:03+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1047,7 +1047,7 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:168
 #: src/opendlp/entrypoints/blueprints/backoffice.py:430
 #: src/opendlp/entrypoints/blueprints/backoffice.py:485
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:198
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:199
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:82
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:94
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:129
@@ -1086,15 +1086,15 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:325
 #: src/opendlp/entrypoints/blueprints/backoffice.py:421
 #: src/opendlp/entrypoints/blueprints/backoffice.py:476
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:204
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:327
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:537
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:595
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:619
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:714
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:775
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:802
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:826
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:205
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:328
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:534
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:583
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:607
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:701
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:762
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:789
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:813
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:407
@@ -1253,92 +1253,92 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:103
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:104
 #, fuzzy, python-format
 msgid "Details for %(name)s"
 msgstr "Hiba részletei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:104
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:105
 #, python-format
 msgid "Copy <img> snippet for %(name)s"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:105
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:106
 #, fuzzy, python-format
 msgid "Delete %(name)s"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:210
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:211
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:221
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:222
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:222
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:223
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:225
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:226
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:228
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:229
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:231
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:232
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:234
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:235
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:235
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:236
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:312
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:531
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:771
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:313
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:528
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:758
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:321
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:534
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:592
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:773
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:800
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:824
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:322
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:531
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:580
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:760
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:787
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:811
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:337
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:338
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:404
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:405
 #, fuzzy
 msgid "Registration auto-reply"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:405
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:406
 msgid "Thanks for registering for {{ assembly.title }}"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:407
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:408
 msgid ""
 "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
 "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
@@ -1347,97 +1347,101 @@ msgid ""
 "<p>Best wishes,<br>The team</p>"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:434
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:444
 msgid "Auto-reply email created. Edit it below and click Save."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:446
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:455
 msgid "There is no auto-reply email to save yet — set one up first."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:463
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:467
 msgid "Auto-reply email saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:528
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:490
+msgid "Unknown action — nothing was changed."
+msgstr ""
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:525
 msgid "The auto-reply email could not be found."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:546
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:543
 #, fuzzy
 msgid "An error occurred while saving the auto-reply email"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:587
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:575
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:600
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:588
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:604
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:592
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:617
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:708
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:605
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:695
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:622
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:610
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:718
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:705
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:745
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:732
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:751
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:738
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:755
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:790
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:742
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:777
 #: templates/backoffice/assembly_registration.html:1254
 #: templates/backoffice/assembly_registration.html:1393
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:778
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:765
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:796
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:820
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:783
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:807
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:798
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:822
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:785
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:809
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:805
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:792
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:829
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:816
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-23 10:13+0200\n"
+"POT-Creation-Date: 2026-07-27 11:07+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1628,28 +1628,28 @@ msgstr "További beállítások"
 msgid "An unexpected error occurred"
 msgstr "Hiba történt a betöltés indítása közben"
 
-#: src/opendlp/entrypoints/blueprints/dev.py:118
-#: src/opendlp/entrypoints/blueprints/dev.py:138
-#: src/opendlp/entrypoints/blueprints/dev.py:1266
-#: src/opendlp/entrypoints/blueprints/dev.py:1301
+#: src/opendlp/entrypoints/blueprints/dev.py:129
+#: src/opendlp/entrypoints/blueprints/dev.py:149
+#: src/opendlp/entrypoints/blueprints/dev.py:1452
+#: src/opendlp/entrypoints/blueprints/dev.py:1487
 #, fuzzy
 msgid "You don't have permission to access developer tools"
 msgstr "Jelenleg egy közösségi gyűlés eléréséhez sincs jogosultságod"
 
-#: src/opendlp/entrypoints/blueprints/dev.py:1309
+#: src/opendlp/entrypoints/blueprints/dev.py:1495
 msgid "Success! Your changes have been saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/dev.py:1310
+#: src/opendlp/entrypoints/blueprints/dev.py:1496
 msgid "Warning: Please review the data before continuing."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/dev.py:1311
+#: src/opendlp/entrypoints/blueprints/dev.py:1497
 #, fuzzy
 msgid "Error: Something went wrong. Please try again."
 msgstr "Hiba történt a bejelentkezés során. Kérjük, próbáld újra."
 
-#: src/opendlp/entrypoints/blueprints/dev.py:1312
+#: src/opendlp/entrypoints/blueprints/dev.py:1498
 msgid "Info: A new feature is available."
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 msgid "An error occurred while regenerating backup codes"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/registration.py:85
+#: src/opendlp/entrypoints/blueprints/registration.py:88
 msgid "Leave this blank"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/registration.py:304
+#: src/opendlp/entrypoints/blueprints/registration.py:307
 #, fuzzy
 msgid "Too many registrations from your location. Please try again later."
 msgstr "Hiba történt a bejelentkezés során. Kérjük, próbáld újra."
@@ -2751,6 +2751,14 @@ msgstr ""
 msgid "Failed to %(action)s old tabs: %(error)s"
 msgstr "A kiválasztás futtatásának indítása sikertelen: %(error)s"
 
+#: src/opendlp/service_layer/document_processing.py:12
+msgid "The PDF file is too large"
+msgstr ""
+
+#: src/opendlp/service_layer/document_processing.py:14
+msgid "The file must be a PDF"
+msgstr ""
+
 #: src/opendlp/service_layer/email_template_service.py:55
 msgid ""
 "The registration page does not collect an email address, so the auto-"
@@ -2771,39 +2779,39 @@ msgstr ""
 msgid "parse_error_single_column"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:58
+#: src/opendlp/service_layer/exceptions.py:60
 #, python-format
 msgid "User with email '%(email)s' already exists"
 msgstr "A(z) „%(email)s” e-mail címmel rendelkező felhasználó már létezik"
 
-#: src/opendlp/service_layer/exceptions.py:58
+#: src/opendlp/service_layer/exceptions.py:60
 msgid "User already exists"
 msgstr "A felhasználó már létezik"
 
-#: src/opendlp/service_layer/exceptions.py:68
+#: src/opendlp/service_layer/exceptions.py:70
 msgid "Invalid email or password"
 msgstr "Érvénytelen e-mail cím vagy jelszó"
 
-#: src/opendlp/service_layer/exceptions.py:77
+#: src/opendlp/service_layer/exceptions.py:79
 #, python-format
 msgid "Invalid invite code '%(code)s': %(reason)s"
 msgstr "Érvénytelen meghívókód: '%(code)s': %(reason)s"
 
-#: src/opendlp/service_layer/exceptions.py:79
+#: src/opendlp/service_layer/exceptions.py:81
 #, python-format
 msgid "Invalid invite code '%(code)s'"
 msgstr "Érvénytelen meghívókód: '%(code)s'"
 
-#: src/opendlp/service_layer/exceptions.py:81
+#: src/opendlp/service_layer/exceptions.py:83
 #, python-format
 msgid "Invalid invite code: %(reason)s"
 msgstr "Érvénytelen meghívókód: %(reason)s"
 
-#: src/opendlp/service_layer/exceptions.py:83
+#: src/opendlp/service_layer/exceptions.py:85
 msgid "Invalid invite code"
 msgstr "Érvénytelen meghívókód"
 
-#: src/opendlp/service_layer/exceptions.py:95
+#: src/opendlp/service_layer/exceptions.py:97
 #, python-format
 msgid ""
 "Insufficient permissions for action: %(action)s (requires role: "
@@ -2812,89 +2820,94 @@ msgstr ""
 "Nincs elegendő jogosultság a következő művelethez: %(action)s (szükséges "
 "szerepkör: %(required_role)s)"
 
-#: src/opendlp/service_layer/exceptions.py:100
+#: src/opendlp/service_layer/exceptions.py:102
 #, python-format
 msgid "Insufficient permissions for action: %(action)s"
 msgstr "Nincs elegendő jogosultság a következő művelethez: %(action)s"
 
-#: src/opendlp/service_layer/exceptions.py:102
+#: src/opendlp/service_layer/exceptions.py:104
 #, python-format
 msgid "Insufficient permissions (requires role: %(required_role)s)"
 msgstr "Nincsenek megfelelő jogosultságok (szükséges szerepkör: %(required_role)s)"
 
-#: src/opendlp/service_layer/exceptions.py:104
+#: src/opendlp/service_layer/exceptions.py:106
 msgid "Insufficient permissions"
 msgstr "Nincsenek megfelelő jogosultságok"
 
-#: src/opendlp/service_layer/exceptions.py:115
+#: src/opendlp/service_layer/exceptions.py:117
 #, fuzzy, python-format
 msgid "Invalid password reset token: %(reason)s"
 msgstr "A jelszó túl gyenge: %(reason)s"
 
-#: src/opendlp/service_layer/exceptions.py:117
+#: src/opendlp/service_layer/exceptions.py:119
 #, fuzzy
 msgid "Invalid password reset token"
 msgstr "Érvénytelen e-mail cím vagy jelszó"
 
-#: src/opendlp/service_layer/exceptions.py:126
+#: src/opendlp/service_layer/exceptions.py:128
 msgid "Please confirm your email address before logging in."
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:134
+#: src/opendlp/service_layer/exceptions.py:136
 #, fuzzy, python-format
 msgid "Invalid or expired confirmation link: %(reason)s"
 msgstr "A jelszó túl gyenge: %(reason)s"
 
-#: src/opendlp/service_layer/exceptions.py:136
+#: src/opendlp/service_layer/exceptions.py:138
 #, fuzzy
 msgid "Invalid or expired confirmation link"
 msgstr "Érvénytelen vagy lejárt meghívó kód."
 
-#: src/opendlp/service_layer/exceptions.py:147
+#: src/opendlp/service_layer/exceptions.py:149
 #, python-format
 msgid ""
 "Rate limit exceeded for %(operation)s. Please try again in %(seconds)s "
 "seconds"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:152
+#: src/opendlp/service_layer/exceptions.py:154
 #, python-format
 msgid "Rate limit exceeded for %(operation)s"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:154
+#: src/opendlp/service_layer/exceptions.py:156
 msgid "Rate limit exceeded. Please try again later"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:208
+#: src/opendlp/service_layer/exceptions.py:214
 #, python-format
 msgid "This registration page already has the maximum of %(limit)s images"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:224
+#: src/opendlp/service_layer/exceptions.py:221
+#, python-format
+msgid "This registration page already has the maximum of %(limit)s documents"
+msgstr ""
+
+#: src/opendlp/service_layer/exceptions.py:237
 #, python-format
 msgid "OAuth authentication failed for %(provider)s: %(reason)s"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:226
+#: src/opendlp/service_layer/exceptions.py:239
 #, python-format
 msgid "OAuth authentication failed for %(provider)s"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:228
+#: src/opendlp/service_layer/exceptions.py:241
 #, python-format
 msgid "OAuth authentication failed: %(reason)s"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:230
+#: src/opendlp/service_layer/exceptions.py:243
 msgid "OAuth authentication failed"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:240
+#: src/opendlp/service_layer/exceptions.py:253
 msgid "Invalid OAuth state parameter"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:247
+#: src/opendlp/service_layer/exceptions.py:260
 msgid "Cannot remove last authentication method. Add another method first."
 msgstr ""
 
@@ -3358,6 +3371,7 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/components/respondent_status_form.html:87
 #: templates/backoffice/respondents/confirm_upload_diff.html:107
 #: templates/backoffice/respondents/export_modal.html:77
+#: templates/backoffice/showcase/modal_component.html:25
 #: templates/backoffice/targets/category_block.html:47
 #: templates/backoffice/targets/category_block.html:228
 #: templates/backoffice/targets/category_block.html:330
@@ -4267,6 +4281,7 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:82
 #: templates/backoffice/service_docs/_emails.html:365
+#: templates/backoffice/showcase/modal_component.html:26
 #: templates/backoffice/targets/category_block.html:32
 #: templates/backoffice/targets/category_block.html:157
 #: templates/targets/components/category_block.html:21
@@ -5059,8 +5074,8 @@ msgstr "Rétegzett kiválasztás"
 #: templates/backoffice/assembly_registration.html:836
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
-#: templates/backoffice/components/modal.html:54
-#: templates/backoffice/components/modal.html:133
+#: templates/backoffice/components/modal.html:106
+#: templates/backoffice/components/modal.html:164
 #: templates/backoffice/components/replacement_modal.html:170
 #: templates/backoffice/components/selection_progress_modal.html:89
 #, fuzzy
@@ -6157,13 +6172,23 @@ msgstr "Jelentések a folyamatról"
 
 #: templates/backoffice/service_docs.html:49
 #, fuzzy
+msgid "Documents"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/service_docs.html:50
+#, fuzzy
 msgid "Emails"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/service_docs.html:51
+#: templates/backoffice/service_docs.html:52
 #, fuzzy
 msgid "Service categories"
 msgstr "Feladat állapota"
+
+#: templates/backoffice/showcase.html:63 templates/backoffice/showcase.html:78
+#, fuzzy
+msgid "Jump to section"
+msgstr "Kiválasztás"
 
 #: templates/backoffice/components/alert.html:84
 msgid "Dismiss"
@@ -6329,7 +6354,7 @@ msgid "Manage Tabs Progress"
 msgstr "Feladat folyamatban"
 
 #: templates/backoffice/components/manage_tabs_progress_modal.html:21
-#: templates/backoffice/components/modal.html:274
+#: templates/backoffice/components/modal.html:301
 #: templates/backoffice/components/replacement_modal.html:50
 msgid "Processing..."
 msgstr ""
@@ -6364,11 +6389,11 @@ msgstr "Táblázat megtekintése"
 msgid "Delete These Tabs"
 msgstr ""
 
-#: templates/backoffice/components/modal.html:242
+#: templates/backoffice/components/modal.html:269
 msgid "Waiting for task to start..."
 msgstr ""
 
-#: templates/backoffice/components/modal.html:244
+#: templates/backoffice/components/modal.html:271
 #, fuzzy
 msgid "Messages:"
 msgstr "Jelentések a folyamatról"
@@ -6463,7 +6488,7 @@ msgstr "Táblázat lapfülei"
 msgid "No results found"
 msgstr "Az oldal nem elérhető"
 
-#: templates/backoffice/components/split_button.html:98
+#: templates/backoffice/components/split_button.html:61
 #, fuzzy
 msgid "More actions"
 msgstr "Kiválasztás"
@@ -6568,6 +6593,7 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:294
 #: templates/backoffice/service_docs/_config.html:25
 #: templates/backoffice/service_docs/_config.html:128
+#: templates/backoffice/service_docs/_documents.html:35
 #: templates/backoffice/service_docs/_emails.html:41
 #: templates/backoffice/service_docs/_emails.html:142
 #: templates/backoffice/service_docs/_emails.html:202
@@ -8132,6 +8158,8 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:225
 #: templates/backoffice/service_docs/_assembly.html:333
 #: templates/backoffice/service_docs/_config.html:50
+#: templates/backoffice/service_docs/_documents.html:75
+#: templates/backoffice/service_docs/_documents.html:176
 #: templates/backoffice/service_docs/_emails.html:50
 #: templates/backoffice/service_docs/_emails.html:148
 #: templates/backoffice/service_docs/_emails.html:208
@@ -8181,6 +8209,12 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:128
 #: templates/backoffice/service_docs/_assembly.html:235
 #: templates/backoffice/service_docs/_assembly.html:343
+#: templates/backoffice/service_docs/_documents.html:106
+#: templates/backoffice/service_docs/_documents.html:186
+#: templates/backoffice/service_docs/_documents.html:239
+#: templates/backoffice/service_docs/_documents.html:300
+#: templates/backoffice/service_docs/_documents.html:368
+#: templates/backoffice/service_docs/_documents.html:421
 #: templates/backoffice/service_docs/_images.html:106
 #: templates/backoffice/service_docs/_images.html:186
 #: templates/backoffice/service_docs/_images.html:239
@@ -8203,6 +8237,12 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:166
 #: templates/backoffice/service_docs/_assembly.html:260
 #: templates/backoffice/service_docs/_assembly.html:384
+#: templates/backoffice/service_docs/_documents.html:149
+#: templates/backoffice/service_docs/_documents.html:209
+#: templates/backoffice/service_docs/_documents.html:270
+#: templates/backoffice/service_docs/_documents.html:338
+#: templates/backoffice/service_docs/_documents.html:391
+#: templates/backoffice/service_docs/_documents.html:449
 #: templates/backoffice/service_docs/_images.html:149
 #: templates/backoffice/service_docs/_images.html:209
 #: templates/backoffice/service_docs/_images.html:270
@@ -8331,6 +8371,76 @@ msgstr "Új jelszó"
 #, fuzzy
 msgid "Reset"
 msgstr "Válaszadókat tartalmazó lapful neve"
+
+#: templates/backoffice/service_docs/_documents.html:6
+msgid ""
+"Upload, list, relabel and delete PDF documents attached to an assembly's "
+"registration page. Uploads are size-capped, gated on the PDF magic bytes,"
+" stored as-uploaded and de-duplicated by SHA-256."
+msgstr ""
+
+#: templates/backoffice/service_docs/_documents.html:9
+msgid ""
+"Only PDF files are accepted. The page must already exist (use the "
+"Registration tab to create one)."
+msgstr ""
+
+#: templates/backoffice/service_docs/_documents.html:30
+msgid ""
+"Validate and store a PDF for the assembly's registration page. Identical "
+"bytes on the same page collapse to one row; on re-upload the caller's "
+"label wins."
+msgstr ""
+
+#: templates/backoffice/service_docs/_documents.html:84
+#: templates/backoffice/service_docs/_images.html:84
+#: templates/backoffice/service_docs/_registration.html:409
+#: templates/backoffice/service_docs/_registration.html:628
+#: templates/backoffice/service_docs/_registration.html:756
+#: templates/backoffice/service_docs/_registration.html:970
+#: templates/backoffice/service_docs/_registration.html:1086
+#: templates/backoffice/service_docs/_registration.html:1198
+#: templates/backoffice/service_docs/_registration.html:1310
+#: templates/backoffice/service_docs/_respondents.html:118
+#: templates/backoffice/service_docs/_respondents.html:304
+#: templates/backoffice/service_docs/_selection.html:245
+#: templates/backoffice/service_docs/_selection.html:320
+#, fuzzy
+msgid "Error Cases"
+msgstr "Hiba részletei"
+
+#: templates/backoffice/service_docs/_documents.html:173
+msgid ""
+"Return every document attached to the assembly's registration page. Empty"
+" list when no page exists yet."
+msgstr ""
+
+#: templates/backoffice/service_docs/_documents.html:233
+msgid ""
+"Permanently delete a document. The document_id must belong to the "
+"assembly's registration page."
+msgstr ""
+
+#: templates/backoffice/service_docs/_documents.html:294
+msgid ""
+"Update a document's label in place. Records an edit on the parent "
+"registration page."
+msgstr ""
+
+#: templates/backoffice/service_docs/_documents.html:362
+msgid ""
+"List documents paired with ready-to-paste <a> download snippets. URLs "
+"point at the public /register/<slug>/documents/<sha>.pdf route; link text"
+" is the label plus a human-readable size."
+msgstr ""
+
+#: templates/backoffice/service_docs/_documents.html:415
+msgid ""
+"Lookup helper used by the public "
+"/register/<slug>/documents/<document_name> route. Returns None unless the"
+" registration page is publicly loadable (TEST or PUBLISHED). The response"
+" here reports metadata; fetch the actual bytes from the public URL."
+msgstr ""
 
 #: templates/backoffice/service_docs/_emails.html:10
 #, fuzzy
@@ -8625,22 +8735,6 @@ msgid ""
 "page. Identical bytes on the same page collapse to one row."
 msgstr ""
 
-#: templates/backoffice/service_docs/_images.html:84
-#: templates/backoffice/service_docs/_registration.html:409
-#: templates/backoffice/service_docs/_registration.html:628
-#: templates/backoffice/service_docs/_registration.html:756
-#: templates/backoffice/service_docs/_registration.html:970
-#: templates/backoffice/service_docs/_registration.html:1086
-#: templates/backoffice/service_docs/_registration.html:1198
-#: templates/backoffice/service_docs/_registration.html:1310
-#: templates/backoffice/service_docs/_respondents.html:118
-#: templates/backoffice/service_docs/_respondents.html:304
-#: templates/backoffice/service_docs/_selection.html:245
-#: templates/backoffice/service_docs/_selection.html:320
-#, fuzzy
-msgid "Error Cases"
-msgstr "Hiba részletei"
-
 #: templates/backoffice/service_docs/_images.html:173
 msgid ""
 "Return every image attached to the assembly's registration page. Empty "
@@ -8912,6 +9006,17 @@ msgstr ""
 
 #: templates/backoffice/service_docs/_targets.html:151
 msgid "This operation always replaces existing targets for the selected assembly."
+msgstr ""
+
+#: templates/backoffice/showcase/modal_component.html:24
+#, fuzzy
+msgid "Delete Account?"
+msgstr "Hozzon létre fiókot"
+
+#: templates/backoffice/showcase/modal_component.html:24
+msgid ""
+"Deleting account is irreversible and will erase all your data. This "
+"action cannot be undone."
 msgstr ""
 
 #: templates/backoffice/showcase/pagination_component.html:82

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-22 15:08+0200\n"
+"POT-Creation-Date: 2026-07-21 09:59+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1424,8 +1424,8 @@ msgstr ""
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:702
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:737
-#: templates/backoffice/assembly_registration.html:1021
-#: templates/backoffice/assembly_registration.html:1160
+#: templates/backoffice/assembly_registration.html:1165
+#: templates/backoffice/assembly_registration.html:1304
 msgid "Alt text is required for accessibility"
 msgstr ""
 
@@ -1642,28 +1642,28 @@ msgstr "További beállítások"
 msgid "An unexpected error occurred"
 msgstr "Hiba történt a betöltés indítása közben"
 
-#: src/opendlp/entrypoints/blueprints/dev.py:129
-#: src/opendlp/entrypoints/blueprints/dev.py:149
-#: src/opendlp/entrypoints/blueprints/dev.py:1452
-#: src/opendlp/entrypoints/blueprints/dev.py:1487
+#: src/opendlp/entrypoints/blueprints/dev.py:118
+#: src/opendlp/entrypoints/blueprints/dev.py:138
+#: src/opendlp/entrypoints/blueprints/dev.py:1266
+#: src/opendlp/entrypoints/blueprints/dev.py:1301
 #, fuzzy
 msgid "You don't have permission to access developer tools"
 msgstr "Jelenleg egy közösségi gyűlés eléréséhez sincs jogosultságod"
 
-#: src/opendlp/entrypoints/blueprints/dev.py:1495
+#: src/opendlp/entrypoints/blueprints/dev.py:1309
 msgid "Success! Your changes have been saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/dev.py:1496
+#: src/opendlp/entrypoints/blueprints/dev.py:1310
 msgid "Warning: Please review the data before continuing."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/dev.py:1497
+#: src/opendlp/entrypoints/blueprints/dev.py:1311
 #, fuzzy
 msgid "Error: Something went wrong. Please try again."
 msgstr "Hiba történt a bejelentkezés során. Kérjük, próbáld újra."
 
-#: src/opendlp/entrypoints/blueprints/dev.py:1498
+#: src/opendlp/entrypoints/blueprints/dev.py:1312
 msgid "Info: A new feature is available."
 msgstr ""
 
@@ -2018,11 +2018,11 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 msgid "An error occurred while regenerating backup codes"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/registration.py:88
+#: src/opendlp/entrypoints/blueprints/registration.py:85
 msgid "Leave this blank"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/registration.py:307
+#: src/opendlp/entrypoints/blueprints/registration.py:304
 #, fuzzy
 msgid "Too many registrations from your location. Please try again later."
 msgstr "Hiba történt a bejelentkezés során. Kérjük, próbáld újra."
@@ -2765,14 +2765,6 @@ msgstr ""
 msgid "Failed to %(action)s old tabs: %(error)s"
 msgstr "A kiválasztás futtatásának indítása sikertelen: %(error)s"
 
-#: src/opendlp/service_layer/document_processing.py:12
-msgid "The PDF file is too large"
-msgstr ""
-
-#: src/opendlp/service_layer/document_processing.py:14
-msgid "The file must be a PDF"
-msgstr ""
-
 #: src/opendlp/service_layer/email_template_service.py:55
 msgid ""
 "The registration page does not collect an email address, so the auto-"
@@ -2793,39 +2785,39 @@ msgstr ""
 msgid "parse_error_single_column"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:60
+#: src/opendlp/service_layer/exceptions.py:58
 #, python-format
 msgid "User with email '%(email)s' already exists"
 msgstr "A(z) „%(email)s” e-mail címmel rendelkező felhasználó már létezik"
 
-#: src/opendlp/service_layer/exceptions.py:60
+#: src/opendlp/service_layer/exceptions.py:58
 msgid "User already exists"
 msgstr "A felhasználó már létezik"
 
-#: src/opendlp/service_layer/exceptions.py:70
+#: src/opendlp/service_layer/exceptions.py:68
 msgid "Invalid email or password"
 msgstr "Érvénytelen e-mail cím vagy jelszó"
 
-#: src/opendlp/service_layer/exceptions.py:79
+#: src/opendlp/service_layer/exceptions.py:77
 #, python-format
 msgid "Invalid invite code '%(code)s': %(reason)s"
 msgstr "Érvénytelen meghívókód: '%(code)s': %(reason)s"
 
-#: src/opendlp/service_layer/exceptions.py:81
+#: src/opendlp/service_layer/exceptions.py:79
 #, python-format
 msgid "Invalid invite code '%(code)s'"
 msgstr "Érvénytelen meghívókód: '%(code)s'"
 
-#: src/opendlp/service_layer/exceptions.py:83
+#: src/opendlp/service_layer/exceptions.py:81
 #, python-format
 msgid "Invalid invite code: %(reason)s"
 msgstr "Érvénytelen meghívókód: %(reason)s"
 
-#: src/opendlp/service_layer/exceptions.py:85
+#: src/opendlp/service_layer/exceptions.py:83
 msgid "Invalid invite code"
 msgstr "Érvénytelen meghívókód"
 
-#: src/opendlp/service_layer/exceptions.py:97
+#: src/opendlp/service_layer/exceptions.py:95
 #, python-format
 msgid ""
 "Insufficient permissions for action: %(action)s (requires role: "
@@ -2834,94 +2826,89 @@ msgstr ""
 "Nincs elegendő jogosultság a következő művelethez: %(action)s (szükséges "
 "szerepkör: %(required_role)s)"
 
-#: src/opendlp/service_layer/exceptions.py:102
+#: src/opendlp/service_layer/exceptions.py:100
 #, python-format
 msgid "Insufficient permissions for action: %(action)s"
 msgstr "Nincs elegendő jogosultság a következő művelethez: %(action)s"
 
-#: src/opendlp/service_layer/exceptions.py:104
+#: src/opendlp/service_layer/exceptions.py:102
 #, python-format
 msgid "Insufficient permissions (requires role: %(required_role)s)"
 msgstr "Nincsenek megfelelő jogosultságok (szükséges szerepkör: %(required_role)s)"
 
-#: src/opendlp/service_layer/exceptions.py:106
+#: src/opendlp/service_layer/exceptions.py:104
 msgid "Insufficient permissions"
 msgstr "Nincsenek megfelelő jogosultságok"
 
-#: src/opendlp/service_layer/exceptions.py:117
+#: src/opendlp/service_layer/exceptions.py:115
 #, fuzzy, python-format
 msgid "Invalid password reset token: %(reason)s"
 msgstr "A jelszó túl gyenge: %(reason)s"
 
-#: src/opendlp/service_layer/exceptions.py:119
+#: src/opendlp/service_layer/exceptions.py:117
 #, fuzzy
 msgid "Invalid password reset token"
 msgstr "Érvénytelen e-mail cím vagy jelszó"
 
-#: src/opendlp/service_layer/exceptions.py:128
+#: src/opendlp/service_layer/exceptions.py:126
 msgid "Please confirm your email address before logging in."
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:136
+#: src/opendlp/service_layer/exceptions.py:134
 #, fuzzy, python-format
 msgid "Invalid or expired confirmation link: %(reason)s"
 msgstr "A jelszó túl gyenge: %(reason)s"
 
-#: src/opendlp/service_layer/exceptions.py:138
+#: src/opendlp/service_layer/exceptions.py:136
 #, fuzzy
 msgid "Invalid or expired confirmation link"
 msgstr "Érvénytelen vagy lejárt meghívó kód."
 
-#: src/opendlp/service_layer/exceptions.py:149
+#: src/opendlp/service_layer/exceptions.py:147
 #, python-format
 msgid ""
 "Rate limit exceeded for %(operation)s. Please try again in %(seconds)s "
 "seconds"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:154
+#: src/opendlp/service_layer/exceptions.py:152
 #, python-format
 msgid "Rate limit exceeded for %(operation)s"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:156
+#: src/opendlp/service_layer/exceptions.py:154
 msgid "Rate limit exceeded. Please try again later"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:214
+#: src/opendlp/service_layer/exceptions.py:208
 #, python-format
 msgid "This registration page already has the maximum of %(limit)s images"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:221
-#, python-format
-msgid "This registration page already has the maximum of %(limit)s documents"
-msgstr ""
-
-#: src/opendlp/service_layer/exceptions.py:237
+#: src/opendlp/service_layer/exceptions.py:224
 #, python-format
 msgid "OAuth authentication failed for %(provider)s: %(reason)s"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:239
+#: src/opendlp/service_layer/exceptions.py:226
 #, python-format
 msgid "OAuth authentication failed for %(provider)s"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:241
+#: src/opendlp/service_layer/exceptions.py:228
 #, python-format
 msgid "OAuth authentication failed: %(reason)s"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:243
+#: src/opendlp/service_layer/exceptions.py:230
 msgid "OAuth authentication failed"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:253
+#: src/opendlp/service_layer/exceptions.py:240
 msgid "Invalid OAuth state parameter"
 msgstr ""
 
-#: src/opendlp/service_layer/exceptions.py:260
+#: src/opendlp/service_layer/exceptions.py:247
 msgid "Cannot remove last authentication method. Add another method first."
 msgstr ""
 
@@ -3376,16 +3363,15 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_data.html:508
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
-#: templates/backoffice/assembly_registration.html:277
-#: templates/backoffice/assembly_registration.html:475
-#: templates/backoffice/assembly_registration.html:722
-#: templates/backoffice/assembly_registration.html:883
+#: templates/backoffice/assembly_registration.html:155
+#: templates/backoffice/assembly_registration.html:400
+#: templates/backoffice/assembly_registration.html:761
+#: templates/backoffice/assembly_registration.html:922
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:40
 #: templates/backoffice/components/respondent_status_form.html:87
 #: templates/backoffice/respondents/confirm_upload_diff.html:107
 #: templates/backoffice/respondents/export_modal.html:77
-#: templates/backoffice/showcase/modal_component.html:25
 #: templates/backoffice/targets/category_block.html:47
 #: templates/backoffice/targets/category_block.html:228
 #: templates/backoffice/targets/category_block.html:330
@@ -3422,7 +3408,7 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:505
+#: templates/backoffice/assembly_registration.html:543
 #: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Registration URL"
@@ -3757,8 +3743,8 @@ msgstr "Módosítsa a számot."
 
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
 #: templates/backoffice/assembly_edit_respondent.html:21
-#: templates/backoffice/assembly_registration.html:282
-#: templates/backoffice/assembly_registration.html:479
+#: templates/backoffice/assembly_registration.html:158
+#: templates/backoffice/assembly_registration.html:403
 #: templates/backoffice/assembly_respondents.html:148
 #: templates/backoffice/assembly_selection.html:81
 #: templates/backoffice/assembly_selection.html:299
@@ -4294,7 +4280,6 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:82
 #: templates/backoffice/service_docs/_emails.html:365
-#: templates/backoffice/showcase/modal_component.html:26
 #: templates/backoffice/targets/category_block.html:32
 #: templates/backoffice/targets/category_block.html:157
 #: templates/targets/components/category_block.html:21
@@ -4521,8 +4506,8 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
-#: templates/backoffice/assembly_registration.html:190
-#: templates/backoffice/assembly_registration.html:723
+#: templates/backoffice/assembly_registration.html:206
+#: templates/backoffice/assembly_registration.html:762
 msgid "Upload"
 msgstr ""
 
@@ -4635,46 +4620,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:506
+#: templates/backoffice/assembly_registration.html:544
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:513
+#: templates/backoffice/assembly_registration.html:551
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:514
+#: templates/backoffice/assembly_registration.html:552
 #: templates/backoffice/edit_assembly.html:112
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:522
+#: templates/backoffice/assembly_registration.html:560
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:524
+#: templates/backoffice/assembly_registration.html:562
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:530
+#: templates/backoffice/assembly_registration.html:568
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:542
+#: templates/backoffice/assembly_registration.html:580
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:545
+#: templates/backoffice/assembly_registration.html:583
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4828,14 +4813,14 @@ msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_registration.html:75
-#: templates/backoffice/assembly_registration.html:317
+#: templates/backoffice/assembly_registration.html:333
 #: templates/backoffice/patterns/_stepper.html:29
 #, fuzzy
 msgid "Auto-reply email"
 msgstr "Hiba részletei"
 
 #: templates/backoffice/assembly_registration.html:76
-#: templates/backoffice/assembly_registration.html:496
+#: templates/backoffice/assembly_registration.html:534
 #: templates/backoffice/patterns/_stepper.html:30
 #, fuzzy
 msgid "Preview and publish"
@@ -4870,44 +4855,13 @@ msgstr ""
 msgid "Published"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:133
-#, fuzzy
-msgid "Registration Form HTML"
-msgstr "Vissza a regisztrációhoz"
-
-#: templates/backoffice/assembly_registration.html:142
-msgid "Show Form Skeleton"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:152
-msgid ""
-"Paste your HTML form code below. The only required placeholders are {{ "
-"form_action }} for the form's action attribute and {{ csrf_form_element "
-"}} for CSRF protection."
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:183
-#, fuzzy
-msgid "Assets"
-msgstr "Kezdés dátuma"
-
-#: templates/backoffice/assembly_registration.html:204
-#, python-format
-msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:211
-#, fuzzy
-msgid "No images uploaded yet."
-msgstr "Feladat állapota"
-
-#: templates/backoffice/assembly_registration.html:273
+#: templates/backoffice/assembly_registration.html:126
 #, fuzzy
 msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:273
-#: templates/backoffice/assembly_registration.html:476
+#: templates/backoffice/assembly_registration.html:126
+#: templates/backoffice/assembly_registration.html:401
 #: templates/backoffice/components/edit_number_to_select_modal.html:41
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4920,325 +4874,376 @@ msgstr "Módosítások mentése"
 msgid "Save"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:274
+#: templates/backoffice/assembly_registration.html:138
 #, fuzzy
-msgid "Save and Republish and next →"
-msgstr "Módosítások mentése"
+msgid "Registration Form HTML"
+msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:274
-#: templates/backoffice/assembly_registration.html:477
+#: templates/backoffice/assembly_registration.html:149
+msgid "Show Form Skeleton"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:165
+msgid ""
+"Paste your HTML form code below. The only required placeholders are {{ "
+"form_action }} for the form's action attribute and {{ csrf_form_element "
+"}} for CSRF protection."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:199
 #, fuzzy
-msgid "Save and next →"
-msgstr "Elkezdve"
+msgid "Assets"
+msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:284
-#: templates/backoffice/assembly_registration.html:480
+#: templates/backoffice/assembly_registration.html:220
+#, python-format
+msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:227
+#, fuzzy
+msgid "No images uploaded yet."
+msgstr "Feladat állapota"
+
+#: templates/backoffice/assembly_registration.html:293
+#: templates/backoffice/assembly_registration.html:513
+msgid "Editing in progress — save or cancel to continue"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:295
+#: templates/backoffice/assembly_registration.html:297
+#: templates/backoffice/assembly_registration.html:350
+#: templates/backoffice/assembly_registration.html:516
+#: templates/backoffice/assembly_registration.html:519
 #, fuzzy
 msgid "Next →"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:306
+#: templates/backoffice/assembly_registration.html:322
 #, fuzzy
 msgid "Auto-reply cannot be sent"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:306
+#: templates/backoffice/assembly_registration.html:322
 msgid "Heads up"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:320
+#: templates/backoffice/assembly_registration.html:336
 msgid ""
 "Automatically send a confirmation email to people after they register. "
 "Templates support variables like the respondent's first name and the "
 "assembly title."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:325
+#: templates/backoffice/assembly_registration.html:341
 msgid "Set up auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:361
+#: templates/backoffice/assembly_registration.html:349
+#: templates/backoffice/assembly_registration.html:511
+#: templates/backoffice/assembly_registration.html:518
+#: templates/backoffice/assembly_registration.html:599
+msgid "← Back"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:386
 msgid "Auto-reply email template"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:367
+#: templates/backoffice/assembly_registration.html:395
 msgid "Send auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:381
+#: templates/backoffice/assembly_registration.html:416
 msgid "Email subject"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:383
+#: templates/backoffice/assembly_registration.html:418
 msgid "Jinja variables allowed, e.g. {{ assembly.title }}."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:393
+#: templates/backoffice/assembly_registration.html:428
 msgid "HTML body"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:395
+#: templates/backoffice/assembly_registration.html:430
 msgid ""
 "Jinja + HTML. A plain-text version is generated automatically for email "
 "clients that need it."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:413
+#: templates/backoffice/assembly_registration.html:451
 #, fuzzy
 msgid "Available variables"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:416
+#: templates/backoffice/assembly_registration.html:454
 msgid ""
 "Click a variable to select it, then copy and paste into the subject or "
 "body. Missing values render as an empty string."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:419
+#: templates/backoffice/assembly_registration.html:457
 #, fuzzy
 msgid "Assembly title"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/assembly_registration.html:420
+#: templates/backoffice/assembly_registration.html:458
 #, fuzzy
 msgid "Assembly question"
 msgstr "A gyűlés fő témája"
 
-#: templates/backoffice/assembly_registration.html:421
+#: templates/backoffice/assembly_registration.html:459
 #, fuzzy
 msgid "First assembly date (ISO)"
 msgstr "Első gyűlés időpontja"
 
-#: templates/backoffice/assembly_registration.html:422
+#: templates/backoffice/assembly_registration.html:460
 #, fuzzy
 msgid "Respondent first name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:423
+#: templates/backoffice/assembly_registration.html:461
 msgid "First name, or 'Friend' as a fallback"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:424
+#: templates/backoffice/assembly_registration.html:462
 #, fuzzy
 msgid "Respondent full name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:425
+#: templates/backoffice/assembly_registration.html:463
 #, fuzzy
 msgid "Respondent email address"
 msgstr "Email cím hiányzik"
 
-#: templates/backoffice/assembly_registration.html:448
+#: templates/backoffice/assembly_registration.html:486
 msgid "Variable copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:452
+#: templates/backoffice/assembly_registration.html:490
 #, python-format
 msgid "Copy %(label)s variable"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:473
-#: templates/backoffice/assembly_registration.html:560
-msgid "← Back"
-msgstr ""
-
-#: templates/backoffice/assembly_registration.html:568
+#: templates/backoffice/assembly_registration.html:607
 msgid "Publish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:597
+#: templates/backoffice/assembly_registration.html:636
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:603
-#: templates/backoffice/assembly_registration.html:666
-#: templates/backoffice/assembly_registration.html:757
+#: templates/backoffice/assembly_registration.html:642
+#: templates/backoffice/assembly_registration.html:705
+#: templates/backoffice/assembly_registration.html:796
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
-#: templates/backoffice/components/modal.html:106
-#: templates/backoffice/components/modal.html:164
+#: templates/backoffice/components/modal.html:54
+#: templates/backoffice/components/modal.html:133
 #: templates/backoffice/components/replacement_modal.html:170
 #: templates/backoffice/components/selection_progress_modal.html:89
 #, fuzzy
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:612
+#: templates/backoffice/assembly_registration.html:651
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:616
+#: templates/backoffice/assembly_registration.html:655
 msgid "Form skeleton preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:632
+#: templates/backoffice/assembly_registration.html:671
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:659
+#: templates/backoffice/assembly_registration.html:698
 #, fuzzy
 msgid "Upload image"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:675
+#: templates/backoffice/assembly_registration.html:714
 #, python-format
 msgid ""
 "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
 "Files are downscaled and re-encoded to PNG on upload."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:681
+#: templates/backoffice/assembly_registration.html:720
 msgid "Image file"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:697
-#: templates/backoffice/assembly_registration.html:856
+#: templates/backoffice/assembly_registration.html:736
+#: templates/backoffice/assembly_registration.html:895
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:709
-#: templates/backoffice/assembly_registration.html:868
+#: templates/backoffice/assembly_registration.html:748
+#: templates/backoffice/assembly_registration.html:907
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:750
+#: templates/backoffice/assembly_registration.html:789
 #, fuzzy
 msgid "Image details"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:776
+#: templates/backoffice/assembly_registration.html:815
 msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:783
+#: templates/backoffice/assembly_registration.html:822
 msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:788
+#: templates/backoffice/assembly_registration.html:827
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:793
+#: templates/backoffice/assembly_registration.html:832
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:796
+#: templates/backoffice/assembly_registration.html:835
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:804
+#: templates/backoffice/assembly_registration.html:843
 #, fuzzy
 msgid "File name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:817
+#: templates/backoffice/assembly_registration.html:856
 msgid "File name copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:821
+#: templates/backoffice/assembly_registration.html:860
 #, fuzzy
 msgid "Copy file name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:832
+#: templates/backoffice/assembly_registration.html:871
 #, fuzzy
 msgid "Image snippet"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:846
+#: templates/backoffice/assembly_registration.html:885
 msgid "Copy image snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:881
+#: templates/backoffice/assembly_registration.html:920
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:884
+#: templates/backoffice/assembly_registration.html:923
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:970
+#: templates/backoffice/assembly_registration.html:952
+#, fuzzy
+msgid "Discard your changes?"
+msgstr "ID (azonosító) oszlop"
+
+#: templates/backoffice/assembly_registration.html:957
+msgid ""
+"You have unsaved changes. If you leave now they will be lost and the last"
+" saved version will be kept."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:962
+#, fuzzy
+msgid "Keep editing"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/assembly_registration.html:963
+#, fuzzy
+msgid "Discard changes"
+msgstr "Módosítások mentése"
+
+#: templates/backoffice/assembly_registration.html:1114
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:981
-#: templates/backoffice/assembly_registration.html:1106
+#: templates/backoffice/assembly_registration.html:1125
+#: templates/backoffice/assembly_registration.html:1250
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:984
-#: templates/backoffice/assembly_registration.html:1094
-#: templates/backoffice/assembly_registration.html:1107
+#: templates/backoffice/assembly_registration.html:1128
+#: templates/backoffice/assembly_registration.html:1238
+#: templates/backoffice/assembly_registration.html:1251
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1039
+#: templates/backoffice/assembly_registration.html:1183
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1050
+#: templates/backoffice/assembly_registration.html:1194
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1053
+#: templates/backoffice/assembly_registration.html:1197
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1062
+#: templates/backoffice/assembly_registration.html:1206
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1073
-#: templates/backoffice/assembly_registration.html:1139
+#: templates/backoffice/assembly_registration.html:1217
+#: templates/backoffice/assembly_registration.html:1283
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1077
-#: templates/backoffice/assembly_registration.html:1146
+#: templates/backoffice/assembly_registration.html:1221
+#: templates/backoffice/assembly_registration.html:1290
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1080
-#: templates/backoffice/assembly_registration.html:1149
+#: templates/backoffice/assembly_registration.html:1224
+#: templates/backoffice/assembly_registration.html:1293
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1089
+#: templates/backoffice/assembly_registration.html:1233
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1093
+#: templates/backoffice/assembly_registration.html:1237
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1176
+#: templates/backoffice/assembly_registration.html:1320
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1184
+#: templates/backoffice/assembly_registration.html:1328
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1187
+#: templates/backoffice/assembly_registration.html:1331
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -6116,23 +6121,13 @@ msgstr "Jelentések a folyamatról"
 
 #: templates/backoffice/service_docs.html:49
 #, fuzzy
-msgid "Documents"
-msgstr "Kieső emberek pótlása új kiválasztással"
-
-#: templates/backoffice/service_docs.html:50
-#, fuzzy
 msgid "Emails"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/service_docs.html:52
+#: templates/backoffice/service_docs.html:51
 #, fuzzy
 msgid "Service categories"
 msgstr "Feladat állapota"
-
-#: templates/backoffice/showcase.html:63 templates/backoffice/showcase.html:78
-#, fuzzy
-msgid "Jump to section"
-msgstr "Kiválasztás"
 
 #: templates/backoffice/components/alert.html:84
 msgid "Dismiss"
@@ -6298,7 +6293,7 @@ msgid "Manage Tabs Progress"
 msgstr "Feladat folyamatban"
 
 #: templates/backoffice/components/manage_tabs_progress_modal.html:21
-#: templates/backoffice/components/modal.html:301
+#: templates/backoffice/components/modal.html:274
 #: templates/backoffice/components/replacement_modal.html:50
 msgid "Processing..."
 msgstr ""
@@ -6333,11 +6328,11 @@ msgstr "Táblázat megtekintése"
 msgid "Delete These Tabs"
 msgstr ""
 
-#: templates/backoffice/components/modal.html:269
+#: templates/backoffice/components/modal.html:242
 msgid "Waiting for task to start..."
 msgstr ""
 
-#: templates/backoffice/components/modal.html:271
+#: templates/backoffice/components/modal.html:244
 #, fuzzy
 msgid "Messages:"
 msgstr "Jelentések a folyamatról"
@@ -6432,7 +6427,7 @@ msgstr "Táblázat lapfülei"
 msgid "No results found"
 msgstr "Az oldal nem elérhető"
 
-#: templates/backoffice/components/split_button.html:61
+#: templates/backoffice/components/split_button.html:98
 #, fuzzy
 msgid "More actions"
 msgstr "Kiválasztás"
@@ -6537,7 +6532,6 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:294
 #: templates/backoffice/service_docs/_config.html:25
 #: templates/backoffice/service_docs/_config.html:128
-#: templates/backoffice/service_docs/_documents.html:35
 #: templates/backoffice/service_docs/_emails.html:41
 #: templates/backoffice/service_docs/_emails.html:142
 #: templates/backoffice/service_docs/_emails.html:202
@@ -8074,8 +8068,6 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:225
 #: templates/backoffice/service_docs/_assembly.html:333
 #: templates/backoffice/service_docs/_config.html:50
-#: templates/backoffice/service_docs/_documents.html:75
-#: templates/backoffice/service_docs/_documents.html:176
 #: templates/backoffice/service_docs/_emails.html:50
 #: templates/backoffice/service_docs/_emails.html:148
 #: templates/backoffice/service_docs/_emails.html:208
@@ -8125,12 +8117,6 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:128
 #: templates/backoffice/service_docs/_assembly.html:235
 #: templates/backoffice/service_docs/_assembly.html:343
-#: templates/backoffice/service_docs/_documents.html:106
-#: templates/backoffice/service_docs/_documents.html:186
-#: templates/backoffice/service_docs/_documents.html:239
-#: templates/backoffice/service_docs/_documents.html:300
-#: templates/backoffice/service_docs/_documents.html:368
-#: templates/backoffice/service_docs/_documents.html:421
 #: templates/backoffice/service_docs/_images.html:106
 #: templates/backoffice/service_docs/_images.html:186
 #: templates/backoffice/service_docs/_images.html:239
@@ -8153,12 +8139,6 @@ msgstr ""
 #: templates/backoffice/service_docs/_assembly.html:166
 #: templates/backoffice/service_docs/_assembly.html:260
 #: templates/backoffice/service_docs/_assembly.html:384
-#: templates/backoffice/service_docs/_documents.html:149
-#: templates/backoffice/service_docs/_documents.html:209
-#: templates/backoffice/service_docs/_documents.html:270
-#: templates/backoffice/service_docs/_documents.html:338
-#: templates/backoffice/service_docs/_documents.html:391
-#: templates/backoffice/service_docs/_documents.html:449
 #: templates/backoffice/service_docs/_images.html:149
 #: templates/backoffice/service_docs/_images.html:209
 #: templates/backoffice/service_docs/_images.html:270
@@ -8287,76 +8267,6 @@ msgstr "Új jelszó"
 #, fuzzy
 msgid "Reset"
 msgstr "Válaszadókat tartalmazó lapful neve"
-
-#: templates/backoffice/service_docs/_documents.html:6
-msgid ""
-"Upload, list, relabel and delete PDF documents attached to an assembly's "
-"registration page. Uploads are size-capped, gated on the PDF magic bytes,"
-" stored as-uploaded and de-duplicated by SHA-256."
-msgstr ""
-
-#: templates/backoffice/service_docs/_documents.html:9
-msgid ""
-"Only PDF files are accepted. The page must already exist (use the "
-"Registration tab to create one)."
-msgstr ""
-
-#: templates/backoffice/service_docs/_documents.html:30
-msgid ""
-"Validate and store a PDF for the assembly's registration page. Identical "
-"bytes on the same page collapse to one row; on re-upload the caller's "
-"label wins."
-msgstr ""
-
-#: templates/backoffice/service_docs/_documents.html:84
-#: templates/backoffice/service_docs/_images.html:84
-#: templates/backoffice/service_docs/_registration.html:409
-#: templates/backoffice/service_docs/_registration.html:628
-#: templates/backoffice/service_docs/_registration.html:756
-#: templates/backoffice/service_docs/_registration.html:970
-#: templates/backoffice/service_docs/_registration.html:1086
-#: templates/backoffice/service_docs/_registration.html:1198
-#: templates/backoffice/service_docs/_registration.html:1310
-#: templates/backoffice/service_docs/_respondents.html:118
-#: templates/backoffice/service_docs/_respondents.html:304
-#: templates/backoffice/service_docs/_selection.html:245
-#: templates/backoffice/service_docs/_selection.html:320
-#, fuzzy
-msgid "Error Cases"
-msgstr "Hiba részletei"
-
-#: templates/backoffice/service_docs/_documents.html:173
-msgid ""
-"Return every document attached to the assembly's registration page. Empty"
-" list when no page exists yet."
-msgstr ""
-
-#: templates/backoffice/service_docs/_documents.html:233
-msgid ""
-"Permanently delete a document. The document_id must belong to the "
-"assembly's registration page."
-msgstr ""
-
-#: templates/backoffice/service_docs/_documents.html:294
-msgid ""
-"Update a document's label in place. Records an edit on the parent "
-"registration page."
-msgstr ""
-
-#: templates/backoffice/service_docs/_documents.html:362
-msgid ""
-"List documents paired with ready-to-paste <a> download snippets. URLs "
-"point at the public /register/<slug>/documents/<sha>.pdf route; link text"
-" is the label plus a human-readable size."
-msgstr ""
-
-#: templates/backoffice/service_docs/_documents.html:415
-msgid ""
-"Lookup helper used by the public "
-"/register/<slug>/documents/<document_name> route. Returns None unless the"
-" registration page is publicly loadable (TEST or PUBLISHED). The response"
-" here reports metadata; fetch the actual bytes from the public URL."
-msgstr ""
 
 #: templates/backoffice/service_docs/_emails.html:10
 #, fuzzy
@@ -8651,6 +8561,22 @@ msgid ""
 "page. Identical bytes on the same page collapse to one row."
 msgstr ""
 
+#: templates/backoffice/service_docs/_images.html:84
+#: templates/backoffice/service_docs/_registration.html:409
+#: templates/backoffice/service_docs/_registration.html:628
+#: templates/backoffice/service_docs/_registration.html:756
+#: templates/backoffice/service_docs/_registration.html:970
+#: templates/backoffice/service_docs/_registration.html:1086
+#: templates/backoffice/service_docs/_registration.html:1198
+#: templates/backoffice/service_docs/_registration.html:1310
+#: templates/backoffice/service_docs/_respondents.html:118
+#: templates/backoffice/service_docs/_respondents.html:304
+#: templates/backoffice/service_docs/_selection.html:245
+#: templates/backoffice/service_docs/_selection.html:320
+#, fuzzy
+msgid "Error Cases"
+msgstr "Hiba részletei"
+
 #: templates/backoffice/service_docs/_images.html:173
 msgid ""
 "Return every image attached to the assembly's registration page. Empty "
@@ -8922,17 +8848,6 @@ msgstr ""
 
 #: templates/backoffice/service_docs/_targets.html:151
 msgid "This operation always replaces existing targets for the selected assembly."
-msgstr ""
-
-#: templates/backoffice/showcase/modal_component.html:24
-#, fuzzy
-msgid "Delete Account?"
-msgstr "Hozzon létre fiókot"
-
-#: templates/backoffice/showcase/modal_component.html:24
-msgid ""
-"Deleting account is irreversible and will erase all your data. This "
-"action cannot be undone."
 msgstr ""
 
 #: templates/backoffice/showcase/pagination_component.html:82
@@ -13821,13 +13736,4 @@ msgstr ""
 #~ "Submissions made via these URLs are "
 #~ "recorded as test submissions and will"
 #~ " not enter the selection pool."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Upload, list, relabel and delete PDF "
-#~ "documents attached to an assembly's "
-#~ "registration page. Uploads are size-"
-#~ "capped, gated on the %PDF- magic "
-#~ "bytes, stored as-uploaded and de-"
-#~ "duplicated by SHA-256."
 #~ msgstr ""


### PR DESCRIPTION
## What

Reworks the registration setup wizard's UX end to end: heavy HTML content can't be edited (or lost) accidentally, each step is a clean review page, the published lifecycle is fully controllable, and the whole flow keeps its click-through "tour" feeling.

### Explicit view/edit mode
- **Editing controls live in the editor card header.** View mode shows an **Edit** button next to "Show Form Skeleton"; edit mode swaps it in place for **Cancel / Save** ("Save and Republish" when published). Same pattern on the form and email steps. "Save and next" is dropped from the UI (the backend action remains for compatibility).
- **Sidebars render only in edit mode.** The Assets panel (form step) and Available-variables panel (email step) are editing tools; the read-only view is a clean, full-width review of the content.
- **Unsaved changes are guarded.** Alpine dirty-tracking (CodeMirror edits are caught too); cancelling with unsaved changes opens the Figma-aligned **"Discard changes?"** dialog (destructive plain-text button, "Keep editing" as the focused primary); `beforeunload` is the backstop for browser-level navigation.
- **Navigation is fully locked while editing.** The footer's Back/Next are disabled with a hint, and the **stepper is disabled too** via a new macro-level `disabled` attribute on the stepper component (works in tabs and wizard modes: steps render as non-focusable `aria-disabled` spans). The attribute is documented with live examples on the component showcase and the frontend patterns page. Result: the preview step can never silently lag unsaved edits, and a clean edit session can't wander off mid-edit either.
- **Scroll position is preserved** across Edit/Cancel mode switches and Back/Next step navigation via the existing `x-scroll-preserve-links` directive.

### Sticky wizard footer
- The footer is **navigation only** (Back / Next / lifecycle actions) and sticks to the viewport bottom on all three steps.
- **Card when in flow, full-bleed when stuck:** in normal document flow it looks like every other box (border, radius, padding); when its `position: sticky` engages, a pure-CSS `@container scroll-state(stuck: bottom)` query stretches it to the full viewport width with no button shift. Non-Chromium browsers gracefully keep the card look.

### Preview step refactor
- Now uses the same 2/3 + 1/3 layout as the other steps: the left column **embeds a live, read-only preview of the saved registration form** (same-origin iframe of a new GET-only backoffice route rendering through the public pipeline), so organisers can inspect and test interactions (dropdowns etc.) without opening the public URL. Submission is neutralised twice over (empty form action → 405, plus a capture-phase submit blocker); the security form fields are omitted. The endpoint gets a narrow same-origin-only exemption from the global `frame-ancestors 'none'` policy.
- The right column is a sticky **"Share your form"** sidebar with the registration URL, short URL and QR code.

### Registration lifecycle controls
- Published forms previously offered no way out. The preview footer now shows **Unpublish** (tertiary, back to test mode) and **Close registration** (secondary) when published. Closing is terminal (no reopen in the UI) so it goes through a confirmation dialog. Lifecycle actions redirect back to the preview step.

### Auto-reply simplification (always-on)
- The enable/disable switch abused template assign/unassign as an on/off state, with the page-template association round-tripping through a hidden form field. It's gone: **the auto-reply is always sent once a template exists**. The checkbox stays as a checked, disabled indicator; page creation assigns the seeded template immediately; saving self-heals legacy pages left unassigned by the old switch. A real off-switch gets a first-class service method if the need ever emerges.

### Misc UX / hardening
- **Toasts and flash alerts** moved from bottom-right to the **top-center** of the viewport.
- **Registration pages are invisible to search engines** in every status: the blanket `X-Robots-Tag` header upgraded to `noindex, nofollow` across the whole registration blueprint, with matching `<meta name=robots>` tags on all public templates (the closed page was missing one). Complements the existing robots.txt `Disallow` rules.

## Testing

- **Component:** per-status footer controls, lifecycle transitions and redirects, preview-route contract (rendering, submission neutralisation, framing headers, 403/404), header Save controls, hidden sidebars, always-on auto-reply (incl. self-heal), robots headers/meta, floating-alert positioning.
- **BDD (real browser):** editor round-trips, nav lock while editing (footer buttons and disabled stepper), clean/dirty Cancel with keep-editing and discard paths, scroll preservation on Edit, embedded preview (visible, interactive, submit does nothing), unpublish, and the close-confirmation keep-open/confirm paths. Full backoffice suite passing (73 scenarios) plus the accessibility suite.
- **e2e:** stepper journey updated for the always-on auto-reply.
- `just check` clean (lint, mypy, deptry); Tailwind CSS rebuilt; translation catalogs regenerated.

Note for local BDD runs: with `FF_OLD_DEFAULT_DASHBOARD=false` in `.env` the suite's login helper times out (pre-existing, unrelated); run with `FF_OLD_DEFAULT_DASHBOARD=true FF_DASHBOARD_SWITCH_LINKS=true CI=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


