### PR TITLE
Define missing design tokens and guard against undefined references

### DIFF
--- a/backend/.claude/skills/sf-code-review/SKILL.md
+++ b/backend/.claude/skills/sf-code-review/SKILL.md
@@ -21,6 +21,7 @@ I want you to review the changes on this branch, compared to the main branch. Ge
 - Review `docs/architecture` and what changed under `src/opendlp/`
 - Has anything been added to `config.py` (or removed)? Any new feature flags, or have we cleaned up any? If so, are there examples in `env.example` and explanations in `docs/configuration.md`
 - If templates have been added/updated, are we using the Jinja components well? Also review `docs/agent/component_accessibility.md`
+- If templates reference CSS custom properties (`var(--color-...)` etc.), each one must be defined in `static/backoffice/tokens/primitive.css` or `semantic.css` — an undefined token has no error, it silently inherits the parent colour (invisible links, uncoloured status banners). Prefer semantic tokens over primitives, and add an alias to `semantic.css` rather than inventing a new name in a template. See "Backoffice design tokens" in `docs/agent/frontend_design_system.md`. `tests/unit/test_design_tokens.py` enforces this; flag any change that weakens or deletes that test.
 - Is most JavaScript in files under `static/js/`? Will it work with CSP restrictions - see `docs/frontend_security.md`
 - Does the change touch cookies, sessions, logging of personal data, analytics, third-party scripts, or data retention? If so, check it against `docs/personal-data.md` — especially the "What would change the answer" list. Anything on that list needs a decision, not just a review.
 

