### PR TITLE
feat(768): PDF document upload UI in the registration Assets panel

### DIFF
--- a/backend/docs/agent/768-pdf-upload-ui/code-review-findings.md
+++ b/backend/docs/agent/768-pdf-upload-ui/code-review-findings.md
@@ -1,0 +1,74 @@
+# Code review findings — 768-pdf-upload-ui (PR #225)
+
+Reviewed: `git diff origin/main...768-pdf-upload-ui` (3 commits), 2026-07-29, high effort.
+Scope: document upload/relabel/delete routes in `backoffice_registration.py`, Assets panel
+Documents subsection + modals + Alpine JS in `assembly_registration.html`, component tests,
+and the service-docs error-token fixes. Excluded per agreement: the pre-existing
+`test_2fa_flow.py::test_login_with_2fa_backup_code` failure on main, and the undefined
+info/success/warning token family (handled on branch `797-undefined-design-token-references`).
+
+## Verdict
+
+**No correctness, security, or CSP findings.** The implementation mirrors the image-asset
+pattern closely, and the places where that pattern carries risk were checked and cleared
+(see "Verified non-issues"). The findings below are minor consistency and coverage notes,
+none blocking merge.
+
+## Findings (most severe first — all low)
+
+### 1. Snippet text diverges from the service-layer snippet helper (cosmetic)
+
+`_document_to_dict` builds the `<a>` snippet text from `display_name` (label → original
+filename → short-sha fallback), while `registration_document_service._snippet_text` uses
+`document.label` directly. For a document whose label is blank — only creatable through the
+dev service-docs tab, since the product routes default the label to the filename and reject
+blank labels on PATCH — the dev tab's snippet renders as ` (PDF, 123 KB)` with empty link
+text while the product UI shows the filename. Suggest aligning `_snippet_text` to the same
+fallback chain. File: `src/opendlp/service_layer/registration_document_service.py:153`.
+
+### 2. Route tests omit the permission and quota branches (test coverage)
+
+`test_backoffice_registration_documents.py` covers auth redirects, upload happy path,
+label default, non-PDF rejection, missing file, PATCH, and DELETE (204/404), but not the
+403 (non-manager role) or `DocumentQuotaExceeded` → 400 branches. The image route tests
+have the same gap, so this is inherited parity rather than a regression — worth closing
+for both in one follow-up if desired.
+
+### 3. Native `confirm()` for list-row deletion (UX consistency, inherited)
+
+`deleteDocument()` uses the browser-native `confirm()` dialog, copied from `deleteImage()`.
+The app's own destructive flows (close registration, discard changes) use styled modal
+dialogs. Kept for parity with images; if it changes, change both together.
+
+### 4. File input `accept` could include the extension fallback (nit)
+
+`accept="application/pdf"` works in current browsers, but `accept="application/pdf,.pdf"`
+is more robust on some OS file-picker combinations where the MIME association is missing.
+Server-side validation (magic-bytes check) is the real gate either way.
+
+## Verified non-issues
+
+- **Oversized uploads**: Flask `MAX_CONTENT_LENGTH` is set globally (`config.py:492`), so a
+  multi-GB body is rejected before `upload.read()`; `validate_pdf` enforces the 5 MB PDF cap
+  after that.
+- **Label length**: the `registration_documents.label` column is an unbounded Postgres
+  `String` — no silent truncation or 500 on long labels.
+- **CSRF**: all three fetch verbs send `X-CSRFToken`; routes are `@login_required` and the
+  service layer enforces `can_manage_assembly`.
+- **CSP-safe Alpine**: flat `x-model` props only; `@click` passes identifiers (`doc`,
+  `editingDocument`), never string literals; clipboard copy for the file name uses the
+  `data-copy-text` attribute pattern.
+- **i18n**: every new user-facing string (routes, template, JS toasts, aria-labels) is
+  wrapped in `_()`; Hungarian catalog regenerated. Aria-labels are built server-side with
+  `%(name)s` placeholders so word order is translatable.
+- **Logging/PII**: new log lines carry only assembly/document UUIDs and error strings via
+  structlog — no filenames or user PII.
+- **XSS**: snippet HTML is built by `generate_document_html`, which HTML-escapes href and
+  text; `documents|tojson` in the script block uses Flask's script-safe JSON encoding.
+- **Template gating**: document modals and JS live inside the same
+  `{% if has_registration_page %}` blocks as the image ones; the view always passes
+  `documents` (empty list when no page), so `x-data` seeding cannot KeyError.
+- **Dedup re-upload**: server returns the existing row (with the caller's label applied);
+  the JS replaces the matching row in place instead of duplicating it.
+- **mypy strict / prek**: both clean; component suite 709 passed (single failure is the
+  excluded pre-existing 2FA test).

--- a/backend/docs/agent/768-pdf-upload-ui/code-review-findings.md
+++ b/backend/docs/agent/768-pdf-upload-ui/code-review-findings.md
@@ -26,13 +26,20 @@ blank labels on PATCH — the dev tab's snippet renders as ` (PDF, 123 KB)` with
 text while the product UI shows the filename. Suggest aligning `_snippet_text` to the same
 fallback chain. File: `src/opendlp/service_layer/registration_document_service.py:153`.
 
-### 2. Route tests omit the permission and quota branches (test coverage)
+### 2. Route tests omitted the error branches (test coverage) — RESOLVED
 
-`test_backoffice_registration_documents.py` covers auth redirects, upload happy path,
-label default, non-PDF rejection, missing file, PATCH, and DELETE (204/404), but not the
-403 (non-manager role) or `DocumentQuotaExceeded` → 400 branches. The image route tests
-have the same gap, so this is inherited parity rather than a regression — worth closing
-for both in one follow-up if desired.
+This finding originally understated the problem as "inherited parity, optional follow-up".
+In fact `codecov/patch` failed on the PR at 84.5% with **34 uncovered new lines** — all of
+them error-handling branches of the three new routes (upload read-failure/quota/no-page/
+403/404/500; PATCH and DELETE 404/403/500 variants). Parity with the image routes' gaps
+did not help, because the patch check measures only the diff's new lines.
+
+**Resolved 2026-07-29**: 15 error-branch tests added (`TestUploadErrorBranches` plus PATCH/
+DELETE branch tests) using a non-manager user for 403s, a monkeypatched document quota for
+the 400, assemblies without a registration page for those 404s, and monkeypatched service
+raises for the 500 handlers. Full component-suite coverage now shows **no uncovered lines
+in any code added by this branch**; the file's remaining uncovered lines (image/email error
+branches) are inherited from main.
 
 ### 3. Native `confirm()` for list-row deletion (UX consistency, inherited)
 

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -11,7 +11,13 @@ from flask_login import current_user, login_required
 from werkzeug.exceptions import HTTPException
 
 from opendlp import bootstrap