--- a/backend/docs/agent/frontend_design_system.md
+++ b/backend/docs/agent/frontend_design_system.md
@@ -53,6 +53,21 @@ $dark-grey: #424242;
 $white: #ffffff;
 ```
 
+## Backoffice Design Tokens
+
+The backoffice (Tailwind) side uses CSS custom properties as design tokens:
+
+- `static/backoffice/tokens/primitive.css` - raw palette (`--color-brand-400`, `--color-neutral-600`, spacing, fonts, radii, shadows)
+- `static/backoffice/tokens/semantic.css` - purpose-based aliases (`--color-primary-action`, `--color-body-text`, `--color-links`, status colours)
+
+Rules for using tokens in templates:
+
+- **Every `var(--...)` referenced in a template must be defined in one of the two token files.** An undefined token is not an error - `var(--x)` with no fallback silently resolves to the inherited value, so links render in body-text colour and status banners lose their background. `tests/unit/test_design_tokens.py` enforces this in CI.
+- Prefer semantic tokens over primitives (`--color-links`, not `--color-brand-400`).
+- Never invent a token name in a template. If no existing token fits, add a semantic alias to `semantic.css` first.
+- Status colours use a `100/400/600` scale (background/border/text), with purpose-named aliases `--color-{success,warning,error,info}-{background,text}`. There are no `-500`/`-700` shades - use `-400` for borders/strokes and `-600` for text.
+- Links need an explicit colour (`--color-links` or `--color-link-text`) because the Tailwind preflight sets `a { color: inherit }`.
+
 ## HTML Template Requirements
 
 All templates must extend `base.html` which includes:

--- a/backend/static/backoffice/tokens/semantic.css
+++ b/backend/static/backoffice/tokens/semantic.css
@@ -35,6 +35,15 @@
     --color-headings: var(--color-neutral-700);
     --color-navigation-bars: var(--color-neutral-800);
     --color-dark-mode-base: var(--color-neutral-900);
+    --color-table-row-alt: var(--color-neutral-50);
+
+    /* ========================================
+     LINK COLOURS
+     Tailwind preflight sets a { color: inherit }, so links must opt in.
+     ======================================== */
+
+    --color-links: var(--color-primary-action);
+    --color-link-text: var(--color-primary-action);
 
     /* ========================================
      FOCUS RING
@@ -99,4 +108,14 @@
     --color-info-100: #E8F1FA;
     --color-info-400: #3A7BD5;
     --color-info-600: #2B5FA6;
+
+    /* Purpose-named aliases onto the 100/400/600 scale */
+    --color-success-background: var(--color-success-100);
+    --color-success-text: var(--color-success-600);
+    --color-warning-background: var(--color-warning-100);
+    --color-warning-text: var(--color-warning-600);
+    --color-error-background: var(--color-error-100);
+    --color-error-text: var(--color-error-600);
+    --color-info-background: var(--color-info-100);
+    --color-info-text: var(--color-info-600);
 }

--- a/backend/templates/backoffice/assembly_data.html
+++ b/backend/templates/backoffice/assembly_data.html
@@ -313,7 +313,7 @@ ABOUTME: Displays data source selection and data management for assemblies
                              fill="none"
                              viewBox="0 0 24 24"
                              stroke="currentColor"
-                             style="color: var(--color-success-green)">
+                             style="color: var(--color-success-600)">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                         </svg>
                         <span class="text-body-sm" style="color: var(--color-body-text);">
@@ -362,7 +362,7 @@ ABOUTME: Displays data source selection and data management for assemblies
                              fill="none"
                              viewBox="0 0 24 24"
                              stroke="currentColor"
-                             style="color: var(--color-success-green)">
+                             style="color: var(--color-success-600)">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                         </svg>
                         <span class="text-body-sm" style="color: var(--color-body-text);">
@@ -484,7 +484,7 @@ ABOUTME: Displays data source selection and data management for assemblies
                                      fill="none"
                                      viewBox="0 0 24 24"
                                      stroke="currentColor"
-                                     style="color: var(--color-success-green)">
+                                     style="color: var(--color-success-600)">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                                 </svg>
                                 <span class="text-body-sm" style="color: var(--color-body-text);">

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -223,7 +223,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                                             </svg>
-                                            <p class="text-body-sm" style="color: var(--color-info-700);">
+                                            <p class="text-body-sm" style="color: var(--color-info-600);">
                                                 {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
                                             </p>
                                         </div>

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -302,7 +302,7 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0" style="color: var(--color-info-600);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                                             </svg>
-                                            <p class="text-body-sm" style="color: var(--color-info-700);">
+                                            <p class="text-body-sm" style="color: var(--color-info-600);">
                                                 {{ _("PDF files only. Maximum file size: %(max)s MB per document.", max=max_pdf_upload_mb) }}
                                             </p>
                                         </div>

--- a/backend/templates/backoffice/respondent_field_schema/view.html
+++ b/backend/templates/backoffice/respondent_field_schema/view.html
@@ -244,7 +244,7 @@ ABOUTME: Grouped field list with per-field label edit, move up/down, and delete 
                                 </tr>
                                 {% if not field.is_fixed and field.field_type.value in choice_type_values %}
                                     <tr>
-                                        <td colspan="7" class="py-2 pl-8" style="background: var(--color-table-row-alt, #f5f5f5);">
+                                        <td colspan="7" class="py-2 pl-8" style="background: var(--color-table-row-alt);">
                                             <div class="text-label-md mb-2">{{ _("Options for %(label)s", label=field.label) }}</div>
                                             {% if field.options %}
                                                 <ul class="mb-2">

--- a/backend/templates/backoffice/service_docs/_documents.html
+++ b/backend/templates/backoffice/service_docs/_documents.html
@@ -408,7 +408,7 @@
                 <div class="flex gap-2">
                     <span class="text-body-sm px-2 py-1 rounded"
                           style="background-color: var(--color-info-100);
-                                 color: var(--color-info-700)">🌐 public (no auth)</span>
+                                 color: var(--color-info-600)">🌐 public (no auth)</span>
                 </div>
             </div>
             <p class="text-body-md mb-4" style="color: var(--color-body-text);">

--- a/backend/templates/backoffice/service_docs/_images.html
+++ b/backend/templates/backoffice/service_docs/_images.html
@@ -408,7 +408,7 @@
                 <div class="flex gap-2">
                     <span class="text-body-sm px-2 py-1 rounded"
                           style="background-color: var(--color-info-100);
-                                 color: var(--color-info-700)">🌐 public (no auth)</span>
+                                 color: var(--color-info-600)">🌐 public (no auth)</span>
                 </div>
             </div>
             <p class="text-body-md mb-4" style="color: var(--color-body-text);">

--- a/backend/templates/backoffice/service_docs/_registration.html
+++ b/backend/templates/backoffice/service_docs/_registration.html
@@ -12,7 +12,7 @@
                     {# TEST State #}
                     <div class="text-center">
                         <div class="px-6 py-3 rounded-lg font-semibold"
-                             style="background-color: var(--color-warning-100); border: 2px solid var(--color-warning-500); color: var(--color-warning-700);">
+                             style="background-color: var(--color-warning-100); border: 2px solid var(--color-warning-400); color: var(--color-warning-600);">
                             TEST
                         </div>
                         <p class="text-body-sm mt-2" style="color: var(--color-secondary-text); max-width: 120px;">
@@ -24,7 +24,7 @@
                     <div class="flex flex-col items-center">
                         <span class="text-body-sm mb-1" style="color: var(--color-success-600);">publish()</span>
                         <svg class="w-12 h-6" viewBox="0 0 48 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M0 12h40M40 12l-8-6M40 12l-8 6" stroke="var(--color-success-500)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path d="M0 12h40M40 12l-8-6M40 12l-8 6" stroke="var(--color-success-400)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
                         <span class="text-body-sm mt-1" style="color: var(--color-info-600);">← unpublish()</span>
                     </div>
@@ -32,7 +32,7 @@
                     {# PUBLISHED State #}
                     <div class="text-center">
                         <div class="px-6 py-3 rounded-lg font-semibold"
-                             style="background-color: var(--color-success-100); border: 2px solid var(--color-success-500); color: var(--color-success-700);">
+                             style="background-color: var(--color-success-100); border: 2px solid var(--color-success-400); color: var(--color-success-600);">
                             PUBLISHED
                         </div>
                         <p class="text-body-sm mt-2" style="color: var(--color-secondary-text); max-width: 120px;">
@@ -77,7 +77,7 @@
                     <tbody>
                         <tr>
                             <td class="px-3 py-2 text-code" style="border-bottom: 1px solid var(--color-borders-dividers);">
-                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-warning-100); color: var(--color-warning-700);">TEST</span>
+                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-warning-100); color: var(--color-warning-600);">TEST</span>
                             </td>
                             <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">✅ True</td>
                             <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">Form renders with test banner</td>
@@ -85,7 +85,7 @@
                         </tr>
                         <tr>
                             <td class="px-3 py-2 text-code" style="border-bottom: 1px solid var(--color-borders-dividers);">
-                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-success-100); color: var(--color-success-700);">PUBLISHED</span>
+                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-success-100); color: var(--color-success-600);">PUBLISHED</span>
                             </td>
                             <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">✅ True</td>
                             <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">Form renders normally (live)</td>
@@ -117,7 +117,7 @@
                     <tbody>
                         <tr>
                             <td class="px-3 py-2 text-code" style="border-bottom: 1px solid var(--color-borders-dividers);">
-                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-warning-100); color: var(--color-warning-700);">TEST</span>
+                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-warning-100); color: var(--color-warning-600);">TEST</span>
                             </td>
                             <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">
                                 <span class="px-2 py-1 rounded mr-1" style="background-color: var(--color-button-secondary-bg); border: 1px solid var(--color-borders-dividers);">Save</span>
@@ -127,7 +127,7 @@
                         </tr>
                         <tr>
                             <td class="px-3 py-2 text-code" style="border-bottom: 1px solid var(--color-borders-dividers);">
-                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-success-100); color: var(--color-success-700);">PUBLISHED</span>
+                                <span class="px-2 py-0.5 rounded" style="background-color: var(--color-success-100); color: var(--color-success-600);">PUBLISHED</span>
                             </td>
                             <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">
                                 <span class="px-2 py-1 rounded mr-1" style="background-color: var(--color-button-secondary-bg); border: 1px solid var(--color-borders-dividers);">Unpublish</span>
@@ -172,7 +172,7 @@
                     <tbody>
                         <tr>
                             <td class="px-3 py-2 text-code" style="border-bottom: 1px solid var(--color-borders-dividers);">
-                                <code style="background-color: var(--color-info-100); color: var(--color-info-700); padding: 2px 6px; border-radius: 4px;">&#123;&#123; csrf_form_element &#125;&#125;</code>
+                                <code style="background-color: var(--color-info-100); color: var(--color-info-600); padding: 2px 6px; border-radius: 4px;">&#123;&#123; csrf_form_element &#125;&#125;</code>
                             </td>
                             <td class="px-3 py-2" style="border-bottom: 1px solid var(--color-borders-dividers);">
                                 Hidden input for CSRF protection. <strong>Required</strong> inside your &lt;form&gt; tag.
@@ -180,7 +180,7 @@
                         </tr>
                         <tr>
                             <td class="px-3 py-2 text-code">
-                                <code style="background-color: var(--color-info-100); color: var(--color-info-700); padding: 2px 6px; border-radius: 4px;">&#123;&#123; form_action &#125;&#125;</code>
+                                <code style="background-color: var(--color-info-100); color: var(--color-info-600); padding: 2px 6px; border-radius: 4px;">&#123;&#123; form_action &#125;&#125;</code>
                             </td>
                             <td class="px-3 py-2">
                                 Form submission URL. Use in <code>action="&#123;&#123; form_action &#125;&#125;"</code>. <strong>Required</strong>.
@@ -331,7 +331,7 @@
                 &lt;/form&gt;</pre>
 
             <div class="p-3 rounded" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
-                <p class="text-body-sm" style="color: var(--color-info-700);">
+                <p class="text-body-sm" style="color: var(--color-info-600);">
                     <strong>Note:</strong> On initial page load (GET request), all helpers return empty values. They are populated with submitted data only after a POST with validation errors.
                 </p>
             </div>
@@ -1439,7 +1439,7 @@
             <div class="mb-6">
                 <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("Status Logic") }}</h4>
                 <div class="p-3 rounded" style="background-color: var(--color-info-100); border: 1px solid var(--color-info-400);">
-                    <ul class="list-disc list-inside text-body-sm" style="color: var(--color-info-700);">
+                    <ul class="list-disc list-inside text-body-sm" style="color: var(--color-info-600);">
                         <li><strong>is_test=false</strong> → Creates respondent with <code>POOL</code> status (real submission)</li>
                         <li><strong>is_test=true</strong> → Creates respondent with <code>TEST_SUBMISSION</code> status (quarantined from selection)</li>
                     </ul>

--- a/backend/templates/backoffice/showcase/primitive_tokens.html
+++ b/backend/templates/backoffice/showcase/primitive_tokens.html
@@ -51,7 +51,7 @@ ABOUTME: Displays brand primary and neutral color scales
 
         {{ showcase_subtitle("Core Neutrals Scale") }}
         <div class="flex flex-wrap gap-4">
-            <div style="background-color: var(--color-neutral-0); color: var(--color-headings); border: 1px solid var(--color-borders-dividerss-dividers);" class="p-4 rounded-lg shadow-md w-48">
+            <div style="background-color: var(--color-neutral-0); color: var(--color-headings); border: 1px solid var(--color-borders-dividers);" class="p-4 rounded-lg shadow-md w-48">
                 <p class="text-label-lg">neutral-0</p>
                 <p class="text-body-sm opacity-90">#FFFFFF</p>
             </div>

--- a/backend/templates/backoffice/showcase/semantic_tokens.html
+++ b/backend/templates/backoffice/showcase/semantic_tokens.html
@@ -51,7 +51,7 @@ ABOUTME: Displays purpose-based tokens that reference primitive scales
 
         {{ showcase_subtitle("Neutral Semantic Tokens") }}
         <div class="flex flex-wrap gap-4 mb-8">
-            <div style="background-color: var(--color-page-background); color: var(--color-headings); border: 1px solid var(--color-borders-dividerss-dividers);" class="p-4 rounded-lg shadow-md w-56">
+            <div style="background-color: var(--color-page-background); color: var(--color-headings); border: 1px solid var(--color-borders-dividers);" class="p-4 rounded-lg shadow-md w-56">
                 <p class="text-code">--color-page-background</p>
                 <p class="text-caption opacity-75 mt-1">→ neutral-0</p>
             </div>
@@ -63,8 +63,8 @@ ABOUTME: Displays purpose-based tokens that reference primitive scales
                 <p class="text-code">--color-tables-cards</p>
                 <p class="text-caption opacity-75 mt-1">→ neutral-100</p>
             </div>
-            <div style="background-color: var(--color-borders-dividerss-dividers); color: var(--color-headings);" class="p-4 rounded-lg shadow-md w-56">
-                <p class="text-code">--color-borders-dividerss-dividers</p>
+            <div style="background-color: var(--color-borders-dividers); color: var(--color-headings);" class="p-4 rounded-lg shadow-md w-56">
+                <p class="text-code">--color-borders-dividers</p>
                 <p class="text-caption opacity-75 mt-1">→ neutral-200</p>
             </div>
             <div style="background-color: var(--color-disabled-borders); color: var(--color-headings);" class="p-4 rounded-lg shadow-md w-56">
@@ -99,7 +99,7 @@ ABOUTME: Displays purpose-based tokens that reference primitive scales
 
         {{ showcase_subtitle("Focus Ring") }}
         <div class="flex flex-wrap gap-4 mb-8">
-            <div style="background-color: var(--color-page-background); box-shadow: 0 0 0 3px var(--color-focus-ring); border: 1px solid var(--color-borders-dividerss-dividers);" class="p-4 rounded-lg w-56">
+            <div style="background-color: var(--color-page-background); box-shadow: 0 0 0 3px var(--color-focus-ring); border: 1px solid var(--color-borders-dividers);" class="p-4 rounded-lg w-56">
                 <p style="color: var(--color-body-text);" class="text-code">--color-focus-ring</p>
                 <p style="color: var(--color-secondary-text);" class="text-caption mt-1">→ brand-200</p>
             </div>

--- a/backend/tests/unit/test_design_tokens.py
+++ b/backend/tests/unit/test_design_tokens.py
@@ -2,6 +2,7 @@
 ABOUTME: Every var(--...) in templates must be defined in the backoffice token files (see issue #797)"""
 
 import re
+from pathlib import Path
 
 from opendlp import config
 
@@ -21,24 +22,38 @@ def _defined_tokens() -> set[str]:
     return defined
 
 
+def _find_undefined_refs(templates_path: Path, defined: set[str]) -> dict[str, set[str]]:
+    undefined_refs: dict[str, set[str]] = {}
+    for template in sorted(templates_path.rglob("*.html")):
+        text = template.read_text()
+        # Tokens a template defines inline (e.g. in a <style> block) are fine to reference.
+        local = set(DEFINITION_RE.findall(text))
+        for token in REFERENCE_RE.findall(text):
+            if token not in defined and token not in local:
+                undefined_refs.setdefault(token, set()).add(str(template.relative_to(templates_path)))
+    return undefined_refs
+
+
 def test_token_files_exist_and_define_tokens() -> None:
     for token_file in TOKEN_FILES:
         assert token_file.is_file(), f"design token file missing: {token_file}"
     assert len(_defined_tokens()) > 50
 
 
+def test_scan_detects_undefined_and_allows_defined_tokens(tmp_path: Path) -> None:
+    (tmp_path / "page.html").write_text(
+        '<a style="color: var(--color-bogus)">x</a>'
+        '<p style="color: var(--color-known); background: var(--local)">y</p>'
+        "<style>:root { --local: red; }</style>"
+    )
+    undefined_refs = _find_undefined_refs(tmp_path, {"--color-known"})
+    assert undefined_refs == {"--color-bogus": {"page.html"}}
+
+
 def test_templates_only_reference_defined_tokens() -> None:
     """An undefined var(--x) with no fallback silently resolves to the inherited value,
     so links render in body-text colour and status banners lose their background."""
-    defined = _defined_tokens()
-    undefined_refs: dict[str, set[str]] = {}
-    for template in sorted(config.get_templates_path().rglob("*.html")):
-        text = template.read_text()
-        # Tokens a template defines inline (e.g. in a <style> block) are fine to reference.
-        local = set(DEFINITION_RE.findall(text))
-        for token in REFERENCE_RE.findall(text):
-            if token not in defined and token not in local:
-                undefined_refs.setdefault(token, set()).add(str(template.relative_to(config.get_templates_path())))
+    undefined_refs = _find_undefined_refs(config.get_templates_path(), _defined_tokens())
     assert not undefined_refs, (
         "Templates reference CSS custom properties that are not defined in "
         "static/backoffice/tokens/{primitive,semantic}.css - define the token (or an alias) "

--- a/backend/tests/unit/test_design_tokens.py
+++ b/backend/tests/unit/test_design_tokens.py
@@ -1,0 +1,46 @@
+"""ABOUTME: Guards against templates referencing undefined CSS design tokens
+ABOUTME: Every var(--...) in templates must be defined in the backoffice token files (see issue #797)"""
+
+import re
+
+from opendlp import config
+
+TOKEN_FILES = (
+    config.get_static_path() / "backoffice" / "tokens" / "primitive.css",
+    config.get_static_path() / "backoffice" / "tokens" / "semantic.css",
+)
+
+DEFINITION_RE = re.compile(r"(--[a-z0-9-]+)\s*:")
+REFERENCE_RE = re.compile(r"var\(\s*(--[a-z0-9-]+)")
+
+
+def _defined_tokens() -> set[str]:
+    defined: set[str] = set()
+    for token_file in TOKEN_FILES:
+        defined.update(DEFINITION_RE.findall(token_file.read_text()))
+    return defined
+
+
+def test_token_files_exist_and_define_tokens() -> None:
+    for token_file in TOKEN_FILES:
+        assert token_file.is_file(), f"design token file missing: {token_file}"
+    assert len(_defined_tokens()) > 50
+
+
+def test_templates_only_reference_defined_tokens() -> None:
+    """An undefined var(--x) with no fallback silently resolves to the inherited value,
+    so links render in body-text colour and status banners lose their background."""
+    defined = _defined_tokens()
+    undefined_refs: dict[str, set[str]] = {}
+    for template in sorted(config.get_templates_path().rglob("*.html")):
+        text = template.read_text()
+        # Tokens a template defines inline (e.g. in a <style> block) are fine to reference.
+        local = set(DEFINITION_RE.findall(text))
+        for token in REFERENCE_RE.findall(text):
+            if token not in defined and token not in local:
+                undefined_refs.setdefault(token, set()).add(str(template.relative_to(config.get_templates_path())))
+    assert not undefined_refs, (
+        "Templates reference CSS custom properties that are not defined in "
+        "static/backoffice/tokens/{primitive,semantic}.css - define the token (or an alias) "
+        f"there, or repoint the template at an existing token: {undefined_refs}"
+    )


### PR DESCRIPTION
Closes #797

## Summary

Backoffice templates referenced many `--color-*` custom properties that were never defined. An undefined `var(--x)` with no fallback silently resolves to the inherited value, so links rendered in body-text colour and status banners lost their backgrounds. This PR defines the missing tokens once in `semantic.css`, repoints the stragglers, and adds a CI guard so it stays fixed.

### Token definitions (`static/backoffice/tokens/semantic.css`)

- `--color-links` / `--color-link-text` → `--color-primary-action` (Tailwind preflight sets `a { color: inherit }`, so links must opt in)
- Purpose-named status aliases onto the existing 100/400/600 scale: `--color-{success,warning,error,info}-{background,text}`
- `--color-table-row-alt` promoted to a real token (`--color-neutral-50`, matching the old `#f5f5f5` literal fallback, now removed from `respondent_field_schema/view.html`)

### Template clean-ups

Repointed rather than growing the palette: every `-500` usage was a border/stroke and every `-700` a text colour, mapping exactly onto the documented 100/400/600 roles.

- `-500` → `-400`, `-700` → `-600` in `service_docs/_registration.html`, `_images.html`, `_documents.html` (not in the issue's inventory — same copy-pasted styles as `_images.html`) and `assembly_registration.html`
- `--color-success-green` → `--color-success-600` in `assembly_data.html`
- `--color-borders-dividerss-dividers` typo fixed in both showcase templates

### Keeping it fixed

- New `tests/unit/test_design_tokens.py` scans every template for `var(--...)` references and fails if any token is not defined in the two token files (template-local definitions allowed). Verified it fails when a bogus token is introduced.
- New "Backoffice Design Tokens" section in `docs/agent/frontend_design_system.md`
- New check in the `sf-code-review` skill, including flagging changes that weaken the guard test

## Test plan

- [x] The issue's audit grep now returns zero undefined tokens
- [x] `tests/unit` + `tests/component`: 2575 passed; only failure is the pre-existing `test_2fa_flow.py::test_login_with_2fa_backup_code` breakage on main (unrelated)
- [x] `uv run mypy` and `prek run -a` clean
- [x] No asset rebuild needed — token CSS files are served directly with cache-busting hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)