-from opendlp.config import get_max_image_upload_mb
+from opendlp.config import get_max_image_upload_mb, get_max_pdf_upload_mb
+from opendlp.domain.registration_document import (
+    PDF_FILE_EXTENSION,
+    DocumentValidationError,
+    RegistrationDocument,
+    generate_document_html,
+)
 from opendlp.domain.registration_image import (
     ALLOWED_INPUT_FORMATS,
     IMAGE_FILE_EXTENSION,
@@ -24,6 +30,7 @@ from opendlp.domain.registration_page import (
     RegistrationPageNotReady,
     RegistrationPageStatus,
 )
+from opendlp.domain.uploads import human_size
 from opendlp.entrypoints.blueprints.registration import registration_url, short_url
 from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
 from opendlp.service_layer.assembly_service import get_assembly_nav_context
@@ -36,15 +43,23 @@ from opendlp.service_layer.email_template_service import (
     update_email_template,
 )
 from opendlp.service_layer.exceptions import (
+    DocumentQuotaExceeded,
     EmailTemplateInvalid,
     EmailTemplateNotFoundError,
     ImageQuotaExceeded,
     InsufficientPermissions,
     NotFoundError,
+    RegistrationDocumentNotFoundError,
     RegistrationImageNotFoundError,
     RegistrationPageNotFoundError,
 )
 from opendlp.service_layer.qr_codes import generate_qr_code_base64, generate_qr_code_png
+from opendlp.service_layer.registration_document_service import (
+    add_registration_document,
+    delete_registration_document,
+    list_registration_documents,
+    set_registration_document_label,
+)
 from opendlp.service_layer.registration_image_service import (
     add_registration_image,
     delete_registration_image,
@@ -107,6 +122,41 @@ def _image_to_dict(image: RegistrationImage, url_slug: str) -> dict[str, Any]:
     }
 
 
+def _document_to_dict(document: RegistrationDocument, url_slug: str) -> dict[str, Any]:
+    """Serialise a PDF document for the Assets panel.
+
+    ``public_url`` is the public ``/register/<slug>/documents/<sha>.pdf`` route. If the
+    page has no slug yet (newly created), we return a placeholder so the front-end
+    can still render the row.
+    """
+    file_name = f"{document.sha256}.{PDF_FILE_EXTENSION}"
+    public_url = (
+        url_for("registration.serve_registration_document", url_slug=url_slug, document_name=file_name)
+        if url_slug
+        else ""
+    )
+    if document.label and document.label.strip():
+        display_name = document.label.strip()
+    elif document.original_filename:
+        display_name = document.original_filename
+    else:
+        display_name = f"{document.sha256[:8]}.{PDF_FILE_EXTENSION}"
+    snippet_text = f"{display_name} (PDF, {human_size(document.byte_size)})"
+    return {
+        "id": str(document.id),
+        "label": document.label,
+        "original_filename": document.original_filename,
+        "file_name": file_name,
+        "display_name": display_name,
+        "public_url": public_url,
+        "a_snippet": generate_document_html(public_url, snippet_text) if public_url else "",
+        "byte_size": document.byte_size,
+        "aria_label_details": _("Details for %(name)s", name=display_name),
+        "aria_label_copy_snippet": _("Copy download link snippet for %(name)s", name=display_name),
+        "aria_label_delete": _("Delete %(name)s", name=display_name),
+    }
+
+
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration")
 @login_required
 def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
@@ -146,12 +196,15 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
                 registration_short_url = short_url(registration_page.short_url_slug)
                 qr_code_data_url = generate_qr_code_base64(registration_short_url)
 
-        # Load registration images for the Assets panel
+        # Load registration images and PDF documents for the Assets panel
         images: list[dict[str, Any]] = []
+        documents: list[dict[str, Any]] = []
         if has_registration_page and registration_page:
             # Reuse the UnitOfWork from the page lookup above.
             stored_images = list_registration_images(uow, current_user.id, assembly_id)
             images = [_image_to_dict(image, registration_page.url_slug) for image in stored_images]
+            stored_documents = list_registration_documents(uow, current_user.id, assembly_id)
+            documents = [_document_to_dict(document, registration_page.url_slug) for document in stored_documents]
 
         # The HTML editor is read-only by default; ?edit=1 unlocks it. CLOSED pages
         # have no save path so we always keep them read-only regardless of the param.
@@ -182,7 +235,9 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
             thank_you_html=thank_you_html,
             has_registration_page=has_registration_page,
             images=images,
+            documents=documents,
             max_image_upload_mb=get_max_image_upload_mb(),
+            max_pdf_upload_mb=get_max_pdf_upload_mb(),
             allowed_image_formats=sorted(ALLOWED_INPUT_FORMATS),
             edit_mode=edit_mode,
             active_section=active_section,
@@ -814,5 +869,106 @@ def delete_assembly_registration_image(assembly_id: uuid.UUID, image_id: uuid.UU
     except Exception as e:
         logger.error("Delete image error", assembly_id=str(assembly_id), image_id=str(image_id), error=str(e))
         return jsonify({"error": _("An error occurred while deleting the image")}), 500
+
+    return "", 204
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/documents", methods=["POST"])
+@login_required
+def upload_registration_document(assembly_id: uuid.UUID) -> ResponseReturnValue:
+    """Accept a multipart PDF upload and return the stored document metadata as JSON.
+
+    The Assets panel calls this from the registration tab so uploads don't disturb
+    the HTML editor's unsaved state — no full-page reload is required.
+    """
+    upload = request.files.get("document")
+    if upload is None or not upload.filename:
+        return jsonify({"error": _("No file was selected")}), 400
+
+    try:
+        raw = upload.read()
+    except Exception as e:
+        logger.warning("Failed to read uploaded document for assembly", assembly_id=str(assembly_id), error=str(e))
+        return jsonify({"error": _("Failed to read the uploaded file")}), 400
+
+    label = (request.form.get("label") or "").strip()
+
+    try:
+        document = add_registration_document(
+            bootstrap.get_flask_uow(),
+            current_user.id,
+            assembly_id,
+            raw,
+            original_filename=upload.filename or "",
+            label=label,
+        )
+    except DocumentValidationError as e:
+        return jsonify({"error": e.message, "reason": e.reason}), 400
+    except DocumentQuotaExceeded as e:
+        return jsonify({"error": str(e)}), 400
+    except RegistrationPageNotFoundError:
+        return jsonify({"error": _("Please create a registration page first from the Details tab.")}), 400
+    except InsufficientPermissions:
+        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
+    except NotFoundError:
+        return jsonify({"error": _("Assembly not found")}), 404
+    except Exception as e:
+        logger.exception("Document upload error for assembly", assembly_id=str(assembly_id), error=str(e))
+        return jsonify({"error": _("An error occurred while uploading the document")}), 500
+
+    return jsonify({"document": _document_to_dict(document, _resolve_page_url_slug(assembly_id))}), 201
+
+
+@backoffice_registration_bp.route(
+    "/assembly/<uuid:assembly_id>/registration/documents/<uuid:document_id>", methods=["PATCH"]
+)
+@login_required
+def update_assembly_registration_document(assembly_id: uuid.UUID, document_id: uuid.UUID) -> ResponseReturnValue:
+    """Update a document's label. Returns the updated document metadata as JSON."""
+    data = request.get_json(silent=True) or {}
+    label = (data.get("label") or "").strip()
+    if not label:
+        return jsonify({"error": _("Label is required")}), 400
+
+    try:
+        uow = bootstrap.get_flask_uow()
+        document = set_registration_document_label(uow, current_user.id, assembly_id, document_id, label=label)
+    except RegistrationDocumentNotFoundError:
+        return jsonify({"error": _("Document not found")}), 404
+    except RegistrationPageNotFoundError:
+        return jsonify({"error": _("Registration page not found")}), 404
+    except InsufficientPermissions:
+        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
+    except NotFoundError:
+        return jsonify({"error": _("Assembly not found")}), 404
+    except Exception as e:
+        logger.error(
+            "Update document label error", assembly_id=str(assembly_id), document_id=str(document_id), error=str(e)
+        )
+        return jsonify({"error": _("An error occurred while updating the document")}), 500
+
+    return jsonify({"document": _document_to_dict(document, _resolve_page_url_slug(assembly_id))}), 200
+
+
+@backoffice_registration_bp.route(
+    "/assembly/<uuid:assembly_id>/registration/documents/<uuid:document_id>", methods=["DELETE"]
+)
+@login_required
+def delete_assembly_registration_document(assembly_id: uuid.UUID, document_id: uuid.UUID) -> ResponseReturnValue:
+    """Delete a registration document. Returns 204 on success."""
+    try:
+        uow = bootstrap.get_flask_uow()
+        delete_registration_document(uow, current_user.id, assembly_id, document_id)
+    except RegistrationDocumentNotFoundError:
+        return jsonify({"error": _("Document not found")}), 404
+    except RegistrationPageNotFoundError:
+        return jsonify({"error": _("Registration page not found")}), 404
+    except InsufficientPermissions:
+        return jsonify({"error": _("You don't have permission to modify this assembly")}), 403
+    except NotFoundError:
+        return jsonify({"error": _("Assembly not found")}), 404
+    except Exception as e:
+        logger.error("Delete document error", assembly_id=str(assembly_id), document_id=str(document_id), error=str(e))
+        return jsonify({"error": _("An error occurred while deleting the document")}), 500
 
     return "", 204

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -200,13 +200,15 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                 <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
                                        style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers);">
                                     <div class="p-6 sticky top-4 w-full">
+                                        <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
+                                        {% set upload_icon %}
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
+                                            </svg>
+                                        {% endset %}
+                    {# Images subsection #}
                                         <div class="flex items-center justify-between mb-4">
-                                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
-                                            {% set upload_icon %}
-                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
-                                                </svg>
-                                            {% endset %}
+                                            <h3 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Images") }}</h3>
                                             {{ button(
                                             _("Upload"),
                                             variant="tertiary",
@@ -273,6 +275,85 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                                 class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
                                                                 style="color: var(--color-secondary-text);"
                                                                 :aria-label="image.aria_label_delete">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                                                            </svg>
+                                                        </button>
+                                                    </div>
+                                                </li>
+                                            </template>
+                                        </ul>
+
+                    {# Documents subsection #}
+                                        <div class="flex items-center justify-between mt-6 mb-4 pt-4"
+                                             style="border-top: 1px solid var(--color-borders-dividers);">
+                                            <h3 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Documents") }}</h3>
+                                            {{ button(
+                                            _("Upload"),
+                                            variant="tertiary",
+                                            leading_icon=upload_icon,
+                                            attrs='type="button" @click="openDocumentUploadModal()"'
+                                            ) }}
+                                        </div>
+
+                    {# Format / size hint #}
+                                        <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
+                                             style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                            </svg>
+                                            <p class="text-body-sm" style="color: var(--color-info-700);">
+                                                {{ _("PDF files only. Maximum file size: %(max)s MB per document.", max=max_pdf_upload_mb) }}
+                                            </p>
+                                        </div>
+
+                    {# Empty state #}
+                                        <template x-if="!documents.length">
+                                            <p class="text-body-sm text-center py-4" style="color: var(--color-secondary-text);">
+                                                {{ _("No documents uploaded yet.") }}
+                                            </p>
+                                        </template>
+
+                    {# Document list #}
+                                        <ul class="space-y-2" x-show="documents.length" x-cloak>
+                                            <template x-for="doc in documents" :key="doc.id">
+                                                <li class="rounded-md px-3 py-2 flex items-center justify-between"
+                                                    style="background-color: var(--color-subtle-background-panels);">
+                                                    <a :href="doc.public_url"
+                                                       :title="doc.label || doc.file_name"
+                                                       target="_blank"
+                                                       rel="noopener"
+                                                       class="text-body-sm truncate flex-1 mr-2"
+                                                       style="color: var(--color-body-text);"
+                                                       x-text="doc.display_name"></a>
+                                                    <div class="flex items-center gap-1 flex-shrink-0">
+                                    {# Document details / edit label #}
+                                                        <button type="button"
+                                                                @click="openDocumentDetailsModal(doc)"
+                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                style="color: var(--color-secondary-text);"
+                                                                :aria-label="doc.aria_label_details">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                            </svg>
+                                                        </button>
+                                    {# Copy <a> snippet to clipboard #}
+                                                        <button type="button"
+                                                                @click="copyDocumentSnippet(doc)"
+                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                style="color: var(--color-secondary-text);"
+                                                                :aria-label="doc.aria_label_copy_snippet">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                            </svg>
+                                                        </button>
+                                    {# Delete #}
+                                                        <button type="button"
+                                                                @click="deleteDocument(doc)"
+                                                                :disabled="documentBeingDeletedId === doc.id"
+                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                style="color: var(--color-secondary-text);"
+                                                                :aria-label="doc.aria_label_delete">
                                                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
                                                             </svg>
@@ -968,6 +1049,234 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                 </div>
             </template>
 
+        {# Document Upload Modal #}
+            <template x-if="documentUploadModalOpen">
+                <div x-cloak>
+                {# Backdrop overlay #}
+                    <div class="fixed inset-0 z-40"
+                         style="background-color: rgba(0, 0, 0, 0.5)"
+                         @click="closeDocumentUploadModalIfAllowed()"
+                         @keydown.escape.window="closeDocumentUploadModalIfAllowed()"></div>
+                {# Modal panel #}
+                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                         role="dialog"
+                         aria-modal="true"
+                         aria-labelledby="document-upload-modal-title">
+                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
+                             @click.stop>
+                        {# Header #}
+                            <div class="px-6 py-4 flex items-center justify-between"
+                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                <h2 id="document-upload-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                                    {{ _("Upload document") }}
+                                </h2>
+                                <button type="button"
+                                        @click="closeDocumentUploadModalIfAllowed()"
+                                        :disabled="documentUploading"
+                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
+                                        style="color: var(--color-secondary-text);"
+                                        aria-label="{{ _('Close') }}">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                    </svg>
+                                </button>
+                            </div>
+                        {# Content #}
+                            <div class="px-6 py-4">
+                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                    {{ _("PDF files only. Maximum file size: %(max)s MB per document.", max=max_pdf_upload_mb) }}
+                                </p>
+
+                                <div class="space-y-4">
+                                    <div>
+                                        <label for="document-upload-file" class="text-label-md block mb-1" style="color: var(--color-headings);">
+                                            {{ _("PDF file") }}
+                                        </label>
+                                        <input type="file"
+                                               id="document-upload-file"
+                                               x-ref="documentFileInput"
+                                               accept="application/pdf"
+                                               @change="onDocumentFileSelected($event)"
+                                               :disabled="documentUploading"
+                                               class="w-full px-3 py-2 rounded-md text-body-sm"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        <p x-show="documentFileName" x-cloak class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                            <span x-text="documentFileName"></span>
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <label for="document-upload-label" class="text-label-md block mb-1" style="color: var(--color-headings);">
+                                            {{ _("Label") }}
+                                        </label>
+                                        <input type="text"
+                                               id="document-upload-label"
+                                               x-model="documentLabel"
+                                               :disabled="documentUploading"
+                                               class="w-full px-3 py-2 rounded-md text-body-sm"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                            {{ _("Shown to registrants as the download link text and used as the file's display name in the asset list. Defaults to the file name.") }}
+                                        </p>
+                                    </div>
+                                {# Inline error #}
+                                    <div x-show="documentUploadError" x-cloak class="rounded-md p-3"
+                                         style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
+                                        <p class="text-body-sm" style="color: var(--color-error-600);" x-text="documentUploadError"></p>
+                                    </div>
+                                </div>
+                            </div>
+                        {# Footer #}
+                            <div class="px-6 py-3 flex gap-2 justify-end"
+                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeDocumentUploadModalIfAllowed()"', alpine_disabled="documentUploading") }}
+                                {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitDocumentUpload()"', alpine_disabled="!documentFile || documentUploading") }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
+        {# Document Details / Edit Label Modal #}
+            <template x-if="documentDetailsModalOpen && editingDocument">
+                <div x-cloak>
+                {# Backdrop overlay #}
+                    <div class="fixed inset-0 z-40"
+                         style="background-color: rgba(0, 0, 0, 0.5)"
+                         @click="closeDocumentDetailsModalIfAllowed()"
+                         @keydown.escape.window="closeDocumentDetailsModalIfAllowed()"></div>
+                {# Modal panel #}
+                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                         role="dialog"
+                         aria-modal="true"
+                         aria-labelledby="document-details-modal-title">
+                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+                             style="background-color: var(--color-tables-cards); border: 1px solid var(--color-borders-dividers)"
+                             @click.stop>
+                        {# Header #}
+                            <div class="px-6 py-4 flex items-center justify-between"
+                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                <h2 id="document-details-modal-title" class="text-heading-lg" style="color: var(--color-headings)">
+                                    {{ _("Document details") }}
+                                </h2>
+                                <button type="button"
+                                        @click="closeDocumentDetailsModalIfAllowed()"
+                                        :disabled="documentEditing"
+                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
+                                        style="color: var(--color-secondary-text);"
+                                        aria-label="{{ _('Close') }}">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                    </svg>
+                                </button>
+                            </div>
+                        {# Content #}
+                            <div class="px-6 py-4">
+                            {# Compact metadata #}
+                                <div class="rounded-md p-3 mb-4 grid gap-y-1 gap-x-3 text-body-sm content-center"
+                                     style="background-color: var(--color-subtle-background-panels); grid-template-columns: auto 1fr;">
+                                    <template x-if="editingDocument.original_filename">
+                                        <span class="contents">
+                                            <span class="text-label-lg whitespace-nowrap" style="color: var(--color-headings);">{{ _("Original filename") }}</span>
+                                            <span class="min-w-0 truncate text-code" style="color: var(--color-body-text);" :title="editingDocument.original_filename" x-text="editingDocument.original_filename"></span>
+                                        </span>
+                                    </template>
+
+                                    <span class="text-label-lg whitespace-nowrap" style="color: var(--color-headings);">{{ _("File size") }}</span>
+                                    <span class="min-w-0" style="color: var(--color-body-text);" x-text="formatBytes(editingDocument.byte_size)"></span>
+                                </div>
+
+                            {# File name (read-only + copy) #}
+                                <div class="mb-3">
+                                    <label for="document-details-filename" class="text-label-md block mb-1" style="color: var(--color-headings);">
+                                        {{ _("File name") }}
+                                    </label>
+                                    <div class="flex gap-2">
+                                        <input type="text"
+                                               id="document-details-filename"
+                                               readonly
+                                               :value="editingDocument.file_name"
+                                               @click="$event.target.select()"
+                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        {# :data-copy-text is bound reactively so it tracks editingDocument.file_name #}
+                                        <button type="button"
+                                                :data-copy-text="editingDocument.file_name"
+                                                data-copy-msg="{{ _('File name copied to clipboard') }}"
+                                                @click="copyToClipboard($el)"
+                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                                aria-label="{{ _('Copy file name') }}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+
+                            {# <a> snippet (read-only + copy) — hidden when there's no public URL yet #}
+                                <div class="mb-3" x-show="editingDocument.a_snippet">
+                                    <label for="document-details-snippet" class="text-label-md block mb-1" style="color: var(--color-headings);">
+                                        {{ _("Download link snippet") }}
+                                    </label>
+                                    <div class="flex gap-2">
+                                        <input type="text"
+                                               id="document-details-snippet"
+                                               readonly
+                                               :value="editingDocument.a_snippet"
+                                               @click="$event.target.select()"
+                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
+                                               style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                        <button type="button"
+                                                @click="copyDocumentSnippet(editingDocument)"
+                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                style="border: 1px solid var(--color-borders-dividers); color: var(--color-secondary-text);"
+                                                aria-label="{{ _('Copy download link snippet') }}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+
+                                <div>
+                                    <label for="document-edit-label" class="text-label-md block mb-1" style="color: var(--color-headings);">
+                                        {{ _("Label") }}
+                                        <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
+                                    </label>
+                                    <input type="text"
+                                           id="document-edit-label"
+                                           x-model="editingDocumentLabel"
+                                           :disabled="documentEditing"
+                                           required
+                                           aria-required="true"
+                                           class="w-full px-3 py-2 rounded-md text-body-sm"
+                                           style="border: 1px solid var(--color-borders-dividers); background: var(--color-page-background);" />
+                                    <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                        {{ _("Shown to registrants as the download link text and used as the file's display name in the asset list.") }}
+                                    </p>
+                                </div>
+
+                            {# Inline error #}
+                                <div x-show="documentEditError" x-cloak class="rounded-md p-3 mt-3"
+                                     style="background-color: var(--color-error-100); border: 1px solid var(--color-error-400);">
+                                    <p class="text-body-sm" style="color: var(--color-error-600);" x-text="documentEditError"></p>
+                                </div>
+                            </div>
+                        {# Footer #}
+                            <div class="px-6 py-3 flex gap-2 justify-between items-center"
+                                 style="border-top: 1px solid var(--color-borders-dividers); background-color: var(--color-tables-cards)">
+                                {{ button(_("Delete document"), variant="danger", attrs='type="button" @click="deleteEditingDocument()"', alpine_disabled="documentEditing || documentBeingDeletedId === editingDocument.id") }}
+                                <div class="flex gap-2">
+                                    {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeDocumentDetailsModalIfAllowed()"', alpine_disabled="documentEditing") }}
+                                    {{ button(_("Save label"), variant="primary", attrs='type="button" @click="submitDocumentEdit()"', alpine_disabled="!editingDocumentLabel.trim() || documentEditing") }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
         {# Close-registration confirmation — closing is terminal (there is no reopen), so the
            destructive action must be explicit. Same single-surface dialog style as the
            discard confirmation: the safe action is the primary on the right and receives
@@ -1179,6 +1488,31 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                     editingImageAlt: '',
                     imageEditing: false,
                     imageEditError: '',
+
+                    // PDF documents — same contract as images: seeded server-side,
+                    // mutated in place, sentinel-UUID URL template for item routes.
+                    documents: {{ documents|tojson }},
+                    uploadDocumentUrl: '{{ url_for("backoffice_registration.upload_registration_document", assembly_id=assembly.id) }}',
+                    documentItemUrlTemplate: '{{ url_for("backoffice_registration.update_assembly_registration_document", assembly_id=assembly.id, document_id="00000000-0000-0000-0000-000000000000") }}',
+                    documentItemUrl(id) {
+                        return this.documentItemUrlTemplate.replace(
+                            '00000000-0000-0000-0000-000000000000',
+                            encodeURIComponent(id),
+                        );
+                    },
+                    documentUploadModalOpen: false,
+                    documentUploading: false,
+                    documentFile: null,
+                    documentFileName: '',
+                    documentLabel: '',
+                    documentUploadError: '',
+                    documentBeingDeletedId: '',
+                    // Document details / edit-label modal
+                    documentDetailsModalOpen: false,
+                    editingDocument: null,
+                    editingDocumentLabel: '',
+                    documentEditing: false,
+                    documentEditError: '',
 
                     fetchSkeleton() {
                         this.skeletonLoading = true;
@@ -1421,6 +1755,185 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                             })
                             .finally(() => {
                                 this.imageEditing = false;
+                            });
+                    },
+
+                    openDocumentUploadModal() {
+                        this.documentFile = null;
+                        this.documentFileName = '';
+                        this.documentLabel = '';
+                        this.documentUploadError = '';
+                        this.documentUploadModalOpen = true;
+                    },
+
+                    closeDocumentUploadModalIfAllowed() {
+                        if (this.documentUploading) return;
+                        this.documentUploadModalOpen = false;
+                    },
+
+                    onDocumentFileSelected(event) {
+                        const file = event.target.files && event.target.files[0];
+                        this.documentFile = file || null;
+                        this.documentFileName = file ? file.name : '';
+                        this.documentUploadError = '';
+                    },
+
+                    submitDocumentUpload() {
+                        if (!this.documentFile || this.documentUploading) return;
+                        this.documentUploading = true;
+                        this.documentUploadError = '';
+                        const formData = new FormData();
+                        formData.append('document', this.documentFile);
+                        formData.append('label', this.documentLabel.trim());
+                        fetch(this.uploadDocumentUrl, {
+                            method: 'POST',
+                            headers: {
+                                'X-CSRFToken': '{{ csrf_token() }}'
+                            },
+                            body: formData
+                        })
+                            .then(async (response) => {
+                                const data = await response.json().catch(() => ({}));
+                                if (!response.ok) {
+                                    this.documentUploadError = data.error || '{{ _("Upload failed") }}';
+                                    return;
+                                }
+                                // Dedup against existing list (server returns the existing row when bytes match)
+                                const existing = this.documents.findIndex(doc => doc.id === data.document.id);
+                                if (existing >= 0) {
+                                    this.documents.splice(existing, 1, data.document);
+                                } else {
+                                    this.documents.push(data.document);
+                                }
+                                this.documentUploadModalOpen = false;
+                                this.showToast('{{ _("Document uploaded") }}', 'success');
+                            })
+                            .catch(() => {
+                                this.documentUploadError = '{{ _("Network error while uploading the document") }}';
+                            })
+                            .finally(() => {
+                                this.documentUploading = false;
+                            });
+                    },
+
+                    deleteDocument(doc) {
+                        if (!doc || this.documentBeingDeletedId) return;
+                        if (!confirm('{{ _("Delete this document?") }} ' + (doc.display_name || ''))) return;
+                        this.documentBeingDeletedId = doc.id;
+                        fetch(this.documentItemUrl(doc.id), {
+                            method: 'DELETE',
+                            headers: {
+                                'X-CSRFToken': '{{ csrf_token() }}'
+                            }
+                        })
+                            .then(async (response) => {
+                                if (!response.ok) {
+                                    const data = await response.json().catch(() => ({}));
+                                    this.showToast(data.error || '{{ _("Failed to delete document") }}', 'error');
+                                    return;
+                                }
+                                this.documents = this.documents.filter(d => d.id !== doc.id);
+                                this.showToast('{{ _("Document deleted") }}', 'success');
+                            })
+                            .catch(() => {
+                                this.showToast('{{ _("Network error while deleting the document") }}', 'error');
+                            })
+                            .finally(() => {
+                                this.documentBeingDeletedId = '';
+                            });
+                    },
+
+                    copyDocumentSnippet(doc) {
+                        if (!doc || !doc.a_snippet) {
+                            this.showToast('{{ _("No public URL available yet") }}', 'error');
+                            return;
+                        }
+                        navigator.clipboard.writeText(doc.a_snippet)
+                            .then(() => this.showToast('{{ _("Snippet copied to clipboard") }}', 'success'))
+                            .catch(() => this.showToast('{{ _("Failed to copy to clipboard") }}', 'error'));
+                    },
+
+                    openDocumentDetailsModal(doc) {
+                        if (!doc) return;
+                        this.editingDocument = doc;
+                        this.editingDocumentLabel = doc.label || '';
+                        this.documentEditError = '';
+                        this.documentDetailsModalOpen = true;
+                    },
+
+                    closeDocumentDetailsModalIfAllowed() {
+                        if (this.documentEditing) return;
+                        this.documentDetailsModalOpen = false;
+                        this.editingDocument = null;
+                        this.editingDocumentLabel = '';
+                        this.documentEditError = '';
+                    },
+
+                    deleteEditingDocument() {
+                        if (!this.editingDocument || this.documentEditing || this.documentBeingDeletedId) return;
+                        const doc = this.editingDocument;
+                        this.documentBeingDeletedId = doc.id;
+                        fetch(this.documentItemUrl(doc.id), {
+                            method: 'DELETE',
+                            headers: {
+                                'X-CSRFToken': '{{ csrf_token() }}'
+                            }
+                        })
+                            .then(async (response) => {
+                                if (!response.ok) {
+                                    const data = await response.json().catch(() => ({}));
+                                    this.showToast(data.error || '{{ _("Failed to delete document") }}', 'error');
+                                    return;
+                                }
+                                this.documents = this.documents.filter(d => d.id !== doc.id);
+                                this.documentDetailsModalOpen = false;
+                                this.editingDocument = null;
+                                this.editingDocumentLabel = '';
+                                this.showToast('{{ _("Document deleted") }}', 'success');
+                            })
+                            .catch(() => {
+                                this.showToast('{{ _("Network error while deleting the document") }}', 'error');
+                            })
+                            .finally(() => {
+                                this.documentBeingDeletedId = '';
+                            });
+                    },
+
+                    submitDocumentEdit() {
+                        if (!this.editingDocument || this.documentEditing) return;
+                        const label = this.editingDocumentLabel.trim();
+                        if (!label) {
+                            this.documentEditError = '{{ _("Label is required") }}';
+                            return;
+                        }
+                        this.documentEditing = true;
+                        this.documentEditError = '';
+                        fetch(this.documentItemUrl(this.editingDocument.id), {
+                            method: 'PATCH',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRFToken': '{{ csrf_token() }}'
+                            },
+                            body: JSON.stringify({ label: label })
+                        })
+                            .then(async (response) => {
+                                const data = await response.json().catch(() => ({}));
+                                if (!response.ok) {
+                                    this.documentEditError = data.error || '{{ _("Failed to update document") }}';
+                                    return;
+                                }
+                                const idx = this.documents.findIndex(d => d.id === data.document.id);
+                                if (idx >= 0) this.documents.splice(idx, 1, data.document);
+                                this.documentDetailsModalOpen = false;
+                                this.editingDocument = null;
+                                this.editingDocumentLabel = '';
+                                this.showToast('{{ _("Document updated") }}', 'success');
+                            })
+                            .catch(() => {
+                                this.documentEditError = '{{ _("Network error while updating the document") }}';
+                            })
+                            .finally(() => {
+                                this.documentEditing = false;
                             });
                     },
 

--- a/backend/templates/backoffice/service_docs/_documents.html
+++ b/backend/templates/backoffice/service_docs/_documents.html
@@ -259,7 +259,7 @@
                     </div>
                     <button @click="executeDeleteRegistrationDocument()"
                             class="px-4 py-2 rounded text-button-sm"
-                            style="background-color: var(--color-error-500); color: white;"
+                            style="background-color: var(--color-error-400); color: white;"
                             :disabled="loading.delete_document">
                         <span x-show="!loading.delete_document">Delete</span>
                         <span x-show="loading.delete_document">Loading...</span>

--- a/backend/templates/backoffice/service_docs/_images.html
+++ b/backend/templates/backoffice/service_docs/_images.html
@@ -259,7 +259,7 @@
                     </div>
                     <button @click="executeDeleteRegistrationImage()"
                             class="px-4 py-2 rounded text-button-sm"
-                            style="background-color: var(--color-error-500); color: white;"
+                            style="background-color: var(--color-error-400); color: white;"
                             :disabled="loading.delete_image">
                         <span x-show="!loading.delete_image">Delete</span>
                         <span x-show="loading.delete_image">Loading...</span>

--- a/backend/templates/backoffice/service_docs/_registration.html
+++ b/backend/templates/backoffice/service_docs/_registration.html
@@ -44,7 +44,7 @@
                     <div class="flex flex-col items-center">
                         <span class="text-body-sm mb-1" style="color: var(--color-error-600);">close()</span>
                         <svg class="w-12 h-6" viewBox="0 0 48 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M0 12h40M40 12l-8-6M40 12l-8 6" stroke="var(--color-error-500)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path d="M0 12h40M40 12l-8-6M40 12l-8 6" stroke="var(--color-error-400)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
                         <span class="text-body-sm mt-1" style="color: var(--color-info-600);">← reopen()</span>
                     </div>
@@ -52,7 +52,7 @@
                     {# CLOSED State #}
                     <div class="text-center">
                         <div class="px-6 py-3 rounded-lg font-semibold"
-                             style="background-color: var(--color-error-100); border: 2px solid var(--color-error-500); color: var(--color-error-700);">
+                             style="background-color: var(--color-error-100); border: 2px solid var(--color-error-400); color: var(--color-error-600);">
                             CLOSED
                         </div>
                         <p class="text-body-sm mt-2" style="color: var(--color-secondary-text); max-width: 120px;">
@@ -93,7 +93,7 @@
                         </tr>
                         <tr>
                             <td class="px-3 py-2 text-code">
-                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-error-100); color: var(--color-error-700);">CLOSED</span>
+                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-error-100); color: var(--color-error-600);">CLOSED</span>
                             </td>
                             <td class="px-3 py-2">❌ False</td>
                             <td class="px-3 py-2">302 redirect to /registration-closed</td>
@@ -138,7 +138,7 @@
                         </tr>
                         <tr>
                             <td class="px-3 py-2 text-code">
-                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-error-100); color: var(--color-error-700);">CLOSED</span>
+                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-error-100); color: var(--color-error-600);">CLOSED</span>
                             </td>
                             <td class="px-3 py-2">
                                 <span class="px-2 py-1 rounded mr-1" style="background-color: var(--color-button-secondary-bg); border: 1px solid var(--color-borders-dividers);">Save</span>

--- a/backend/tests/component/test_backoffice_registration_documents.py
+++ b/backend/tests/component/test_backoffice_registration_documents.py
@@ -1,0 +1,233 @@
+# ABOUTME: Component tests for the backoffice registration document helpers and JSON routes
+# ABOUTME: Drives the real POST/PATCH/DELETE endpoints + services over a FakeUnitOfWork via the test client
+
+import uuid
+from io import BytesIO
+
+import pytest
+
+from opendlp.domain.registration_document import RegistrationDocument
+from opendlp.entrypoints.blueprints.backoffice_registration import _document_to_dict
+from opendlp.service_layer.document_processing import validate_pdf
+from opendlp.service_layer.registration_page_service import create_registration_page_with_slugs
+from tests.fakes import FakeUnitOfWork
+
+_MAX_BYTES = 10 * 1024 * 1024
+
+
+def _pdf(marker: bytes = b"body") -> bytes:
+    return b"%PDF-1.4\n" + marker + b"\n%%EOF"
+
+
+def _document(*, label: str = "Info pack", sha256: str = "a" * 64, original_filename: str = "") -> RegistrationDocument:
+    return RegistrationDocument(
+        registration_page_id=uuid.uuid4(),
+        byte_size=123,
+        sha256=sha256,
+        data=_pdf(),
+        label=label,
+        original_filename=original_filename,
+        created_by=uuid.uuid4(),
+    )
+
+
+@pytest.fixture
+def registration_page(fake_store, admin_user, existing_assembly):
+    with FakeUnitOfWork(store=fake_store) as uow:
+        page = create_registration_page_with_slugs(uow, admin_user.id, existing_assembly.id)
+    return page
+
+
+def _seed_document(fake_store, page, *, label: str = "Info pack", marker: bytes = b"body") -> RegistrationDocument:
+    validated = validate_pdf(_pdf(marker), max_bytes=_MAX_BYTES)
+    document = RegistrationDocument.from_validated(page.id, validated, label=label)
+    with FakeUnitOfWork(store=fake_store) as uow:
+        uow.registration_documents.add(document)
+        uow.commit()
+    return document.create_detached_copy()
+
+
+def _stored_documents(fake_store, page) -> list[RegistrationDocument]:
+    with FakeUnitOfWork(store=fake_store) as uow:
+        return uow.registration_documents.list_by_page_id(page.id)
+
+
+class TestDocumentToDict:
+    def test_builds_public_url_and_snippet_when_slug_present(self, app):
+        document = _document(label="Assembly info pack", sha256="b" * 64)
+        with app.test_request_context():
+            result = _document_to_dict(document, url_slug="my-slug")
+
+        assert result["id"] == str(document.id)
+        assert result["label"] == "Assembly info pack"
+        assert result["file_name"] == f"{'b' * 64}.pdf"
+        assert result["display_name"] == "Assembly info pack"
+        assert "/register/my-slug/documents/" in result["public_url"]
+        assert result["public_url"].endswith(f"{'b' * 64}.pdf")
+        # Domain helper html-escapes both href and link text
+        assert result["a_snippet"].startswith('<a href="')
+        assert "Assembly info pack (PDF," in result["a_snippet"]
+        assert result["byte_size"] == 123
+
+    def test_includes_original_filename(self, app):
+        document = _document(label="Assembly info pack", original_filename="info-pack.pdf")
+        with app.test_request_context():
+            result = _document_to_dict(document, url_slug="my-slug")
+        assert result["original_filename"] == "info-pack.pdf"
+
+    def test_falls_back_to_original_filename_when_label_blank(self, app):
+        document = _document(label="   ", sha256="c" * 64, original_filename="info pack.pdf")
+        with app.test_request_context():
+            result = _document_to_dict(document, url_slug="my-slug")
+        assert result["display_name"] == "info pack.pdf"
+
+    def test_falls_back_to_short_sha_when_label_and_filename_blank(self, app):
+        document = _document(label="   ", sha256="c" * 64)
+        with app.test_request_context():
+            result = _document_to_dict(document, url_slug="my-slug")
+        assert result["display_name"] == f"{'c' * 8}.pdf"
+
+    def test_omits_public_url_and_snippet_when_no_slug(self, app):
+        document = _document(sha256="d" * 64)
+        with app.test_request_context():
+            result = _document_to_dict(document, url_slug="")
+        assert result["public_url"] == ""
+        assert result["a_snippet"] == ""
+
+
+class TestDocumentRoutesRequireLogin:
+    def test_upload_redirects_anonymous_to_login(self, client):
+        assembly_id = uuid.uuid4()
+        response = client.post(f"/backoffice/assembly/{assembly_id}/registration/documents")
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+    def test_patch_redirects_anonymous_to_login(self, client):
+        assembly_id = uuid.uuid4()
+        document_id = uuid.uuid4()
+        response = client.patch(
+            f"/backoffice/assembly/{assembly_id}/registration/documents/{document_id}",
+            json={"label": "x"},
+        )
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+    def test_delete_redirects_anonymous_to_login(self, client):
+        assembly_id = uuid.uuid4()
+        document_id = uuid.uuid4()
+        response = client.delete(f"/backoffice/assembly/{assembly_id}/registration/documents/{document_id}")
+        assert response.status_code == 302
+        assert "/auth/login" in response.location
+
+
+class TestUploadRoute:
+    def test_upload_with_file_and_label_returns_201_and_stores_document(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={
+                "document": (BytesIO(_pdf()), "info-pack.pdf"),
+                "label": "Assembly info pack",
+            },
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["document"]["label"] == "Assembly info pack"
+        assert body["document"]["original_filename"] == "info-pack.pdf"
+        assert registration_page.url_slug in body["document"]["public_url"]
+
+        stored = _stored_documents(fake_store, registration_page)
+        assert len(stored) == 1
+        assert stored[0].label == "Assembly info pack"
+        assert stored[0].original_filename == "info-pack.pdf"
+        assert body["document"]["id"] == str(stored[0].id)
+
+    def test_upload_without_label_defaults_to_filename(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={"document": (BytesIO(_pdf()), "info-pack.pdf")},
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["document"]["label"] == "info-pack.pdf"
+
+        stored = _stored_documents(fake_store, registration_page)
+        assert len(stored) == 1
+        assert stored[0].label == "info-pack.pdf"
+
+    def test_upload_rejects_non_pdf_bytes(self, logged_in_admin, existing_assembly, registration_page):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={"document": (BytesIO(b"not a pdf"), "info-pack.pdf")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+        assert response.get_json()["reason"] == "unsupported_format"
+
+    def test_upload_rejects_missing_file(self, logged_in_admin, existing_assembly, registration_page):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={"label": "Info pack"},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+
+
+class TestPatchRoute:
+    def test_patch_updates_label_and_returns_document(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        document = _seed_document(fake_store, registration_page, label="Original")
+
+        response = logged_in_admin.patch(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{document.id}",
+            json={"label": "Renamed"},
+        )
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["document"]["label"] == "Renamed"
+        assert body["document"]["id"] == str(document.id)
+
+        with FakeUnitOfWork(store=fake_store) as uow:
+            assert uow.registration_documents.get(document.id).label == "Renamed"
+
+    def test_patch_rejects_missing_label(self, logged_in_admin, fake_store, existing_assembly, registration_page):
+        document = _seed_document(fake_store, registration_page, label="Original")
+
+        response = logged_in_admin.patch(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{document.id}",
+            json={"label": "  "},
+        )
+        assert response.status_code == 400
+
+        with FakeUnitOfWork(store=fake_store) as uow:
+            assert uow.registration_documents.get(document.id).label == "Original"
+
+
+class TestDeleteRoute:
+    def test_delete_returns_204_and_removes_document(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page
+    ):
+        document = _seed_document(fake_store, registration_page)
+
+        response = logged_in_admin.delete(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{document.id}",
+        )
+
+        assert response.status_code == 204
+        assert response.data == b""
+        assert _stored_documents(fake_store, registration_page) == []
+
+    def test_delete_unknown_document_returns_404(self, logged_in_admin, existing_assembly, registration_page):
+        response = logged_in_admin.delete(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{uuid.uuid4()}",
+        )
+        assert response.status_code == 404

--- a/backend/tests/component/test_backoffice_registration_documents.py
+++ b/backend/tests/component/test_backoffice_registration_documents.py
@@ -5,6 +5,8 @@ import uuid
 from io import BytesIO
 
 import pytest
+from flask import has_request_context
+from werkzeug.datastructures import FileStorage
 
 from opendlp.domain.registration_document import RegistrationDocument
 from opendlp.entrypoints.blueprints.backoffice_registration import _document_to_dict
@@ -180,6 +182,81 @@ class TestUploadRoute:
         assert response.status_code == 400
 
 
+class TestUploadErrorBranches:
+    def test_upload_read_failure_returns_400(self, logged_in_admin, existing_assembly, registration_page, monkeypatch):
+        def _read(self, *args, **kwargs):
+            # The test client also uses FileStorage.read while encoding the multipart
+            # body — only fail server-side, inside the request context.
+            if has_request_context():
+                raise OSError("stream broke")
+            return self.stream.read(*args, **kwargs)
+
+        # FileStorage has no ``read`` class attribute (it proxies to the stream via
+        # __getattr__), so create one — instance lookup finds it before __getattr__.
+        monkeypatch.setattr(FileStorage, "read", _read, raising=False)
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={"document": (BytesIO(_pdf()), "info-pack.pdf")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+        assert "read" in response.get_json()["error"].lower()
+
+    def test_upload_quota_exceeded_returns_400(
+        self, logged_in_admin, existing_assembly, registration_page, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "opendlp.service_layer.registration_document_service.get_max_documents_per_registration_page",
+            lambda: 0,
+        )
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={"document": (BytesIO(_pdf()), "info-pack.pdf")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+        assert "maximum" in response.get_json()["error"].lower()
+
+    def test_upload_without_registration_page_returns_400(self, logged_in_admin, existing_assembly):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={"document": (BytesIO(_pdf()), "info-pack.pdf")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+        assert "registration page" in response.get_json()["error"].lower()
+
+    def test_upload_forbidden_for_regular_user_returns_403(self, logged_in_user, existing_assembly, registration_page):
+        response = logged_in_user.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={"document": (BytesIO(_pdf()), "info-pack.pdf")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 403
+
+    def test_upload_unknown_assembly_returns_404(self, logged_in_admin):
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{uuid.uuid4()}/registration/documents",
+            data={"document": (BytesIO(_pdf()), "info-pack.pdf")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 404
+
+    def test_upload_unexpected_error_returns_500(
+        self, logged_in_admin, existing_assembly, registration_page, monkeypatch
+    ):
+        def _raise(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("opendlp.entrypoints.blueprints.backoffice_registration.add_registration_document", _raise)
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents",
+            data={"document": (BytesIO(_pdf()), "info-pack.pdf")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 500
+
+
 class TestPatchRoute:
     def test_patch_updates_label_and_returns_document(
         self, logged_in_admin, fake_store, existing_assembly, registration_page
@@ -211,6 +288,59 @@ class TestPatchRoute:
         with FakeUnitOfWork(store=fake_store) as uow:
             assert uow.registration_documents.get(document.id).label == "Original"
 
+    def test_patch_unknown_document_returns_404(self, logged_in_admin, existing_assembly, registration_page):
+        response = logged_in_admin.patch(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{uuid.uuid4()}",
+            json={"label": "Renamed"},
+        )
+        assert response.status_code == 404
+        assert "document" in response.get_json()["error"].lower()
+
+    def test_patch_without_registration_page_returns_404(self, logged_in_admin, existing_assembly):
+        response = logged_in_admin.patch(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{uuid.uuid4()}",
+            json={"label": "Renamed"},
+        )
+        assert response.status_code == 404
+        assert "registration page" in response.get_json()["error"].lower()
+
+    def test_patch_forbidden_for_regular_user_returns_403(
+        self, logged_in_user, fake_store, existing_assembly, registration_page
+    ):
+        document = _seed_document(fake_store, registration_page, label="Original")
+        response = logged_in_user.patch(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{document.id}",
+            json={"label": "Renamed"},
+        )
+        assert response.status_code == 403
+
+        with FakeUnitOfWork(store=fake_store) as uow:
+            assert uow.registration_documents.get(document.id).label == "Original"
+
+    def test_patch_unknown_assembly_returns_404(self, logged_in_admin):
+        response = logged_in_admin.patch(
+            f"/backoffice/assembly/{uuid.uuid4()}/registration/documents/{uuid.uuid4()}",
+            json={"label": "Renamed"},
+        )
+        assert response.status_code == 404
+
+    def test_patch_unexpected_error_returns_500(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page, monkeypatch
+    ):
+        document = _seed_document(fake_store, registration_page)
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            "opendlp.entrypoints.blueprints.backoffice_registration.set_registration_document_label", _raise
+        )
+        response = logged_in_admin.patch(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{document.id}",
+            json={"label": "Renamed"},
+        )
+        assert response.status_code == 500
+
 
 class TestDeleteRoute:
     def test_delete_returns_204_and_removes_document(
@@ -231,3 +361,42 @@ class TestDeleteRoute:
             f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{uuid.uuid4()}",
         )
         assert response.status_code == 404
+
+    def test_delete_without_registration_page_returns_404(self, logged_in_admin, existing_assembly):
+        response = logged_in_admin.delete(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{uuid.uuid4()}",
+        )
+        assert response.status_code == 404
+        assert "registration page" in response.get_json()["error"].lower()
+
+    def test_delete_forbidden_for_regular_user_returns_403(
+        self, logged_in_user, fake_store, existing_assembly, registration_page
+    ):
+        document = _seed_document(fake_store, registration_page)
+        response = logged_in_user.delete(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{document.id}",
+        )
+        assert response.status_code == 403
+        assert len(_stored_documents(fake_store, registration_page)) == 1
+
+    def test_delete_unknown_assembly_returns_404(self, logged_in_admin):
+        response = logged_in_admin.delete(
+            f"/backoffice/assembly/{uuid.uuid4()}/registration/documents/{uuid.uuid4()}",
+        )
+        assert response.status_code == 404
+
+    def test_delete_unexpected_error_returns_500(
+        self, logged_in_admin, fake_store, existing_assembly, registration_page, monkeypatch
+    ):
+        document = _seed_document(fake_store, registration_page)
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            "opendlp.entrypoints.blueprints.backoffice_registration.delete_registration_document", _raise
+        )
+        response = logged_in_admin.delete(
+            f"/backoffice/assembly/{existing_assembly.id}/registration/documents/{document.id}",
+        )
+        assert response.status_code == 500

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-28 11:03+0200\n"
+"POT-Creation-Date: 2026-07-29 09:51+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1047,7 +1047,7 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:168
 #: src/opendlp/entrypoints/blueprints/backoffice.py:430
 #: src/opendlp/entrypoints/blueprints/backoffice.py:485
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:199
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:254
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:82
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:94
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:129
@@ -1086,15 +1086,18 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:325
 #: src/opendlp/entrypoints/blueprints/backoffice.py:421
 #: src/opendlp/entrypoints/blueprints/backoffice.py:476
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:205
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:328
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:534
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:583
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:607
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:701
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:762
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:789
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:813
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:260
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:383
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:589
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:638
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:662
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:756
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:817
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:844
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:868
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:914
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:943
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:969
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:407
@@ -1253,92 +1256,103 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:104
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:119
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:154
 #, fuzzy, python-format
 msgid "Details for %(name)s"
 msgstr "Hiba részletei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:105
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:120
 #, python-format
 msgid "Copy <img> snippet for %(name)s"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:106
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:121
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:156
 #, fuzzy, python-format
 msgid "Delete %(name)s"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:211
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:155
+#, python-format
+msgid "Copy download link snippet for %(name)s"
+msgstr ""
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:266
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:222
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:277
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:223
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:278
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:226
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:281
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:229
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:284
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:232
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:287
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:235
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:290
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:236
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:291
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:313
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:528
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:758
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:368
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:583
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:813
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:910
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:322
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:531
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:580
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:760
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:787
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:811
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:377
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:586
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:635
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:815
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:842
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:866
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:912
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:941
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:967
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:338
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:393
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:405
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:460
 #, fuzzy
 msgid "Registration auto-reply"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:406
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:461
 msgid "Thanks for registering for {{ assembly.title }}"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:408
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:463
 msgid ""
 "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
 "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
@@ -1347,103 +1361,133 @@ msgid ""
 "<p>Best wishes,<br>The team</p>"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:444
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:499
 msgid "Auto-reply email created. Edit it below and click Save."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:455
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:510
 msgid "There is no auto-reply email to save yet — set one up first."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:467
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:522
 msgid "Auto-reply email saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:490
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:545
 msgid "Unknown action — nothing was changed."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:525
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:580
 msgid "The auto-reply email could not be found."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:543
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:598
 #, fuzzy
 msgid "An error occurred while saving the auto-reply email"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:575
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:630
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:588
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:643
 msgid "This assembly already has a registration page."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:592
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:647
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:605
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:695
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:660
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:750
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:610
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:665
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:705
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:760
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:732
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:787
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:886
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:738
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:793
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:892
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:742
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:777
-#: templates/backoffice/assembly_registration.html:1254
-#: templates/backoffice/assembly_registration.html:1393
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:797
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:832
+#: templates/backoffice/assembly_registration.html:1588
+#: templates/backoffice/assembly_registration.html:1727
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:765
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:820
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:783
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:807
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:838
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:862
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:785
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:809
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:840
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:864
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:939
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:965
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:792
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:847
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:816
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:871
 #, fuzzy
 msgid "An error occurred while deleting the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:917
+#, fuzzy
+msgid "An error occurred while uploading the document"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:931
+#: templates/backoffice/assembly_registration.html:1906
+msgid "Label is required"
+msgstr ""
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:937
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:963
+#, fuzzy
+msgid "Document not found"
+msgstr "Az oldal nem elérhető"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:948
+#, fuzzy
+msgid "An error occurred while updating the document"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:972
+#, fuzzy
+msgid "An error occurred while deleting the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:57
@@ -3367,9 +3411,11 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_edit_respondent.html:139
 #: templates/backoffice/assembly_form.html:96
 #: templates/backoffice/assembly_registration.html:160
-#: templates/backoffice/assembly_registration.html:395
-#: templates/backoffice/assembly_registration.html:801
-#: templates/backoffice/assembly_registration.html:962
+#: templates/backoffice/assembly_registration.html:476
+#: templates/backoffice/assembly_registration.html:882
+#: templates/backoffice/assembly_registration.html:1043
+#: templates/backoffice/assembly_registration.html:1132
+#: templates/backoffice/assembly_registration.html:1271
 #: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/components/edit_number_to_select_modal.html:40
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -3412,7 +3458,7 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:567
+#: templates/backoffice/assembly_registration.html:648
 #: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Registration URL"
@@ -3749,7 +3795,7 @@ msgstr "Módosítsa a számot."
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
 #: templates/backoffice/assembly_edit_respondent.html:21
 #: templates/backoffice/assembly_registration.html:163
-#: templates/backoffice/assembly_registration.html:398
+#: templates/backoffice/assembly_registration.html:479
 #: templates/backoffice/assembly_respondents.html:148
 #: templates/backoffice/assembly_selection.html:81
 #: templates/backoffice/assembly_selection.html:299
@@ -4512,8 +4558,10 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:344
 #: templates/backoffice/assembly_data.html:402
-#: templates/backoffice/assembly_registration.html:211
-#: templates/backoffice/assembly_registration.html:802
+#: templates/backoffice/assembly_registration.html:213
+#: templates/backoffice/assembly_registration.html:292
+#: templates/backoffice/assembly_registration.html:883
+#: templates/backoffice/assembly_registration.html:1133
 msgid "Upload"
 msgstr ""
 
@@ -4626,46 +4674,46 @@ msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:568
+#: templates/backoffice/assembly_registration.html:649
 msgid "The URL for your registration form"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:575
+#: templates/backoffice/assembly_registration.html:656
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:576
+#: templates/backoffice/assembly_registration.html:657
 #: templates/backoffice/edit_assembly.html:112
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:585
+#: templates/backoffice/assembly_registration.html:666
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
 #: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:587
+#: templates/backoffice/assembly_registration.html:668
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:593
+#: templates/backoffice/assembly_registration.html:674
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:605
+#: templates/backoffice/assembly_registration.html:686
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
 #: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:608
+#: templates/backoffice/assembly_registration.html:689
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
@@ -4820,7 +4868,7 @@ msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_registration.html:76
-#: templates/backoffice/assembly_registration.html:339
+#: templates/backoffice/assembly_registration.html:420
 #: templates/backoffice/patterns/_stepper.html:29
 #: templates/backoffice/patterns/_stepper.html:103
 #, fuzzy
@@ -4869,7 +4917,7 @@ msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
 #: templates/backoffice/assembly_registration.html:128
-#: templates/backoffice/assembly_registration.html:396
+#: templates/backoffice/assembly_registration.html:477
 #: templates/backoffice/components/edit_number_to_select_modal.html:41
 #: templates/backoffice/respondent_field_schema/view.html:230
 #: templates/backoffice/respondent_field_schema/view.html:271
@@ -4898,184 +4946,209 @@ msgid ""
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:204
+#: templates/backoffice/assembly_registration.html:203
 #, fuzzy
 msgid "Assets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:225
+#: templates/backoffice/assembly_registration.html:211
+#: templates/backoffice/service_docs.html:48
+#, fuzzy
+msgid "Images"
+msgstr "Jelentések a folyamatról"
+
+#: templates/backoffice/assembly_registration.html:227
 #, python-format
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:232
+#: templates/backoffice/assembly_registration.html:234
 #, fuzzy
 msgid "No images uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:298
-#: templates/backoffice/assembly_registration.html:508
+#: templates/backoffice/assembly_registration.html:290
+#: templates/backoffice/service_docs.html:49
+#, fuzzy
+msgid "Documents"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/assembly_registration.html:306
+#: templates/backoffice/assembly_registration.html:1088
+#, python-format
+msgid "PDF files only. Maximum file size: %(max)s MB per document."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:313
+#, fuzzy
+msgid "No documents uploaded yet."
+msgstr "Feladat állapota"
+
+#: templates/backoffice/assembly_registration.html:379
+#: templates/backoffice/assembly_registration.html:589
 msgid "Editing in progress — save or cancel to continue"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:300
-#: templates/backoffice/assembly_registration.html:302
-#: templates/backoffice/assembly_registration.html:356
-#: templates/backoffice/assembly_registration.html:511
-#: templates/backoffice/assembly_registration.html:514
+#: templates/backoffice/assembly_registration.html:381
+#: templates/backoffice/assembly_registration.html:383
+#: templates/backoffice/assembly_registration.html:437
+#: templates/backoffice/assembly_registration.html:592
+#: templates/backoffice/assembly_registration.html:595
 #, fuzzy
 msgid "Next →"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:328
+#: templates/backoffice/assembly_registration.html:409
 #, fuzzy
 msgid "Auto-reply cannot be sent"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:328
+#: templates/backoffice/assembly_registration.html:409
 msgid "Heads up"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:342
+#: templates/backoffice/assembly_registration.html:423
 msgid ""
 "Automatically send a confirmation email to people after they register. "
 "Templates support variables like the respondent's first name and the "
 "assembly title."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:347
+#: templates/backoffice/assembly_registration.html:428
 msgid "Set up auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:355
-#: templates/backoffice/assembly_registration.html:506
-#: templates/backoffice/assembly_registration.html:513
-#: templates/backoffice/assembly_registration.html:628
+#: templates/backoffice/assembly_registration.html:436
+#: templates/backoffice/assembly_registration.html:587
+#: templates/backoffice/assembly_registration.html:594
+#: templates/backoffice/assembly_registration.html:709
 msgid "← Back"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:378
+#: templates/backoffice/assembly_registration.html:459
 msgid "Auto-reply email template"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:390
+#: templates/backoffice/assembly_registration.html:471
 msgid "Send auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:411
+#: templates/backoffice/assembly_registration.html:492
 msgid "Email subject"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:413
+#: templates/backoffice/assembly_registration.html:494
 msgid "Jinja variables allowed, e.g. {{ assembly.title }}."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:423
+#: templates/backoffice/assembly_registration.html:504
 msgid "HTML body"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:425
+#: templates/backoffice/assembly_registration.html:506
 msgid ""
 "Jinja + HTML. A plain-text version is generated automatically for email "
 "clients that need it."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:446
+#: templates/backoffice/assembly_registration.html:527
 #, fuzzy
 msgid "Available variables"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:449
+#: templates/backoffice/assembly_registration.html:530
 msgid ""
 "Click a variable to select it, then copy and paste into the subject or "
 "body. Missing values render as an empty string."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:452
+#: templates/backoffice/assembly_registration.html:533
 #, fuzzy
 msgid "Assembly title"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/assembly_registration.html:453
+#: templates/backoffice/assembly_registration.html:534
 #, fuzzy
 msgid "Assembly question"
 msgstr "A gyűlés fő témája"
 
-#: templates/backoffice/assembly_registration.html:454
+#: templates/backoffice/assembly_registration.html:535
 #, fuzzy
 msgid "First assembly date (ISO)"
 msgstr "Első gyűlés időpontja"
 
-#: templates/backoffice/assembly_registration.html:455
+#: templates/backoffice/assembly_registration.html:536
 #, fuzzy
 msgid "Respondent first name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:456
+#: templates/backoffice/assembly_registration.html:537
 msgid "First name, or 'Friend' as a fallback"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:457
+#: templates/backoffice/assembly_registration.html:538
 #, fuzzy
 msgid "Respondent full name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:458
+#: templates/backoffice/assembly_registration.html:539
 #, fuzzy
 msgid "Respondent email address"
 msgstr "Email cím hiányzik"
 
-#: templates/backoffice/assembly_registration.html:481
+#: templates/backoffice/assembly_registration.html:562
 msgid "Variable copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:485
+#: templates/backoffice/assembly_registration.html:566
 #, python-format
 msgid "Copy %(label)s variable"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:534
+#: templates/backoffice/assembly_registration.html:615
 msgid "Form preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:537
+#: templates/backoffice/assembly_registration.html:618
 msgid ""
 "This is the last saved version of your registration form, shown exactly "
 "as visitors will see it. You can try the fields and dropdowns, but the "
 "form cannot be submitted from here."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:546
+#: templates/backoffice/assembly_registration.html:627
 #, fuzzy
 msgid "Registration form preview"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:560
+#: templates/backoffice/assembly_registration.html:641
 msgid "Share your form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:636
+#: templates/backoffice/assembly_registration.html:717
 msgid "Publish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:645
+#: templates/backoffice/assembly_registration.html:726
 msgid "Unpublish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:647
-#: templates/backoffice/assembly_registration.html:1005
+#: templates/backoffice/assembly_registration.html:728
+#: templates/backoffice/assembly_registration.html:1314
 #, fuzzy
 msgid "Close registration"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:676
+#: templates/backoffice/assembly_registration.html:757
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:682
-#: templates/backoffice/assembly_registration.html:745
-#: templates/backoffice/assembly_registration.html:836
+#: templates/backoffice/assembly_registration.html:763
+#: templates/backoffice/assembly_registration.html:826
+#: templates/backoffice/assembly_registration.html:917
+#: templates/backoffice/assembly_registration.html:1079
+#: templates/backoffice/assembly_registration.html:1167
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:106
@@ -5086,221 +5159,332 @@ msgstr "Rétegzett kiválasztás"
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:691
+#: templates/backoffice/assembly_registration.html:772
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:695
+#: templates/backoffice/assembly_registration.html:776
 msgid "Form skeleton preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:711
+#: templates/backoffice/assembly_registration.html:792
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:738
+#: templates/backoffice/assembly_registration.html:819
 #, fuzzy
 msgid "Upload image"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:754
+#: templates/backoffice/assembly_registration.html:835
 #, python-format
 msgid ""
 "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
 "Files are downscaled and re-encoded to PNG on upload."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:760
+#: templates/backoffice/assembly_registration.html:841
 msgid "Image file"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:776
-#: templates/backoffice/assembly_registration.html:935
+#: templates/backoffice/assembly_registration.html:857
+#: templates/backoffice/assembly_registration.html:1016
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:788
-#: templates/backoffice/assembly_registration.html:947
+#: templates/backoffice/assembly_registration.html:869
+#: templates/backoffice/assembly_registration.html:1028
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:829
+#: templates/backoffice/assembly_registration.html:910
 #, fuzzy
 msgid "Image details"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:855
+#: templates/backoffice/assembly_registration.html:936
 msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:862
+#: templates/backoffice/assembly_registration.html:943
+#: templates/backoffice/assembly_registration.html:1180
 msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:867
+#: templates/backoffice/assembly_registration.html:948
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:872
+#: templates/backoffice/assembly_registration.html:953
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:875
+#: templates/backoffice/assembly_registration.html:956
+#: templates/backoffice/assembly_registration.html:1185
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:883
+#: templates/backoffice/assembly_registration.html:964
+#: templates/backoffice/assembly_registration.html:1192
 #, fuzzy
 msgid "File name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:896
+#: templates/backoffice/assembly_registration.html:977
+#: templates/backoffice/assembly_registration.html:1205
 msgid "File name copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:900
+#: templates/backoffice/assembly_registration.html:981
+#: templates/backoffice/assembly_registration.html:1209
 #, fuzzy
 msgid "Copy file name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:911
+#: templates/backoffice/assembly_registration.html:992
 #, fuzzy
 msgid "Image snippet"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:925
+#: templates/backoffice/assembly_registration.html:1006
 msgid "Copy image snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:960
+#: templates/backoffice/assembly_registration.html:1041
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:963
+#: templates/backoffice/assembly_registration.html:1044
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:993
+#: templates/backoffice/assembly_registration.html:1072
+#, fuzzy
+msgid "Upload document"
+msgstr "Kész"
+
+#: templates/backoffice/assembly_registration.html:1094
+#, fuzzy
+msgid "PDF file"
+msgstr "Kész"
+
+#: templates/backoffice/assembly_registration.html:1110
+#: templates/backoffice/assembly_registration.html:1244
+#: templates/backoffice/patterns/_progress.html:125
+#: templates/backoffice/respondent_field_schema/view.html:134
+#: templates/backoffice/respondent_field_schema/view.html:360
+msgid "Label"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:1119
+msgid ""
+"Shown to registrants as the download link text and used as the file's "
+"display name in the asset list. Defaults to the file name."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:1160
+#, fuzzy
+msgid "Document details"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/assembly_registration.html:1220
+#, fuzzy
+msgid "Download link snippet"
+msgstr "Táblázat lapfülei"
+
+#: templates/backoffice/assembly_registration.html:1234
+msgid "Copy download link snippet"
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:1256
+msgid ""
+"Shown to registrants as the download link text and used as the file's "
+"display name in the asset list."
+msgstr ""
+
+#: templates/backoffice/assembly_registration.html:1269
+#, fuzzy
+msgid "Delete document"
+msgstr "Hozzon létre fiókot"
+
+#: templates/backoffice/assembly_registration.html:1272
+#, fuzzy
+msgid "Save label"
+msgstr "Elkezdve"
+
+#: templates/backoffice/assembly_registration.html:1302
 #, fuzzy
 msgid "Close registration?"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:996
+#: templates/backoffice/assembly_registration.html:1305
 msgid ""
 "This permanently stops new registrations. Visitors who follow the form "
 "link will see the 'registration closed' page, and the form cannot be "
 "reopened."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1007
+#: templates/backoffice/assembly_registration.html:1316
 #, fuzzy
 msgid "Keep it open"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1039
+#: templates/backoffice/assembly_registration.html:1348
 #, fuzzy
 msgid "Discard changes?"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1042
+#: templates/backoffice/assembly_registration.html:1351
 msgid ""
 "You have unsaved changes. If you leave this page, your changes will be "
 "lost."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1045
+#: templates/backoffice/assembly_registration.html:1354
 #, fuzzy
 msgid "Discard changes"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1046
+#: templates/backoffice/assembly_registration.html:1355
 #, fuzzy
 msgid "Keep editing"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1203
+#: templates/backoffice/assembly_registration.html:1537
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:1214
-#: templates/backoffice/assembly_registration.html:1339
+#: templates/backoffice/assembly_registration.html:1548
+#: templates/backoffice/assembly_registration.html:1673
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1217
-#: templates/backoffice/assembly_registration.html:1327
-#: templates/backoffice/assembly_registration.html:1340
+#: templates/backoffice/assembly_registration.html:1551
+#: templates/backoffice/assembly_registration.html:1661
+#: templates/backoffice/assembly_registration.html:1674
+#: templates/backoffice/assembly_registration.html:1853
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1272
+#: templates/backoffice/assembly_registration.html:1606
+#: templates/backoffice/assembly_registration.html:1798
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1283
+#: templates/backoffice/assembly_registration.html:1617
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1286
+#: templates/backoffice/assembly_registration.html:1620
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1295
+#: templates/backoffice/assembly_registration.html:1629
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1306
-#: templates/backoffice/assembly_registration.html:1372
+#: templates/backoffice/assembly_registration.html:1640
+#: templates/backoffice/assembly_registration.html:1706
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1310
-#: templates/backoffice/assembly_registration.html:1379
+#: templates/backoffice/assembly_registration.html:1644
+#: templates/backoffice/assembly_registration.html:1713
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1313
-#: templates/backoffice/assembly_registration.html:1382
+#: templates/backoffice/assembly_registration.html:1647
+#: templates/backoffice/assembly_registration.html:1716
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1322
+#: templates/backoffice/assembly_registration.html:1656
+#: templates/backoffice/assembly_registration.html:1848
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1326
+#: templates/backoffice/assembly_registration.html:1660
+#: templates/backoffice/assembly_registration.html:1852
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1409
+#: templates/backoffice/assembly_registration.html:1743
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1417
+#: templates/backoffice/assembly_registration.html:1751
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1420
+#: templates/backoffice/assembly_registration.html:1754
 #, fuzzy
 msgid "Network error while updating the image"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: templates/backoffice/assembly_registration.html:1809
+#, fuzzy
+msgid "Document uploaded"
+msgstr "Új jelszó"
+
+#: templates/backoffice/assembly_registration.html:1812
+#, fuzzy
+msgid "Network error while uploading the document"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: templates/backoffice/assembly_registration.html:1821
+#, fuzzy
+msgid "Delete this document?"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/assembly_registration.html:1832
+#: templates/backoffice/assembly_registration.html:1885
+#, fuzzy
+msgid "Failed to delete document"
+msgstr "Utoljára módosítva"
+
+#: templates/backoffice/assembly_registration.html:1836
+#: templates/backoffice/assembly_registration.html:1892
+#, fuzzy
+msgid "Document deleted"
+msgstr "Kiválasztás"
+
+#: templates/backoffice/assembly_registration.html:1839
+#: templates/backoffice/assembly_registration.html:1895
+#, fuzzy
+msgid "Network error while deleting the document"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: templates/backoffice/assembly_registration.html:1922
+#, fuzzy
+msgid "Failed to update document"
+msgstr "Utoljára módosítva"
+
+#: templates/backoffice/assembly_registration.html:1930
+#, fuzzy
+msgid "Document updated"
+msgstr "Utoljára módosítva"
+
+#: templates/backoffice/assembly_registration.html:1933
+#, fuzzy
+msgid "Network error while updating the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
 #: templates/backoffice/assembly_respondents.html:30
@@ -6168,16 +6352,6 @@ msgstr ""
 #, fuzzy
 msgid "CSV Config"
 msgstr "Beállítások mentése"
-
-#: templates/backoffice/service_docs.html:48
-#, fuzzy
-msgid "Images"
-msgstr "Jelentések a folyamatról"
-
-#: templates/backoffice/service_docs.html:49
-#, fuzzy
-msgid "Documents"
-msgstr "Kieső emberek pótlása új kiválasztással"
 
 #: templates/backoffice/service_docs.html:50
 #, fuzzy
@@ -7435,12 +7609,6 @@ msgstr ""
 #, fuzzy
 msgid "Phase"
 msgstr "Vezetéknév"
-
-#: templates/backoffice/patterns/_progress.html:125
-#: templates/backoffice/respondent_field_schema/view.html:134
-#: templates/backoffice/respondent_field_schema/view.html:360
-msgid "Label"
-msgstr ""
 
 #: templates/backoffice/patterns/_progress.html:126
 msgid "Has Total?"


### PR DESCRIPTION
## What

Adds the product UI for attaching PDF documents to an assembly's registration page, building on the service layer shipped in #213. Organisers can now upload, relabel, copy download-link snippets for, and delete PDFs directly from the registration tab's Assets panel — previously this was only possible through the dev-only service-docs page.

## How

**Backend** (`backoffice_registration.py`)
- Three JSON routes mirroring the existing image asset endpoints: `POST /assembly/<id>/registration/documents` (multipart upload with optional label), `PATCH …/documents/<doc_id>` (label), `DELETE …/documents/<doc_id>`, all delegating to `registration_document_service` with the same error-to-status mapping as images.
- `_document_to_dict` serializer: public `/register/<slug>/documents/<sha>.pdf` URL, ready-to-paste `<a>` snippet with "label (PDF, size)" text, and translated aria-labels. The registration view now passes `documents` and `max_pdf_upload_mb` to the template.

**Frontend** (`assembly_registration.html`)
- The Assets panel is split into **Images** and **Documents** subsections, each with its own upload button. Document rows link to the public URL and offer details, copy-snippet and delete actions.
- New Upload-document and Document-details modals mirror the image modals, following the CSP-safe Alpine patterns (flat `x-model` props, data-attribute clipboard helper, sentinel-UUID item-URL template). The label is optional on upload and defaults server-side to the sanitised filename.

**Drive-by fixes**
- The Delete buttons on the dev service-docs Documents/Images tabs (and the Registration tab's lifecycle diagram) used undefined tokens `--color-error-500`/`-700` — the button rendered as white text on a transparent background. The design system defines only 100/400/600 shades, so these now map to `-400`/`-600`.

## Testing

- 16 new component tests (`test_backoffice_registration_documents.py`) covering the serializer fallbacks, auth redirects, upload happy path + label default + non-PDF/missing-file rejection, label PATCH, and delete (204 + 404).
- Full component suite green (709 passed), mypy clean, prek hooks clean, `just translate-regen` run for the new strings.
- Note: `test_2fa_flow.py::test_login_with_2fa_backup_code` fails on current `main` independently of this branch (expects redirect `/dashboard`, gets `/backoffice/dashboard`) — pre-existing, not addressed here.

Refs #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)