### PR TITLE
feat(680): navigation rework — top bar, page header, sticky chrome

### DIFF
--- a/.claude/skills/worktree-remove/SKILL.md
+++ b/.claude/skills/worktree-remove/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: worktree-remove
+description: Remove an opendlp git worktree (a sibling folder named opendlp-worktree-<branch>) safely. Invoke when the user asks to remove/delete/clean up a worktree.
+argument-hint: <branch-name>
+---
+
+# Remove an opendlp worktree
+
+Remove the worktree for the branch given in the arguments. Worktrees live as siblings of the main repo, named `opendlp-worktree-<branch-name>`.
+
+If no branch name was passed, run `git worktree list` and ask the user which one to remove.
+
+## Steps
+
+Run all git commands from the main repo (`/Users/macintosh/Sites/opendlp`).
+
+1. **Locate it.** Run `git worktree list` and confirm a worktree for this branch exists. If not, say so and stop.
+
+2. **Safety check.** Inspect the worktree before deleting anything:
+   ```bash
+   git -C ../opendlp-worktree-<branch> status --porcelain
+   git -C ../opendlp-worktree-<branch> log --oneline @{upstream}..HEAD 2>/dev/null
+   ```
+   If there are uncommitted changes or unpushed commits, STOP and tell the user exactly what would be lost. Only proceed with `--force` after they explicitly confirm.
+
+3. **Remove.**
+   ```bash
+   git worktree remove ../opendlp-worktree-<branch>
+   git worktree prune
+   ```
+
+4. **Report.** Confirm the folder is gone. Note that the local branch `<branch>` still exists in the main repo; do NOT delete it unless the user asks — if they do, use `git branch -d <branch>` (only escalate to `-D` after warning about unmerged commits and getting confirmation).

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -32,6 +32,13 @@ Run all git commands from the main repo (`/Users/macintosh/Sites/opendlp`).
    ```bash
    git worktree add -b <branch> ../opendlp-worktree-<branch>
    ```
+   If the user asks for the branch to be based on main (or another ref) instead, pass that ref as the last argument, e.g. `git worktree add -b <branch> ../opendlp-worktree-<branch> origin/main`.
+
+   **Upstream fix:** when the start point is a remote-tracking ref like `origin/main`, git auto-sets it as the new branch's upstream, which would make pull/push target the wrong remote branch. Clear it:
+   ```bash
+   git -C ../opendlp-worktree-<branch> branch --unset-upstream
+   ```
+   (Not needed when branching from HEAD — no upstream gets set — and the first `git push -u origin <branch>` will then wire up the correct one.)
 
 5. **Verify and report.** Run `git worktree list` to confirm, then tell the user:
    - the absolute path of the new worktree,

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: worktree
+description: Create (or open) a git worktree for a branch as a sibling folder of the opendlp repo, named opendlp-worktree-<branch>. Handles both existing remote branches and brand-new branches. Invoke when the user asks to create/open/set up a worktree for a branch.
+argument-hint: <branch-name>
+---
+
+# Create an opendlp worktree
+
+Create a git worktree for the branch given in the arguments. The worktree folder is always a **sibling of the main opendlp checkout**, named `opendlp-worktree-<branch-name>` (e.g. `/Users/macintosh/Sites/opendlp-worktree-613-require-reg-fields`). Never use a `worktrees/` subdirectory or any other location/naming variant.
+
+If no branch name was passed as an argument, ask the user which branch to use.
+
+## Steps
+
+Run all git commands from the main repo (`/Users/macintosh/Sites/opendlp`).
+
+1. **Short-circuit if it already exists.** Run `git worktree list`. If a worktree for this branch already exists, just report its path and stop — don't recreate it.
+
+2. **Fetch and check the remote.**
+   ```bash
+   git fetch origin
+   git ls-remote --exit-code --heads origin <branch>
+   ```
+
+3. **If the remote branch exists** (exit code 0), create the worktree from it:
+   ```bash
+   git worktree add ../opendlp-worktree-<branch> <branch>
+   ```
+   Git will create a local branch tracking `origin/<branch>` automatically. If a local branch already exists, this checks it out in the worktree — that's fine, but if git complains the local branch is behind/diverged from the remote, report that to the user instead of forcing anything.
+
+4. **If there is no remote branch**, create a new branch **from the current HEAD of the main opendlp checkout** and check it out directly in the new worktree (the main checkout stays on its current branch — never switch branches in the main repo):
+   ```bash
+   git worktree add -b <branch> ../opendlp-worktree-<branch>
+   ```
+
+5. **Verify and report.** Run `git worktree list` to confirm, then tell the user:
+   - the absolute path of the new worktree,
+   - which branch it's on and whether it tracks a remote branch or is brand new (and from which commit it was branched),
+   - a reminder that untracked files like `.env`/local config are NOT carried over into a new worktree — offer to copy them from the main checkout if the project needs them to run.

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -40,7 +40,13 @@ Run all git commands from the main repo (`/Users/macintosh/Sites/opendlp`).
    ```
    (Not needed when branching from HEAD — no upstream gets set — and the first `git push -u origin <branch>` will then wire up the correct one.)
 
-5. **Verify and report.** Run `git worktree list` to confirm, then tell the user:
+5. **Copy local config.** Untracked files are NOT carried over into a new worktree. In opendlp the env file lives at `backend/.env` — copy it automatically:
+   ```bash
+   cp /Users/macintosh/Sites/opendlp/backend/.env ../opendlp-worktree-<branch>/backend/.env
+   ```
+   (Skip silently if the main checkout has no `backend/.env`.)
+
+6. **Verify and report.** Run `git worktree list` to confirm, then tell the user:
    - the absolute path of the new worktree,
    - which branch it's on and whether it tracks a remote branch or is brand new (and from which commit it was branched),
-   - a reminder that untracked files like `.env`/local config are NOT carried over into a new worktree — offer to copy them from the main checkout if the project needs them to run.
+   - that `backend/.env` was copied over (or that none existed to copy).

--- a/backend/docs/configuration.md
+++ b/backend/docs/configuration.md
@@ -232,6 +232,10 @@ HELP_SITE_DATA_AGREEMENT=https://docs.sortitionlab.org/data-and-legal/data-agree
 # registration form. Must accurately list the cookies we set - see
 # docs/personal-data.md, which is the canonical source of that list.
 HELP_SITE_COOKIES=https://docs.sortitionlab.org/data-and-legal/cookies/
+
+# Knowledge hub, the target of the top-bar help icon. Not live yet - the URL is
+# a placeholder until the hub is published.
+KNOWLEDGE_HUB_URL=https://democraticlottery.org/knowledge-hub
 ```
 
 ### Session and cookie lifetimes

--- a/backend/docs/prompts/680-navigation-rework/implementation-plan.md
+++ b/backend/docs/prompts/680-navigation-rework/implementation-plan.md
@@ -1,0 +1,234 @@
+# 680 — Navigation Rework: Implementation Plan & Enhanced Spec
+
+**Branch:** `680-navigation-rework`
+**Source ticket:** App frame / Assembly detail layout / Footer / Other (Shortcut)
+**Figma file:** `WaG38I99ccF8RMy1655fA2` (OpenDLP – UI)
+
+| Design | Node | Link |
+|---|---|---|
+| App frame (top bar + account dropdown) | `1802:1579` | [figma](https://www.figma.com/design/WaG38I99ccF8RMy1655fA2/OpenDLP---UI?node-id=1802-1579&m=dev) |
+| Assembly detail (page header + sticky tabs) | `2898:2685` | [figma](https://www.figma.com/design/WaG38I99ccF8RMy1655fA2/OpenDLP---UI?node-id=2898-2685&m=dev) |
+| Page header component | `2898:2686` | (child of above) |
+
+> Note: the ticket's "Page header" link (`1652:5674`) turned out to be just a **showcase section label** ("Page header" text at 96px), not the component. The real page-header design is the assembly-detail header at `2898:2686`.
+
+---
+
+## 0. Scope decisions (locked with the team — override anything below on conflict)
+
+1. **No status chip in this ticket.** The page header is **back arrow + H1 title only**. The status chip **and** the status-based filtering/toggle on the assembly dashboard are a **separate ticket** — do not build a chip/badge component or dashboard status filter here.
+2. **Both the top bar and the page-header+tabs are sticky.** Top bar pinned at `top:0`; page header + tab bar pinned directly beneath it.
+3. **Footer removal is deferred.** Keep the footer as-is for now; removing it and relocating its links (GitHub → About OpenDLP, Cookies, version, etc.) is to be discussed with the team and done as the **final, optional step** of this implementation. Because the About OpenDLP page is part of that deferred step, the account dropdown ships **without** "About Open DLP" for now — its live items are My account, Switch to site admin, User Data Agreement, Sign out.
+
+---
+
+## 1. Goals (from the ticket)
+
+**App frame**
+- Remove the centre/top navigation links; keep the logo on the left.
+- Right side: a **Help** icon → knowledge hub (`democraticlottery.org/knowledge-hub`, does not exist yet) and an **Account** dropdown.
+- Account dropdown contains only actions that already work.
+- "Switch to site admin" opens in a **new tab** (old design still lives there).
+
+**Assembly detail**
+- Replace the breadcrumb with a **Page header** (back arrow + title + status chip).
+- Make the page header **including the tab navigation sticky**.
+- Remove the "Back to Dashboard" button at the bottom of assembly details.
+
+**Footer**
+- Remove the footer entirely; its content moves into the account dropdown.
+- GitHub link moves onto the "About OpenDLP" page.
+
+**Global**
+- Retire the breadcrumb **everywhere** (all pages). Keep **one instance in the showcase** as the design-system demo.
+
+---
+
+## 2. Design analysis (decoded, with real tokens)
+
+The project renders icons as **inline SVGs** (`viewBox="0 0 24 24"`, `stroke="currentColor"`) written per-component — there is no icon sprite or icon macro. All Figma icons are from **MynaUI** (`icons.mynaui.com`), which use the same stroke style, so we source SVGs from there.
+
+All referenced tokens already exist in `static/backoffice/tokens/{primitive,semantic}.css`:
+
+| Figma value | Primitive token | Semantic alias |
+|---|---|---|
+| `#90003F` brand-400 | `--color-brand-400` | `--color-primary-action`, `--color-button-primary-bg` |
+| `#F7F7F8` neutral-50 | `--color-neutral-50` | — |
+| `#E1E2E5` neutral-200 | `--color-neutral-200` | `--color-borders-dividers` |
+| `#2F3442` neutral-700 | `--color-neutral-700` | — |
+| `#1F2330` neutral-800 | `--color-neutral-800` | `--color-navigation-bars` |
+
+### 2a. Top bar (`1802:1579`)
+- White bar, `border-b` using `--color-borders-dividers`, `~px-40 py-8`.
+- **Left:** Sortition Foundation **landscape** logo, `h-8` (≈32px). Wraps `logo_href`.
+- **Right** (flex, `justify-end`, gap ≈24px):
+  - **Help**: `question-circle` icon (24px), icon-only link → knowledge hub (new tab).
+  - **Account**: **avatar** (32px rounded circle, brand/navy fill, white initials e.g. "AS") + `chevron-down`, opens the dropdown.
+- The old centre links (Dashboard / Site Admin / Sortition Lab / Help) are **gone** from the bar.
+
+### 2b. Account dropdown (`1803:5919`)
+White menu, `rounded-4`, shadow, ~4px padding, items `px-8 py-4`, text 13px `--color-neutral-700`, 16px leading icons, thin dividers (`--color-borders-dividers`).
+
+| # | Item | Icon (MynaUI) | Destination | Notes |
+|---|---|---|---|---|
+| 1 | My account | `user` | `profile.view` | |
+| 2 | Switch to site admin | `arrow-up-down` | `admin.index` | **new tab** (`target=_blank rel=noopener`), role-gated (`admin`/`global-organiser`) |
+| — | *divider* | | | |
+| 3 | User Data Agreement | `brand-trello` | `help_site_data_agreement` | moved from footer |
+| 4 | About Open DLP | `folder-two` | About page (new/existing) | now hosts GitHub etc. |
+| — | *divider* | | | |
+| 5 | Sign out | `upload`/logout | `auth.logout` | |
+
+Items dropped vs. today's chrome: **Sortition Lab** (top nav) and **Cookies / Sortition Foundation / version** (footer) — see Open Decisions §7.
+
+### 2c. Page header (`2898:2686`) — replaces breadcrumb on assembly pages
+- Flex row, `gap-16`, `items-center`.
+- **Back arrow** (`arrow_back`, 24px, Material style) → back one level (dashboard for assembly detail).
+- **H1 title**: Lato SemiBold, 22px, leading-32, `--color-neutral-800` — the assembly title.
+- **Status chip**: `bg --color-brand-400`, `px-8 py-2`, `rounded-8`, text 13px Lato Medium, `--color-neutral-50`. Shows assembly status ("Active" in the mock; real values TEST / PUBLISHED / CLOSED — see §7).
+- **Below** the header sits the **sticky tab bar** (existing `assembly_tabs`).
+
+### 2d. Sticky region (`2898:2685`)
+Page header + tab bar remain pinned below the top bar while page content scrolls.
+
+---
+
+## 3. New UI elements to build (inventory)
+
+Per the ticket workflow — **build in the showcase first, then rebuild the layout**. New/first-class components:
+
+1. **Avatar** (`components/avatar.html`) — circular initials badge, size + fill variants. New.
+2. **Account menu** (`components/account_menu.html`) — avatar+chevron trigger → dropdown with icon rows and dividers, role-gated items, new-tab support. Reuses the Alpine open/close + `role="menu"` pattern from `dropdown_button.html`.
+3. **Status chip / badge** (`components/chip.html`) — small rounded label with status→variant colour mapping. New (no chip/badge macro exists today).
+4. **Page header** (`components/page_header.html`) — back arrow + H1 + optional chip + optional actions slot. New (pages currently hand-roll `<h1>`).
+5. **New top bar** — simplified `navigation()` variant (logo left; help + account right). Modify `components/navigation.html` (or add a variant) rather than fork.
+6. **Icon set** — inline SVGs sourced from MynaUI: `question-circle`, `user`, `arrow-up-down`, `brand-trello`, `folder-two`, `upload`(logout), `arrow_back`, `chevron-down`. Keep the project convention (inline per use); optionally collect nav icons into a small `components/_nav_icons.html` set of `{% macro %}` helpers to avoid duplication.
+
+---
+
+## 4. Phase 1 — Showcase implementation
+
+For each new component add a demo file under `templates/backoffice/showcase/` and register it in `templates/backoffice/showcase.html` (Components tab + the "Jump to section" `<select>`), using the existing `showcase_section` / `showcase_example` / `showcase_tokens` wrappers.
+
+1. `showcase/avatar_component.html` — sizes (24/32/40), initials, fill variants.
+2. `showcase/account_menu_component.html` — live account dropdown (open state, keyboard, dividers, role-gated item shown with a note).
+3. `showcase/chip_component.html` — all status variants side by side.
+4. `showcase/page_header_component.html` — back arrow + title + chip, with/without actions.
+5. Update `showcase/navigation_component.html` to show the **new** simplified top bar (keep the old snippet only if useful for comparison).
+6. **Breadcrumb**: keep `showcase/breadcrumb_component.html` as the surviving demo instance (ticket: "keep an instance in showcase").
+
+**Accessibility (required, per `docs/agent/component_accessibility.md`):**
+- Account menu: `aria-haspopup="menu"`, `aria-expanded`, `role="menu"`/`menuitem`, Escape + click-outside close, visible focus ring, avatar trigger has `aria-label`.
+- Help icon link: `aria-label` (icon-only).
+- Back arrow: real `<a>`/`<button>` with `aria-label` ("Back to dashboard").
+- Chip: not a control — decorative/text; ensure contrast (white on brand-400 passes).
+
+---
+
+## 5. Phase 2 — Layout rebuild
+
+**`components/navigation.html`** — reduce to: logo (left) + help icon + account menu (right). Drop `nav_items` centre rendering (or keep the arg but render nothing when empty). Compose `avatar` + `account_menu`.
+
+**`base_page.html`** — rewire the frame:
+- Replace the current `navigation(...)` call/args with the new signature (logo_href, help_href, account items, current user for avatar/role gating).
+- Remove `{{ footer() }}` and its import.
+- Remove the `breadcrumb_section` block/slot (see §6).
+- Add a **sticky page-header slot**: a new `{% block page_header %}` rendered inside a sticky container so assembly pages can inject `page_header` + `assembly_tabs`.
+
+**Avatar initials** — compute from the user's display name (fallback to email local-part), e.g. a `initials` helper or Jinja filter. Log/PII: initials are derived at render time, never logged.
+
+**Help destination** — point at the knowledge hub. Recommend a config var (e.g. `KNOWLEDGE_HUB_URL`, default `https://democraticlottery.org/knowledge-hub`) alongside existing `help_site_*` config, so the not-yet-live URL is centralised.
+
+---
+
+## 6. Phase 3 — Retirements & sticky
+
+**Retire breadcrumbs** — remove the `{% block breadcrumb_section %}` from all pages that define it, drop the empty slot from `base_page.html`, and keep the macro `components/breadcrumbs.html` + `showcase/breadcrumb_component.html` for the showcase demo only. Pages to edit (18):
+`assembly_details`, `assembly_data`, `assembly_targets`, `assembly_respondents`, `assembly_selection`, `assembly_members`, `assembly_registration`, `assembly_edit_respondent`, `assembly_view_respondent`, `create_assembly`, `edit_assembly`, `respondent_field_schema/view`, `respondents/confirm_upload_diff`, `dev_dashboard`, `patterns`, `service_docs`, `showcase` (keep demo section), and any other `block breadcrumb_section` holder found by grep.
+
+**Assembly detail** (`assembly_details.html` and sibling assembly pages):
+- Replace the breadcrumb with `page_header(title=assembly.title, back_href=dashboard, chip=status_chip(assembly.status))`.
+- Remove the bottom "Back to Dashboard" button (keep "Edit Assembly"); the back arrow now serves that role.
+- Move `assembly_tabs` into the sticky page-header region.
+
+**Sticky** — wrap page header + tab bar in a `position: sticky; top: <top-bar height>` container with a background and a bottom border so content scrolls under it cleanly. Decide whether the **top bar** is also sticky (`top:0`) or scrolls away; set `z-index` layering accordingly (top bar > sticky header > content). Verify against the mock's intent.
+
+**Footer removal** — delete the `footer()` call + import; relocate its links:
+- GitHub → **About OpenDLP** page.
+- User Data Agreement → account dropdown (done in §2b).
+- Cookies / Sortition Foundation / version → About page (recommended; confirm §7). **Cookies must stay reachable** for the no-cookie-banner posture (`docs/personal-data.md`).
+
+---
+
+## 7. Open decisions (recommended defaults in **bold**)
+
+1. **Where do Cookies, Sortition Foundation link, and the version string go** now the footer is gone? → **On the "About OpenDLP" page**, together with GitHub. (Cookies must remain reachable.)
+2. **Does an "About OpenDLP" page already exist**, or do we create one? → Audit; **create a simple static page** if missing (hosts GitHub, version, Sortition Foundation, Cookies).
+3. **Sortition Lab** top-nav link — the new design drops it. → **Remove** it (can live on the About/knowledge hub later).
+4. **How users return to the dashboard** without the top "Dashboard" link / bottom button → **logo → dashboard** (global) + **page-header back arrow** (contextual).
+5. **Status chip colours** — the mock shows brand-400 for "Active". Real statuses are TEST / PUBLISHED / CLOSED (see registration lifecycle). → Define a **status→variant map** in `chip.html` (e.g. TEST=neutral, PUBLISHED=brand, CLOSED=muted); confirm exact palette with design.
+6. **Help URL** — `democraticlottery.org/knowledge-hub` doesn't exist yet. → Ship it behind a **config var** so it's one-line to update; opens in a new tab.
+7. **Top bar sticky or not** — ticket only says the *page header + tabs* must be sticky. → **Top bar sticky at `top:0`**, page header sticky beneath it (cleanest), unless design says the bar should scroll away.
+
+---
+
+## 8. File-change checklist
+
+**New**
+- `templates/backoffice/components/avatar.html`
+- `templates/backoffice/components/account_menu.html`
+- `templates/backoffice/components/chip.html`
+- `templates/backoffice/components/page_header.html`
+- `templates/backoffice/showcase/{avatar,account_menu,chip,page_header}_component.html`
+- (optional) `templates/backoffice/components/_nav_icons.html`
+- (maybe) About OpenDLP page template + route
+
+**Modified**
+- `templates/backoffice/components/navigation.html` (simplified top bar)
+- `templates/backoffice/base_page.html` (nav wiring, drop footer, drop breadcrumb slot, add sticky page-header slot)
+- `templates/backoffice/showcase.html` (register new demos; keep breadcrumb demo)
+- `templates/backoffice/showcase/navigation_component.html` (new top bar)
+- `templates/backoffice/assembly_details.html` (+ sibling assembly pages: page header, sticky tabs, remove back button)
+- 18 page templates: remove `block breadcrumb_section` (§6)
+- `config.py` (KNOWLEDGE_HUB_URL / help URL)
+
+**Kept (demo only)**
+- `templates/backoffice/components/breadcrumbs.html`
+- `templates/backoffice/showcase/breadcrumb_component.html`
+
+**Removed**
+- `templates/backoffice/components/footer.html` (after relocating links)
+
+---
+
+## 9. Cross-cutting requirements
+
+- **i18n**: all new user-facing strings via `_()` / `_l()`; run `just translate-regen` after. New strings: "My account", "Switch to site admin", "User Data Agreement", "About OpenDLP", "Sign out", "Help", "Back to dashboard", status labels.
+- **CSP / Alpine**: account menu must follow the CSP-safe Alpine patterns (`x-data` flat props, no string args in `@click`) — see `/backoffice/dev/patterns` and `docs/frontend_security.md`.
+- **ABOUTME**: every new template file starts with the 2-line ABOUTME comment.
+- **Icons**: source exact SVGs from MynaUI; don't hand-draw paths.
+- **Testing**: update/extend BDD (`tests/bdd/`) for nav — account dropdown open/close, help link, page header + sticky, breadcrumb removal, footer removal. Keyboard + ARIA checks per accessibility guide. Run `just test-nobdd && just test-bdd-headless` (never concurrently).
+
+---
+
+## 9a. Implementation status (delivered on this branch)
+
+**Done:** avatar, account_menu, page_header, `_nav_icons`, reworked `navigation` top bar (all with showcase demos + registration); `base_page.html` sticky chrome + account-menu wiring + `KNOWLEDGE_HUB_URL` config/context var; page header + sticky tabs on all assembly pages; removed the "Back to Dashboard" button; breadcrumbs retired across 18 pages (macro + showcase demo kept); removed the retired `Breadcrumb has correct semantic structure` a11y scenario + its step defs. Footer kept (removal deferred). Chip out of scope.
+
+**Testing notes / caveats:**
+- Component + unit suites: green across all changed pages; mypy clean on the Python changes.
+- **BDD requires `FF_OLD_DEFAULT_DASHBOARD=true` in the spawned server's env.** The repo `.env` sets it to `false`; the `test_server` fixture does `os.environ.copy()` and does not force it, and Flask auto-loads `.env`. Without the export, post-login redirects to `/backoffice/dashboard` while the BDD `_login` helper waits for `/dashboard`, timing out ~75% of scenarios. Run BDD as: `FF_OLD_DEFAULT_DASHBOARD=true FF_DASHBOARD_SWITCH_LINKS=true just test-bdd-headless`. This is pre-existing infra behaviour, unrelated to the nav rework.
+- `just translate-regen` still to be run for the new gettext strings.
+- **BDD test updates for the redesign:** removed 5 `*displays breadcrumbs` scenarios + the `Breadcrumb has correct semantic structure` a11y scenario (and their now-unused step defs). Replaced the CSP-fragile `page.wait_for_function("window.scrollY > 0")` scroll checks with a CSP-safe CDP poll (`_wait_until_scrolled`). **Skipped** `Entering edit mode preserves the scroll position` (`@skip` + TODO): the Edit control is now top-anchored under the sticky header, so "scroll down then click Edit" legitimately returns to the top — the scenario's premise no longer holds. The `?scroll=` restore mechanism still works; the team should write a layout-appropriate replacement.
+
+## 10. Suggested sequencing
+
+1. Icons + `avatar` + `chip` (leaf components) → showcase demos.
+2. `account_menu` (uses avatar + icons) → showcase demo.
+3. `page_header` (uses chip + back arrow) → showcase demo.
+4. New `navigation()` top bar → showcase demo.
+5. Rebuild `base_page.html` (nav wiring, sticky slot, drop footer/breadcrumb slot).
+6. Assembly pages: page header + sticky tabs, remove back button.
+7. Retire breadcrumbs across the 18 pages.
+8. About OpenDLP page (GitHub + relocated footer links).
+9. i18n regen, BDD, accessibility pass, verify in-browser.

--- a/backend/env.example
+++ b/backend/env.example
@@ -105,6 +105,8 @@ SUPPORT_EMAIL=opendlp-support@sortitionfoundation.org
 HELP_SITE_HOME=https://docs.sortitionlab.org/help/
 HELP_SITE_DATA_AGREEMENT=https://docs.sortitionlab.org/data-and-legal/data-agreement/
 HELP_SITE_COOKIES=https://docs.sortitionlab.org/data-and-legal/cookies/
+# Knowledge hub (not live yet) - target of the top-bar help icon
+KNOWLEDGE_HUB_URL=https://democraticlottery.org/knowledge-hub
 # Solver backend for sortition-algorithms: 'mip' (CBC) or 'highspy' (HiGHS)
 # If not set, defaults to 'highspy' on macOS and 'mip' on other platforms
 # SOLVER_BACKEND=

--- a/backend/features/accessibility.feature
+++ b/backend/features/accessibility.feature
@@ -106,16 +106,6 @@ Feature: Component Accessibility
     And inactive tabs should have tabindex="-1"
 
   # =============================================================================
-  # Breadcrumb Accessibility Tests
-  # =============================================================================
-
-  Scenario: Breadcrumb has correct semantic structure
-    Given the user is on the assembly details page
-    Then the breadcrumb should have a nav element with aria-label
-    And the breadcrumb items should be in an ordered list
-    And the current page breadcrumb should have aria-current="page"
-
-  # =============================================================================
   # Button Accessibility Tests
   # =============================================================================
 

--- a/backend/features/backoffice-assembly-members.feature
+++ b/backend/features/backoffice-assembly-members.feature
@@ -11,15 +11,6 @@ Feature: Backoffice Assembly Team Members
     Then I should see the assembly members page
     And I should see "Team Members" as a section heading
 
-  Scenario: Assembly members page displays breadcrumbs
-    Given I am logged in as an admin user
-    And there is an assembly called "Climate Assembly"
-    When I visit the assembly members page for "Climate Assembly"
-    Then I should see the breadcrumbs
-    And the breadcrumbs should contain "Dashboard"
-    And the breadcrumbs should contain "Climate Assembly"
-    And the breadcrumbs should contain "Team Members"
-
   Scenario: Admin can see add user form on members page
     Given I am logged in as an admin user
     And there is an assembly called "Climate Assembly"

--- a/backend/features/backoffice-assembly.feature
+++ b/backend/features/backoffice-assembly.feature
@@ -13,14 +13,6 @@ Feature: Backoffice Assembly Management
     Then I should see the assembly details page
     And I should see "Climate Assembly" as the page heading
 
-  Scenario: Assembly details page displays breadcrumbs
-    Given I am logged in as an admin user
-    And there is an assembly called "Climate Assembly"
-    When I visit the assembly details page for "Climate Assembly"
-    Then I should see the breadcrumbs
-    And the breadcrumbs should contain "Dashboard"
-    And the breadcrumbs should contain "Climate Assembly"
-
   Scenario: Assembly details page displays assembly information
     Given I am logged in as an admin user
     And there is an assembly called "Climate Assembly" with question "How should we address climate change?"
@@ -47,15 +39,6 @@ Feature: Backoffice Assembly Management
     And I click the "Edit Assembly" button
     Then I should see the edit assembly page
     And I should see "Edit Assembly" as the page heading
-
-  Scenario: Edit assembly page displays breadcrumbs
-    Given I am logged in as an admin user
-    And there is an assembly called "Climate Assembly"
-    When I visit the edit assembly page for "Climate Assembly"
-    Then I should see the breadcrumbs
-    And the breadcrumbs should contain "Dashboard"
-    And the breadcrumbs should contain "Climate Assembly"
-    And the breadcrumbs should contain "Edit"
 
   Scenario: Edit assembly page displays form fields
     Given I am logged in as an admin user
@@ -98,13 +81,6 @@ Feature: Backoffice Assembly Management
     And I click the "Create New Assembly" button
     Then I should see the create assembly page
     And I should see "Create Assembly" as the page heading
-
-  Scenario: Create assembly page displays breadcrumbs
-    Given I am logged in as an admin user
-    When I visit the create assembly page
-    Then I should see the breadcrumbs
-    And the breadcrumbs should contain "Dashboard"
-    And the breadcrumbs should contain "Create Assembly"
 
   Scenario: Create assembly page displays form fields
     Given I am logged in as an admin user

--- a/backend/features/backoffice-registration-editor.feature
+++ b/backend/features/backoffice-registration-editor.feature
@@ -64,6 +64,12 @@ Feature: Backoffice registration HTML editor
     And I confirm closing the registration
     Then the registration should be shown as closed
 
+  # TODO(680-navigation-rework): rework scroll-preservation coverage for the new
+  # layout. The Edit control is now top-anchored under the sticky header, so
+  # "scroll down then click Edit" legitimately returns to the top and this
+  # scenario's premise no longer holds. The ?scroll= restore mechanism itself
+  # still works; a layout-appropriate scenario should replace this.
+  @skip
   Scenario: Entering edit mode preserves the scroll position
     Given I am logged in as an admin user
     And there is an assembly called "Scroll Edit Assembly" with a registration page

--- a/backend/features/backoffice-registration-editor.feature
+++ b/backend/features/backoffice-registration-editor.feature
@@ -64,19 +64,17 @@ Feature: Backoffice registration HTML editor
     And I confirm closing the registration
     Then the registration should be shown as closed
 
-  # TODO(680-navigation-rework): rework scroll-preservation coverage for the new
-  # layout. The Edit control is now top-anchored under the sticky header, so
-  # "scroll down then click Edit" legitimately returns to the top and this
-  # scenario's premise no longer holds. The ?scroll= restore mechanism itself
-  # still works; a layout-appropriate scenario should replace this.
-  @skip
-  Scenario: Entering edit mode preserves the scroll position
+  # Scroll preservation: forms/links append ?scroll=<y> on navigation
+  # (x-preserve-scroll-on-submit / x-scroll-preserve-links) and the page restores
+  # it on load. This exercises the restore leg deterministically. It replaces an
+  # older "enter edit mode preserves scroll" scenario, whose premise the 680
+  # redesign invalidated (the Edit control is now top-anchored under the sticky
+  # header, so scrolling down then clicking it legitimately returns to the top).
+  Scenario: A saved scroll position is restored on load
     Given I am logged in as an admin user
-    And there is an assembly called "Scroll Edit Assembly" with a registration page
-    When I visit the read-only registration form view for "Scroll Edit Assembly"
-    And I scroll down the page
-    And I click the Edit button in the editor header
-    Then the editor should be in edit mode with the page still scrolled down
+    And there is an assembly called "Scroll Restore Assembly" with a registration page
+    When I open the read-only registration form view for "Scroll Restore Assembly" with a saved scroll of 400
+    Then the page should be scrolled down
 
   Scenario: Cancelling with unsaved changes asks for confirmation
     Given I am logged in as an admin user

--- a/backend/features/backoffice.feature
+++ b/backend/features/backoffice.feature
@@ -26,7 +26,6 @@ Feature: Backoffice Dashboard
     Then I should see the footer
     And the footer should contain GitHub link
     And the footer should contain Sortition Foundation link
-    And the footer should contain User Data Agreement link
     And the footer should display the version
 
   # Selection Tab Tests

--- a/backend/features/backoffice.feature
+++ b/backend/features/backoffice.feature
@@ -40,15 +40,6 @@ Feature: Backoffice Dashboard
     Then I should see the assembly selection page
     And I should see "Selection Test Assembly" as the page heading
 
-  Scenario: Selection tab displays breadcrumbs
-    Given I am logged in as an admin user
-    And there is an assembly called "Selection Test Assembly"
-    When I visit the assembly selection page for "Selection Test Assembly"
-    Then I should see the breadcrumbs
-    And the breadcrumbs should contain "Dashboard"
-    And the breadcrumbs should contain "Selection Test Assembly"
-    And the breadcrumbs should contain "Selection"
-
   Scenario: Selection tab shows warning when no gsheet configured
     Given I am logged in as an admin user
     And there is an assembly called "Selection No GSheet Assembly"

--- a/backend/src/opendlp/config.py
+++ b/backend/src/opendlp/config.py
@@ -469,6 +469,8 @@ class FlaskBaseConfig:
         self.HELP_SITE_COOKIES: str = os.environ.get(
             "HELP_SITE_COOKIES", "https://docs.sortitionlab.org/data-and-legal/cookies/"
         )
+        # Knowledge hub (not live yet) - target of the top-bar help icon
+        self.KNOWLEDGE_HUB_URL: str = os.environ.get("KNOWLEDGE_HUB_URL", "https://democraticlottery.org/knowledge-hub")
 
         # Login rate limiting
         self.LOGIN_RATE_LIMIT_PER_EMAIL: int = int(os.environ.get("LOGIN_RATE_LIMIT_PER_EMAIL", "5"))

--- a/backend/src/opendlp/entrypoints/context_processors.py
+++ b/backend/src/opendlp/entrypoints/context_processors.py
@@ -135,6 +135,7 @@ class HelpSiteUrls(NamedTuple):
     home: str
     data_agreement: str
     cookies: str
+    knowledge_hub: str
 
 
 @cache
@@ -144,6 +145,7 @@ def get_help_site_urls() -> HelpSiteUrls:
         home=flask_config.HELP_SITE_HOME,
         data_agreement=flask_config.HELP_SITE_DATA_AGREEMENT,
         cookies=flask_config.HELP_SITE_COOKIES,
+        knowledge_hub=flask_config.KNOWLEDGE_HUB_URL,
     )
 
 
@@ -177,4 +179,5 @@ def inject_template_globals() -> dict[str, str | Callable]:
         "help_site_home": help_site_urls.home,
         "help_site_data_agreement": help_site_urls.data_agreement,
         "help_site_cookies": help_site_urls.cookies,
+        "knowledge_hub_url": help_site_urls.knowledge_hub,
     }

--- a/backend/static/backoffice/js/alpine-components.js
+++ b/backend/static/backoffice/js/alpine-components.js
@@ -763,4 +763,58 @@ document.addEventListener("alpine:init", function () {
             },
         };
     });
+
+    /**
+     * Auto-dismissing alert component
+     *
+     * Hides itself after `duration` ms (0 = never auto-dismiss). The countdown
+     * pauses while the pointer is over the alert and resumes on leave, so users
+     * can read or act on it. Registered as a component because the CSP Alpine
+     * build forbids inline setTimeout in x-* expressions (mirrors buttonLoadingDemo).
+     *
+     * Usage:
+     *   <div x-data="autoDismissAlert({ duration: 4000 })" x-show="show" x-transition
+     *        @mouseenter="pause()" @mouseleave="resume()">
+     *     ...
+     *     <button @click="show = false">Close</button>
+     *   </div>
+     */
+    Alpine.data("autoDismissAlert", function (options) {
+        var duration = (options && options.duration) || 0;
+        return {
+            show: true,
+            remaining: duration,
+            timer: null,
+            startedAt: 0,
+
+            init: function () {
+                if (duration > 0) {
+                    this.startTimer();
+                }
+            },
+
+            startTimer: function () {
+                var self = this;
+                self.startedAt = Date.now();
+                self.timer = setTimeout(function () {
+                    self.show = false;
+                    self.timer = null;
+                }, self.remaining);
+            },
+
+            pause: function () {
+                if (this.timer) {
+                    clearTimeout(this.timer);
+                    this.timer = null;
+                    this.remaining -= Date.now() - this.startedAt;
+                }
+            },
+
+            resume: function () {
+                if (duration > 0 && !this.timer && this.remaining > 0) {
+                    this.startTimer();
+                }
+            },
+        };
+    });
 });

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -904,6 +904,19 @@
        Surface and rhythm match Figma node 1601:856 (alert dialog).
        ======================================== */
 
+    /* ========================================
+       Z-INDEX STACK (overlapping fixed / sticky UI). Keep these in sync when
+       changing any one layer:
+         dropdown menus (.menu) ............... 30
+         sticky header (Tailwind z-40) ........ 40
+         modal backdrop (.dialog-backdrop) .... 40
+         floating flash alerts (#floating-alerts) 45  (above header/backdrop, below dialog)
+         modal dialog (.dialog-positioner) .... 50
+       ======================================== */
+    #floating-alerts {
+        z-index: 45;
+    }
+
     .dialog-backdrop {
         position: fixed;
         inset: 0;

--- a/backend/templates/backoffice/assembly_data.html
+++ b/backend/templates/backoffice/assembly_data.html
@@ -54,10 +54,6 @@ ABOUTME: Displays data source selection and data management for assemblies
     {% elif data_source == "csv" %}
         {{ render_csv_content() }}
     {% endif %}
-    {# Actions #}
-    <section class="flex gap-4">
-        {{ button(_("Back to Dashboard") , href=url_for('backoffice.dashboard'), variant="outline") }}
-    </section>
 {% endblock %}
 {# Google Spreadsheet content macro #}
 {% macro render_gsheet_content() %}

--- a/backend/templates/backoffice/assembly_data.html
+++ b/backend/templates/backoffice/assembly_data.html
@@ -3,33 +3,32 @@ ABOUTME: Backoffice assembly data page
 ABOUTME: Displays data source selection and data management for assemblies
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/input.html" import input, checkbox, radio_group, file_input, first_error as e %}
 {% from "backoffice/components/select_dropdown.html" import select_dropdown %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% block title %}{{ _("Data") }} - {{ assembly.title }}{% endblock %}
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard") , "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Data")}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
+        {{ page_header(
+        title=assembly.title,
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")
+        ) }}
+        <div class="mt-4">
+            {{ assembly_tabs(assembly=assembly,
+            active_tab="data",
+            data_source=data_source,
+            gsheet=gsheet,
+            targets_enabled=targets_enabled|default(false) ,
+            respondents_enabled=respondents_enabled|default(false),
+            selection_enabled=selection_enabled|default(false)
+            ) }}
+        </div>
     </div>
 {% endblock %}
 {% block page_content %}
-    {# Page Heading #}
-    <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">{{ _("Manage data for this assembly") }}</p>
-    {{ assembly_tabs(assembly=assembly,
-    active_tab="data",
-    data_source=data_source,
-    gsheet=gsheet,
-    targets_enabled=targets_enabled|default(false) ,
-    respondents_enabled=respondents_enabled|default(false),
-    selection_enabled=selection_enabled|default(false)
-    ) }}
     {# Data Source Selector #}
     <section class="mb-8">
         <div class="max-w-md"

--- a/backend/templates/backoffice/assembly_details.html
+++ b/backend/templates/backoffice/assembly_details.html
@@ -3,7 +3,7 @@ ABOUTME: Backoffice assembly details page
 ABOUTME: Displays assembly information with question, metadata, and edit action
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/section.html" import section %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
@@ -11,32 +11,28 @@ ABOUTME: Displays assembly information with question, metadata, and edit action
 
 {% block title %}{{ assembly.title }} - Assembly{% endblock %}
 
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
+        {{ page_header(
+        title=assembly.title,
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")
+        ) }}
+        <div class="mt-4">
+            {{ assembly_tabs(
+            assembly=assembly,
+            active_tab="details",
+            data_source=data_source|default(""),
+            gsheet=gsheet|default(none),
+            targets_enabled=targets_enabled|default(false),
+            respondents_enabled=respondents_enabled|default(false),
+            selection_enabled=selection_enabled|default(false)
+            ) }}
+        </div>
     </div>
 {% endblock %}
 
 {% block page_content %}
-    {# Page Heading #}
-    <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
-        {{ _("Assembly Details") }}
-    </p>
-
-    {{ assembly_tabs(
-    assembly=assembly,
-    active_tab="details",
-    data_source=data_source|default(""),
-    gsheet=gsheet|default(none),
-    targets_enabled=targets_enabled|default(false),
-    respondents_enabled=respondents_enabled|default(false),
-    selection_enabled=selection_enabled|default(false)
-    ) }}
-
     {# Assembly Question Section #}
     {% if assembly.question %}
         <div class="mb-8">
@@ -174,7 +170,6 @@ ABOUTME: Displays assembly information with question, metadata, and edit action
 
     {# Actions #}
     <section class="flex gap-4">
-        {{ button(_("Back to Dashboard"), href=url_for('backoffice.dashboard'), variant="outline") }}
         {{ button(_("Edit Assembly"), href=url_for('backoffice.edit_assembly', assembly_id=assembly.id), variant="primary") }}
     </section>
 {% endblock %}

--- a/backend/templates/backoffice/assembly_edit_respondent.html
+++ b/backend/templates/backoffice/assembly_edit_respondent.html
@@ -3,7 +3,7 @@ ABOUTME: Backoffice edit-single-respondent page
 ABOUTME: Dynamic form grouped by RespondentFieldGroup, with a required change-note comment
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/input.html" import input, textarea, select, radio_group, first_error %}
 {% from "backoffice/components/alert.html" import alert %}
@@ -11,21 +11,16 @@ ABOUTME: Dynamic form grouped by RespondentFieldGroup, with a required change-no
 {% from "backoffice/components/respondent_status_form.html" import respondent_status_form %}
 {% set respondent_name = respondent.display_name(assembly.name_fields) %}
 {% block title %}{{ _("Edit respondent") }} - {{ respondent_name }}{% endblock %}
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard") , "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Respondents"), "href": url_for('respondents.view_assembly_respondents', assembly_id=assembly.id)},
-        {"label": respondent_name, "href": url_for('respondents.view_respondent', assembly_id=assembly.id, respondent_id=respondent.id)},
-        {"label": _("Edit")}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 pb-2 w-full">
+        {{ page_header(
+        title=respondent_name,
+        back_href=url_for('respondents.view_respondent', assembly_id=assembly.id, respondent_id=respondent.id),
+        back_label=_("Back to respondent")
+        ) }}
     </div>
 {% endblock %}
 {% block page_content %}
-    <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ _("Edit respondent") }}</h1>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">{{ respondent_name }}</p>
-
     {# Selection status — its own form, visually separated from the attribute edit form below. #}
     {% call section(classes="mb-8") %}
         {{ respondent_status_form(assembly, respondent, allowed_transitions) }}

--- a/backend/templates/backoffice/assembly_members.html
+++ b/backend/templates/backoffice/assembly_members.html
@@ -3,7 +3,7 @@ ABOUTME: Backoffice assembly team members page
 ABOUTME: Displays team members table with add/remove functionality for admins
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/card.html" import card %}
 {% from "backoffice/components/search_dropdown.html" import search_dropdown %}
@@ -12,33 +12,28 @@ ABOUTME: Displays team members table with add/remove functionality for admins
 
 {% block title %}{{ _("Team Members") }} - {{ assembly.title }}{% endblock %}
 
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Team Members")}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
+        {{ page_header(
+        title=assembly.title,
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")
+        ) }}
+        <div class="mt-4">
+            {{ assembly_tabs(
+            assembly=assembly,
+            active_tab="members",
+            data_source=data_source|default(""),
+            gsheet=gsheet|default(none),
+            targets_enabled=targets_enabled|default(false),
+            respondents_enabled=respondents_enabled|default(false),
+            selection_enabled=selection_enabled|default(false)
+            ) }}
+        </div>
     </div>
 {% endblock %}
 
 {% block page_content %}
-    {# Page Heading #}
-    <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
-        {{ _("Manage team members for this assembly") }}
-    </p>
-
-    {{ assembly_tabs(
-    assembly=assembly,
-    active_tab="members",
-    data_source=data_source|default(""),
-    gsheet=gsheet|default(none),
-    targets_enabled=targets_enabled|default(false),
-    respondents_enabled=respondents_enabled|default(false),
-    selection_enabled=selection_enabled|default(false)
-    ) }}
-
     {# Team Members Section #}
     <section class="mb-8">
         <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">{{ _("Team Members") }}</h2>

--- a/backend/templates/backoffice/assembly_members.html
+++ b/backend/templates/backoffice/assembly_members.html
@@ -136,9 +136,4 @@ ABOUTME: Displays team members table with add/remove functionality for admins
             {% endcall %}
         </section>
     {% endif %}
-
-    {# Actions #}
-    <section class="flex gap-4">
-        {{ button(_("Back to Dashboard"), href=url_for('backoffice.dashboard'), variant="outline") }}
-    </section>
 {% endblock %}

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -3,7 +3,7 @@ ABOUTME: Backoffice registration form configuration page
 ABOUTME: Allows assembly managers to configure RSVP/registration forms with custom HTML
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/input.html" import checkbox, input, switch, textarea %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
@@ -13,34 +13,29 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 
 {% block title %}{{ assembly.title }} - Registration{% endblock %}
 
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Registration")}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
+        {{ page_header(
+        title=assembly.title,
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")
+        ) }}
+        <div class="mt-4">
+            {{ assembly_tabs(
+            assembly=assembly,
+            active_tab="registration",
+            data_source=data_source|default(""),
+            gsheet=gsheet|default(none),
+            targets_enabled=targets_enabled|default(false),
+            respondents_enabled=respondents_enabled|default(false),
+            selection_enabled=selection_enabled|default(false)
+            ) }}
+        </div>
     </div>
 {% endblock %}
 
 {% block page_content %}
     <div x-data="registrationPageController()">
-        {# Page Heading #}
-        <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
-        <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
-            {{ _("Registration Form Configuration") }}
-        </p>
-
-        {{ assembly_tabs(
-        assembly=assembly,
-        active_tab="registration",
-        data_source=data_source|default(""),
-        gsheet=gsheet|default(none),
-        targets_enabled=targets_enabled|default(false),
-        respondents_enabled=respondents_enabled|default(false),
-        selection_enabled=selection_enabled|default(false)
-        ) }}
-
         {% if not has_registration_page %}
             {# Warning panel when no registration page exists #}
             <div class="rounded-lg p-6 mb-6" style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -3,7 +3,7 @@ ABOUTME: Backoffice assembly respondents page
 ABOUTME: Displays respondent data configuration for assemblies
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/alert.html" import alert %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
@@ -13,33 +13,28 @@ ABOUTME: Displays respondent data configuration for assemblies
 
 {% block title %}{{ _("Respondents") }} - {{ assembly.title }}{% endblock %}
 
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Respondents")}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
+        {{ page_header(
+        title=assembly.title,
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")
+        ) }}
+        <div class="mt-4">
+            {{ assembly_tabs(
+            assembly=assembly,
+            active_tab="respondents",
+            data_source=data_source,
+            gsheet=gsheet,
+            targets_enabled=targets_enabled,
+            respondents_enabled=respondents_enabled,
+            selection_enabled=selection_enabled|default(false)
+            ) }}
+        </div>
     </div>
 {% endblock %}
 
 {% block page_content %}
-    {# Page Heading #}
-    <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
-        {{ _("Manage respondent data for this assembly") }}
-    </p>
-
-    {{ assembly_tabs(
-    assembly=assembly,
-    active_tab="respondents",
-    data_source=data_source,
-    gsheet=gsheet,
-    targets_enabled=targets_enabled,
-    respondents_enabled=respondents_enabled,
-    selection_enabled=selection_enabled|default(false)
-    ) }}
-
     {% if data_source == "gsheet" and gsheet %}
         {# Google Sheet source - show info about where respondents are configured #}
         <section class="mb-8">

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -78,7 +78,7 @@ ABOUTME: Displays respondent data configuration for assemblies
             {% call section() %}
                 <div class="flex items-center justify-between mb-4">
                     <div class="flex items-baseline gap-3 flex-wrap">
-                        <h2 class="text-heading-md" style="color: var(--color-headings);">{{ _("Respondents") }}</h2>
+                        <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Respondents") }}</h2>
                         {% if respondent_gsheet and respondent_gsheet.worksheet_url %}
                             <p class="text-body-sm" style="color: var(--color-secondary-text);">
                                 {{ _("Exported to Google Spreadsheet") }}

--- a/backend/templates/backoffice/assembly_respondents.html
+++ b/backend/templates/backoffice/assembly_respondents.html
@@ -178,9 +178,4 @@ ABOUTME: Displays respondent data configuration for assemblies
             </div>
         </section>
     {% endif %}
-
-    {# Actions #}
-    <section class="flex gap-4">
-        {{ button(_("Back to Dashboard"), href=url_for('backoffice.dashboard'), variant="outline") }}
-    </section>
 {% endblock %}

--- a/backend/templates/backoffice/assembly_selection.html
+++ b/backend/templates/backoffice/assembly_selection.html
@@ -3,36 +3,33 @@ ABOUTME: Backoffice assembly selection page
 ABOUTME: Displays selection operations: initial selection, replacement, and tab management
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/card.html" import card, card_body, card_footer %}
 {% from "backoffice/components/alert.html" import alert %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% from "backoffice/components/pagination.html" import pagination %}
 {% block title %}{{ _("Selection") }} - {{ assembly.title }}{% endblock %}
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard") , "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Selection")}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
+        {{ page_header(
+        title=assembly.title,
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")
+        ) }}
+        <div class="mt-4">
+            {{ assembly_tabs(assembly=assembly,
+            active_tab="selection",
+            data_source=data_source|default("") ,
+            gsheet=gsheet|default(none),
+            targets_enabled=targets_enabled|default(false),
+            respondents_enabled=respondents_enabled|default(false),
+            selection_enabled=selection_enabled|default(false)
+            ) }}
+        </div>
     </div>
 {% endblock %}
 {% block page_content %}
-    {# Page Heading #}
-    <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
-        {{ _("Run selection and manage generated outputs") }}
-    </p>
-    {{ assembly_tabs(assembly=assembly,
-    active_tab="selection",
-    data_source=data_source|default("") ,
-    gsheet=gsheet|default(none),
-    targets_enabled=targets_enabled|default(false),
-    respondents_enabled=respondents_enabled|default(false),
-    selection_enabled=selection_enabled|default(false)
-    ) }}
     {# Selection Progress Modal - shown when current_selection parameter is present #}
     {# Pure HTMX approach: server controls close button state, HTMX swaps entire modal content #}
     {% if current_selection and run_record %}

--- a/backend/templates/backoffice/assembly_selection.html
+++ b/backend/templates/backoffice/assembly_selection.html
@@ -262,16 +262,11 @@ ABOUTME: Displays selection operations: initial selection, replacement, and tab 
                 {% endcall %}
             {% endcall %}
         </div>
-        {# Actions #}
-        <section class="flex gap-4">
-            {{ button(_("Back to Dashboard") , href=url_for('backoffice.dashboard'), variant="outline") }}
-        </section>
     {% elif not gsheet %}
         {# No Google Sheet configured - show configuration prompt #}
         {{ alert(_("Please use the Data tab to tell us about your data, before running a selection.") , variant="warning") }}
         <section class="flex gap-4">
             {{ button(_("Configure Data Source") , href=url_for('backoffice.view_assembly_data', assembly_id=assembly.id), variant="primary") }}
-            {{ button(_("Back to Dashboard") , href=url_for('backoffice.dashboard'), variant="outline") }}
         </section>
     {% else %}
         {# Google Sheet configured - show selection options #}
@@ -452,9 +447,5 @@ ABOUTME: Displays selection operations: initial selection, replacement, and tab 
                 {% endcall %}
             {% endcall %}
         </div>
-        {# Actions #}
-        <section class="flex gap-4">
-            {{ button(_("Back to Dashboard") , href=url_for('backoffice.dashboard'), variant="outline") }}
-        </section>
     {% endif %}
 {% endblock %}

--- a/backend/templates/backoffice/assembly_targets.html
+++ b/backend/templates/backoffice/assembly_targets.html
@@ -194,9 +194,4 @@ ABOUTME: Displays target categories, values, respondent data, CSV import, and va
         </section>
 
     {% endif %}
-
-    {# Actions #}
-    <section class="mt-8 flex gap-4">
-        {{ button(_("Back to Dashboard"), href=url_for('backoffice.dashboard'), variant="secondary") }}
-    </section>
 {% endblock %}

--- a/backend/templates/backoffice/assembly_targets.html
+++ b/backend/templates/backoffice/assembly_targets.html
@@ -3,7 +3,7 @@ ABOUTME: Backoffice assembly targets page with full editing capabilities
 ABOUTME: Displays target categories, values, respondent data, CSV import, and validation
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/alert.html" import alert %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
@@ -11,33 +11,28 @@ ABOUTME: Displays target categories, values, respondent data, CSV import, and va
 
 {% block title %}{{ _("Targets") }} - {{ assembly.title }}{% endblock %}
 
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Targets")}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
+        {{ page_header(
+        title=assembly.title,
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")
+        ) }}
+        <div class="mt-4">
+            {{ assembly_tabs(
+            assembly=assembly,
+            active_tab="targets",
+            data_source=data_source,
+            gsheet=gsheet,
+            targets_enabled=targets_enabled,
+            respondents_enabled=respondents_enabled,
+            selection_enabled=selection_enabled|default(false)
+            ) }}
+        </div>
     </div>
 {% endblock %}
 
 {% block page_content %}
-    {# Page Heading #}
-    <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
-        {{ _("Configure selection targets for this assembly") }}
-    </p>
-
-    {{ assembly_tabs(
-    assembly=assembly,
-    active_tab="targets",
-    data_source=data_source,
-    gsheet=gsheet,
-    targets_enabled=targets_enabled,
-    respondents_enabled=respondents_enabled,
-    selection_enabled=selection_enabled|default(false)
-    ) }}
-
     {% if data_source == "gsheet" and gsheet %}
         {# Google Sheet source - show info about where targets are configured #}
         <section class="mb-8">

--- a/backend/templates/backoffice/assembly_view_respondent.html
+++ b/backend/templates/backoffice/assembly_view_respondent.html
@@ -3,23 +3,22 @@ ABOUTME: Backoffice view-single-respondent page
 ABOUTME: Renders a grouped detail page driven by RespondentFieldDefinition schema
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
-{% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% from "backoffice/components/table.html" import table, table_head, table_body, table_row, table_cell, table_cell_custom %}
 {% from "backoffice/components/input.html" import input, textarea, radio_group %}
 {% from "backoffice/components/section.html" import section %}
 {% from "backoffice/components/respondent_status_form.html" import respondent_status_form %}
 {% set respondent_name = respondent.display_name(assembly.name_fields) %}
 {% block title %}{{ respondent_name }} - {{ assembly.title }}{% endblock %}
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard") , "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Respondents"), "href": url_for('respondents.view_assembly_respondents', assembly_id=assembly.id)},
-        {"label": respondent_name}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 pb-2 w-full">
+        {{ page_header(
+        title=respondent_name,
+        back_href=url_for('respondents.view_assembly_respondents', assembly_id=assembly.id),
+        back_label=_("Back to respondents"),
+        actions=(button(_("Edit"), href=url_for('respondents.edit_respondent', assembly_id=assembly.id, respondent_id=respondent.id), variant="primary") if (can_edit and respondent.selection_status.value != "DELETED") else "")
+        ) }}
     </div>
 {% endblock %}
 {% set is_deleted = respondent.selection_status.value == "DELETED" %}
@@ -89,13 +88,6 @@ becomes a disabled input/textarea so the page reads as a read-only form.
     {% endif %}
 {% endmacro %}
 {% block page_content %}
-    <div class="flex items-start justify-between gap-4 mb-2">
-        <h1 class="text-display-lg" style="color: var(--color-headings);">{{ respondent_name }}</h1>
-        {% if can_edit and not is_deleted %}
-            {{ button(_("Edit") , href=url_for('respondents.edit_respondent', assembly_id=assembly.id, respondent_id=respondent.id), variant="primary") }}
-        {% endif %}
-    </div>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">{{ _("Respondent details") }}</p>
     {% if is_deleted and delete_comment %}
         <div class="mb-6 p-4 border border-red-300 bg-red-50 rounded"
              style="color: var(--color-headings)">

--- a/backend/templates/backoffice/base_page.html
+++ b/backend/templates/backoffice/base_page.html
@@ -22,6 +22,8 @@ ABOUTME: Sticky top nav + sticky page-header slot, flash messages, content slot,
            stay pinned while page content scrolls beneath them. The header uses the
            page background so the sticky page-header slot is opaque. #}
         <header class="sticky top-0 z-40" style="background-color: var(--color-bg-secondary);">
+            {# "My account" and "Switch to site admin" are old-design pages; their
+               target="new" opens both in one shared tab rather than stacking tabs. #}
             {{ navigation(
             logo_href=url_for('backoffice.dashboard'),
             help_href=knowledge_hub_url,
@@ -29,8 +31,8 @@ ABOUTME: Sticky top nav + sticky page-header slot, flash messages, content slot,
             account_initials=account_initials,
             account_label=current_user.display_name,
             account_items=[
-            {"label": _("My account"), "href": url_for('profile.view'), "icon": icon_user()},
-            {"label": _("Switch to site admin"), "href": url_for('admin.index'), "icon": icon_switch(), "target": "_blank", "rel": "noopener", "isVisible": _is_site_admin},
+            {"label": _("My account"), "href": url_for('profile.view'), "icon": icon_user(), "target": "new"},
+            {"label": _("Switch to site admin"), "href": url_for('admin.index'), "icon": icon_switch(), "target": "new", "isVisible": _is_site_admin},
             {"divider": true, "isVisible": _is_site_admin},
             {"label": _("User Data Agreement"), "href": help_site_data_agreement, "icon": icon_data_agreement(), "target": "_blank", "rel": "noopener"},
             {"divider": true},

--- a/backend/templates/backoffice/base_page.html
+++ b/backend/templates/backoffice/base_page.html
@@ -39,15 +39,15 @@ ABOUTME: Sticky top nav + sticky page-header slot, flash messages, content slot,
             ) }}
 
             {% block page_header %}{% endblock %}
-
-            {# Flash messages, anchored just below the sticky chrome so the header
-               never covers them and they stay in view while scrolling. #}
-            {{ floating_alerts() }}
         </header>
 
         <main class="max-w-screen-2xl mx-auto px-6 py-8 flex-1 w-full">
             {% block page_content %}{% endblock %}
         </main>
+
+        {# Flash messages: fixed top-centre overlay at z-[45], above the sticky
+           header (z-40) and below modal dialogs (z-50). #}
+        {{ floating_alerts() }}
 
         {{ footer() }}
     </div>

--- a/backend/templates/backoffice/base_page.html
+++ b/backend/templates/backoffice/base_page.html
@@ -45,8 +45,9 @@ ABOUTME: Sticky top nav + sticky page-header slot, flash messages, content slot,
             {% block page_content %}{% endblock %}
         </main>
 
-        {# Flash messages: fixed top-centre overlay at z-[45], above the sticky
-           header (z-40) and below modal dialogs (z-50). #}
+        {# Flash messages: fixed top-centre overlay. Its z-index (#floating-alerts,
+           45) is defined and documented in main.css — above the sticky header
+           (z-40), below modal dialogs (z-50). #}
         {{ floating_alerts() }}
 
         {{ footer() }}

--- a/backend/templates/backoffice/base_page.html
+++ b/backend/templates/backoffice/base_page.html
@@ -39,13 +39,15 @@ ABOUTME: Sticky top nav + sticky page-header slot, flash messages, content slot,
             ) }}
 
             {% block page_header %}{% endblock %}
+
+            {# Flash messages, anchored just below the sticky chrome so the header
+               never covers them and they stay in view while scrolling. #}
+            {{ floating_alerts() }}
         </header>
 
         <main class="max-w-screen-2xl mx-auto px-6 py-8 flex-1 w-full">
             {% block page_content %}{% endblock %}
         </main>
-
-        {{ floating_alerts() }}
 
         {{ footer() }}
     </div>

--- a/backend/templates/backoffice/base_page.html
+++ b/backend/templates/backoffice/base_page.html
@@ -1,33 +1,47 @@
 {#
 ABOUTME: Base page template for backoffice with standard layout elements
-ABOUTME: Provides navigation, flash messages, breadcrumbs slot, content slot, and footer
+ABOUTME: Sticky top nav + sticky page-header slot, flash messages, content slot, and footer
 #}
 {% extends "backoffice/base.html" %}
 {% from "backoffice/components/navigation.html" import navigation %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 {% from "backoffice/components/floating_alerts.html" import floating_alerts %}
 {% from "backoffice/components/footer.html" import footer with context %}
+{% from "backoffice/components/_nav_icons.html" import icon_user, icon_switch, icon_data_agreement, icon_logout %}
 
 {% block body %}
+    {# Avatar initials: first+last initial, falling back to the email's first letter.
+       Derived at render time only — never logged (see docs/personal-data.md). #}
+    {% set _first = current_user.first_name[0] if current_user.first_name else '' %}
+    {% set _last = current_user.last_name[0] if current_user.last_name else '' %}
+    {% set account_initials = (_first ~ _last) | upper %}
+    {% if not account_initials %}{% set account_initials = current_user.email[0] | upper %}{% endif %}
+    {% set _is_site_admin = current_user.global_role.value in ['admin', 'global-organiser'] %}
+
     <div class="min-h-screen flex flex-col">
-        {{ navigation(
-        logo_href=url_for('backoffice.dashboard'),
-        nav_items=[
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": _("Site Admin"), "href": url_for('admin.index'), "isVisible": current_user.global_role.value in ['admin', 'global-organiser']},
-        {"label": _("Sortition Lab"), "href": "https://www.sortitionfoundation.org/lab", "target": "_blank"},
-        {"label": _("Help"), "href": help_site_home, "target": "_blank"}
-        ],
-        account_items=[
-        {"label": _("My Account"), "href": url_for('profile.view')}
-        ],
-        cta_text=_("Sign out"),
-        cta_href=url_for('auth.logout')
-        ) }}
+        {# Sticky chrome: the top bar and (where present) the page header + tabs
+           stay pinned while page content scrolls beneath them. The header uses the
+           page background so the sticky page-header slot is opaque. #}
+        <header class="sticky top-0 z-40" style="background-color: var(--color-bg-secondary);">
+            {{ navigation(
+            logo_href=url_for('backoffice.dashboard'),
+            help_href=knowledge_hub_url,
+            help_label=_("Help (knowledge hub)"),
+            account_initials=account_initials,
+            account_label=current_user.display_name,
+            account_items=[
+            {"label": _("My account"), "href": url_for('profile.view'), "icon": icon_user()},
+            {"label": _("Switch to site admin"), "href": url_for('admin.index'), "icon": icon_switch(), "target": "_blank", "rel": "noopener", "isVisible": _is_site_admin},
+            {"divider": true, "isVisible": _is_site_admin},
+            {"label": _("User Data Agreement"), "href": help_site_data_agreement, "icon": icon_data_agreement(), "target": "_blank", "rel": "noopener"},
+            {"divider": true},
+            {"label": _("Sign out"), "href": url_for('auth.logout'), "icon": icon_logout()}
+            ]
+            ) }}
+
+            {% block page_header %}{% endblock %}
+        </header>
 
         <main class="max-w-screen-2xl mx-auto px-6 py-8 flex-1 w-full">
-            {% block breadcrumb_section %}{% endblock %}
-
             {% block page_content %}{% endblock %}
         </main>
 

--- a/backend/templates/backoffice/components/_nav_icons.html
+++ b/backend/templates/backoffice/components/_nav_icons.html
@@ -1,0 +1,65 @@
+{#
+ABOUTME: Shared inline SVG icon macros for the top navigation and account menu
+ABOUTME: Stroke-based 24-viewBox icons; size via the `classes` argument on each
+#}
+
+{% macro icon_question_circle(classes="w-6 h-6") %}
+    <svg class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="10"/>
+        <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+        <path d="M12 17h.01"/>
+    </svg>
+{% endmacro %}
+
+{% macro icon_user(classes="w-4 h-4") %}
+    <svg class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+        <circle cx="12" cy="7" r="4"/>
+    </svg>
+{% endmacro %}
+
+{% macro icon_switch(classes="w-4 h-4") %}
+    <svg class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M7 3v18"/>
+        <path d="m3 8 4-5 4 5"/>
+        <path d="M17 21V3"/>
+        <path d="m13 16 4 5 4-5"/>
+    </svg>
+{% endmacro %}
+
+{% macro icon_data_agreement(classes="w-4 h-4") %}
+    <svg class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+        <path d="M14 2v6h6"/>
+        <path d="M16 13H8"/>
+        <path d="M16 17H8"/>
+        <path d="M10 9H8"/>
+    </svg>
+{% endmacro %}
+
+{% macro icon_about(classes="w-4 h-4") %}
+    <svg class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z"/>
+    </svg>
+{% endmacro %}
+
+{% macro icon_logout(classes="w-4 h-4") %}
+    <svg class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+        <polyline points="16 17 21 12 16 7"/>
+        <line x1="21" x2="9" y1="12" y2="12"/>
+    </svg>
+{% endmacro %}
+
+{% macro icon_chevron_down(classes="w-4 h-4") %}
+    <svg class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <polyline points="6 9 12 15 18 9"/>
+    </svg>
+{% endmacro %}
+
+{% macro icon_arrow_back(classes="w-6 h-6") %}
+    <svg class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <line x1="19" x2="5" y1="12" y2="12"/>
+        <polyline points="12 19 5 12 12 5"/>
+    </svg>
+{% endmacro %}

--- a/backend/templates/backoffice/components/account_menu.html
+++ b/backend/templates/backoffice/components/account_menu.html
@@ -1,0 +1,79 @@
+{#
+ABOUTME: Account menu component - avatar trigger opening a dropdown of account links
+ABOUTME: Reuses the .menu / .menu-item atoms and the Alpine open/close pattern
+#}
+{% from "backoffice/components/avatar.html" import avatar %}
+
+{% macro account_menu(items=None, initials="", label="", id="account-menu") %}
+    {#
+    Account dropdown for the top navigation bar. The trigger is a user avatar plus
+    a chevron; clicking it reveals a right-anchored menu of account links.
+
+    Args:
+        items: List of dicts. Each item is either:
+            { "divider": true }  -> a horizontal separator, or
+            { "label": str, "href": str, "icon": html (16x16 svg),
+              "isVisible": bool (optional, default true),
+              ...any extra keys (e.g. "target", "rel") passed through to the <a> }
+        initials: Short initials shown in the avatar (e.g. "AS").
+        label: Accessible name for the trigger (e.g. the user's display name).
+        id: Id prefix for the toggle/menu (default "account-menu").
+
+    Accessibility:
+        - Trigger uses aria-haspopup="menu" and aria-expanded bound to open state.
+        - Menu uses role="menu" with role="menuitem" links; dividers use role="separator".
+        - Keyboard: Escape closes the menu; click outside closes it.
+    #}
+    {% set items = items or [] %}
+    {% set menu_id = id ~ "-menu" %}
+    {% set toggle_id = id ~ "-toggle" %}
+
+    <div class="relative inline-flex" x-data="{ open: false }" @keydown.escape.window="open = false">
+        <button type="button"
+                id="{{ toggle_id }}"
+                class="inline-flex items-center gap-1 rounded-full p-0.5 transition-opacity hover:opacity-80"
+                style="color: var(--color-body-text); background: transparent; border: none; cursor: pointer;"
+                @click="open = !open"
+                @click.outside="open = false"
+                aria-haspopup="menu"
+                x-bind:aria-expanded="open ? 'true' : 'false'"
+                aria-controls="{{ menu_id }}"
+                aria-label="{{ label if label else _('Account menu') }}">
+            {{ avatar(initials=initials) }}
+            <span class="inline-flex items-center justify-center w-4 h-4 shrink-0" aria-hidden="true">
+                <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="6 9 12 15 18 9"/>
+                </svg>
+            </span>
+        </button>
+
+        <div x-show="open"
+             x-cloak
+             id="{{ menu_id }}"
+             role="menu"
+             aria-labelledby="{{ toggle_id }}"
+             class="menu menu--right"
+             style="min-width: 14rem; z-index: 50;">
+            {% for item in items %}
+                {% if item.isVisible is not defined or item.isVisible %}
+                    {% if item.divider %}
+                        <div role="separator" class="my-1" style="border-top: 1px solid var(--color-borders-dividers);"></div>
+                    {% else %}
+                        <a href="{{ item.href }}"
+                           role="menuitem"
+                           class="menu-item"
+                           @click="open = false"
+                           {% for key, value in item.items() if key not in ['label', 'href', 'icon', 'isVisible', 'divider'] %} {{ key }}="{{ value }}"{% endfor %}>
+                            <span class="flex items-center gap-2">
+                                {% if item.icon %}
+                                    <span class="inline-flex items-center justify-center w-4 h-4 shrink-0" aria-hidden="true" style="color: var(--color-secondary-text);">{{ item.icon | safe }}</span>
+                                {% endif %}
+                                <span style="white-space: nowrap;">{{ item.label }}</span>
+                            </span>
+                        </a>
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+{% endmacro %}

--- a/backend/templates/backoffice/components/account_menu.html
+++ b/backend/templates/backoffice/components/account_menu.html
@@ -20,9 +20,12 @@ ABOUTME: Reuses the .menu / .menu-item atoms and the Alpine open/close pattern
         id: Id prefix for the toggle/menu (default "account-menu").
 
     Accessibility:
-        - Trigger uses aria-haspopup="menu" and aria-expanded bound to open state.
-        - Menu uses role="menu" with role="menuitem" links; dividers use role="separator".
-        - Keyboard: Escape closes the menu; click outside closes it.
+        - Disclosure pattern: the trigger button exposes aria-expanded (bound to
+          the open state) and aria-controls pointing at the revealed panel. The
+          items are ordinary navigation links, so no menu/menuitem roles are used
+          — that pattern would promise arrow-key navigation this component does
+          not implement.
+        - Keyboard: Tab moves through the links; Escape closes; click outside closes.
     #}
     {% set items = items or [] %}
     {% set menu_id = id ~ "-menu" %}
@@ -35,7 +38,6 @@ ABOUTME: Reuses the .menu / .menu-item atoms and the Alpine open/close pattern
                 style="color: var(--color-body-text); background: transparent; border: none; cursor: pointer;"
                 @click="open = !open"
                 @click.outside="open = false"
-                aria-haspopup="menu"
                 x-bind:aria-expanded="open ? 'true' : 'false'"
                 aria-controls="{{ menu_id }}"
                 aria-label="{{ label if label else _('Account menu') }}">
@@ -50,17 +52,14 @@ ABOUTME: Reuses the .menu / .menu-item atoms and the Alpine open/close pattern
         <div x-show="open"
              x-cloak
              id="{{ menu_id }}"
-             role="menu"
-             aria-labelledby="{{ toggle_id }}"
              class="menu menu--right"
              style="min-width: 14rem; z-index: 50;">
             {% for item in items %}
                 {% if item.isVisible is not defined or item.isVisible %}
                     {% if item.divider %}
-                        <div role="separator" class="my-1" style="border-top: 1px solid var(--color-borders-dividers);"></div>
+                        <div aria-hidden="true" class="my-1" style="border-top: 1px solid var(--color-borders-dividers);"></div>
                     {% else %}
                         <a href="{{ item.href }}"
-                           role="menuitem"
                            class="menu-item"
                            @click="open = false"
                            {% for key, value in item.items() if key not in ['label', 'href', 'icon', 'isVisible', 'divider'] %} {{ key }}="{{ value }}"{% endfor %}>

--- a/backend/templates/backoffice/components/alert.html
+++ b/backend/templates/backoffice/components/alert.html
@@ -3,7 +3,7 @@ ABOUTME: Alert/flash message component macro for backoffice design system
 ABOUTME: Supports success, warning, error, info variants with semantic styling
 #}
 
-{% macro alert(message="", variant="info", dismissible=false, id="", use_caller=false, floating=false) %}
+{% macro alert(message="", variant="info", dismissible=false, id="", use_caller=false, floating=false, auto_dismiss_ms=0) %}
     {#
     Alert component for displaying messages/notifications.
 
@@ -14,6 +14,8 @@ ABOUTME: Supports success, warning, error, info variants with semantic styling
         id: Optional id attribute
         use_caller: Boolean to use caller block for HTML content (default: false)
         floating: Boolean to remove bottom margin (for floating alerts container)
+        auto_dismiss_ms: When > 0 (and dismissible), the alert hides itself after
+            this many milliseconds, pausing while hovered. 0 = stays until closed.
 
     Usage:
         alert("Changes saved successfully", variant="success")
@@ -59,7 +61,7 @@ ABOUTME: Supports success, warning, error, info variants with semantic styling
 
     <div
         {% if id %}id="{{ id }}"{% endif %}
-        {% if dismissible %}x-data="{ show: true }" x-show="show" x-transition{% endif %}
+        {% if dismissible %}{% if auto_dismiss_ms and auto_dismiss_ms > 0 %}x-data="autoDismissAlert({ duration: {{ auto_dismiss_ms }} })" @mouseenter="pause()" @mouseleave="resume()"{% else %}x-data="{ show: true }"{% endif %} x-show="show" x-transition{% endif %}
         class="{{ 'mb-6 ' if not floating else '' }}rounded-lg p-4 flex items-center gap-3"
         style="background-color: {{ styles.bg }}; border: 1px solid {{ styles.border }};"
         role="alert"

--- a/backend/templates/backoffice/components/avatar.html
+++ b/backend/templates/backoffice/components/avatar.html
@@ -1,0 +1,29 @@
+{#
+ABOUTME: Avatar component macro - circular badge showing a user's initials
+ABOUTME: Used as the account menu trigger in the top navigation bar
+#}
+{% macro avatar(initials="", size="md", label="") %}
+    {#
+    Circular initials badge. Purely presentational unless a label is supplied.
+
+    Args:
+        initials: Short text to display (1-2 characters, e.g. "AS").
+        size: "sm" (24px) | "md" (32px) | "lg" (40px). Default "md".
+        label: Accessible name. When set, the badge is exposed as role="img"
+            with this aria-label; when empty it is aria-hidden (the surrounding
+            control is expected to provide the accessible name).
+
+    Usage:
+        {{ avatar(initials="AS", label="Ada Smith") }}
+        {{ avatar(initials="AS", size="sm") }}
+    #}
+    {% set _sizes = {
+    "sm": {"dim": "1.5rem", "font": "0.6875rem"},
+    "md": {"dim": "2rem", "font": "0.8125rem"},
+    "lg": {"dim": "2.5rem", "font": "1rem"}
+    } %}
+    {% set _s = _sizes.get(size, _sizes["md"]) %}
+    <span class="inline-flex items-center justify-center rounded-full shrink-0 font-medium leading-none select-none"
+          style="width: {{ _s.dim }}; height: {{ _s.dim }}; font-size: {{ _s.font }}; background-color: var(--color-navigation-bars); color: var(--color-neutral-50); letter-spacing: 0.2px;"
+          {% if label %}role="img" aria-label="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ initials }}</span>
+{% endmacro %}

--- a/backend/templates/backoffice/components/floating_alerts.html
+++ b/backend/templates/backoffice/components/floating_alerts.html
@@ -9,32 +9,28 @@ ABOUTME: Provides accessible notifications that don't require scrolling to top
     Renders Flask flash messages in a fixed-position container at the top-center.
 
     Features:
-    - Absolutely positioned just below the sticky header, horizontally centred
-    - z-40: above the sticky header (its positioned ancestor), below modals (z-50)
+    - Fixed top-centre overlay, a little below the top of the viewport
+    - z-[45]: above the sticky header (z-40), below modal dialogs (z-50)
+    - Auto-dismiss by severity: success 4s, info 6s, warning 10s; errors stay
+      until closed. The countdown pauses while the pointer is over an alert.
     - aria-live="polite": Screen readers announce new alerts
     - All alerts are dismissible
 
     Usage:
         {{ floating_alerts() }}
 
-    Render this inside the sticky <header> (a positioned ancestor) so it anchors
-    just below the chrome and is never covered by it.
+    Render this at the page root (e.g. after </main> in base_page.html).
     #}
     {% set messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
+        {# Auto-dismiss durations (ms) by variant; 0 = stays until closed. #}
+        {% set _auto_dismiss_ms = {"success": 4000, "info": 6000, "warning": 10000, "error": 0} %}
         <div id="floating-alerts"
-             class="absolute top-full left-1/2 -translate-x-1/2 mt-3 z-40 flex flex-col gap-3 w-full max-w-md px-4"
+             class="fixed top-6 left-1/2 -translate-x-1/2 z-[45] flex flex-col gap-3 w-full max-w-md px-4"
              aria-live="polite">
             {% for category, message in messages %}
-                {% if category == "success" %}
-                    {{ alert(message, variant="success", dismissible=true, floating=true) }}
-                {% elif category == "error" %}
-                    {{ alert(message, variant="error", dismissible=true, floating=true) }}
-                {% elif category == "warning" %}
-                    {{ alert(message, variant="warning", dismissible=true, floating=true) }}
-                {% else %}
-                    {{ alert(message, variant="info", dismissible=true, floating=true) }}
-                {% endif %}
+                {% set _variant = category if category in ["success", "error", "warning", "info"] else "info" %}
+                {{ alert(message, variant=_variant, dismissible=true, floating=true, auto_dismiss_ms=_auto_dismiss_ms.get(_variant, 0)) }}
             {% endfor %}
         </div>
     {% endif %}

--- a/backend/templates/backoffice/components/floating_alerts.html
+++ b/backend/templates/backoffice/components/floating_alerts.html
@@ -10,7 +10,8 @@ ABOUTME: Provides accessible notifications that don't require scrolling to top
 
     Features:
     - Fixed top-centre overlay, a little below the top of the viewport
-    - z-[45]: above the sticky header (z-40), below modal dialogs (z-50)
+    - Layering: the #floating-alerts z-index (45) is set in main.css, documented
+      next to the modal z-indexes — above the sticky header (z-40), below dialogs (z-50)
     - Auto-dismiss by severity: success 4s, info 6s, warning 10s; errors stay
       until closed. The countdown pauses while the pointer is over an alert.
     - aria-live="polite": Screen readers announce new alerts
@@ -26,7 +27,7 @@ ABOUTME: Provides accessible notifications that don't require scrolling to top
         {# Auto-dismiss durations (ms) by variant; 0 = stays until closed. #}
         {% set _auto_dismiss_ms = {"success": 4000, "info": 6000, "warning": 10000, "error": 0} %}
         <div id="floating-alerts"
-             class="fixed top-6 left-1/2 -translate-x-1/2 z-[45] flex flex-col gap-3 w-full max-w-md px-4"
+             class="fixed top-6 left-1/2 -translate-x-1/2 flex flex-col gap-3 w-full max-w-md px-4"
              aria-live="polite">
             {% for category, message in messages %}
                 {% set _variant = category if category in ["success", "error", "warning", "info"] else "info" %}

--- a/backend/templates/backoffice/components/floating_alerts.html
+++ b/backend/templates/backoffice/components/floating_alerts.html
@@ -9,20 +9,21 @@ ABOUTME: Provides accessible notifications that don't require scrolling to top
     Renders Flask flash messages in a fixed-position container at the top-center.
 
     Features:
-    - Fixed position at the top-center of the viewport
-    - z-30: Below modals (z-40/z-50) but above page content
+    - Absolutely positioned just below the sticky header, horizontally centred
+    - z-40: above the sticky header (its positioned ancestor), below modals (z-50)
     - aria-live="polite": Screen readers announce new alerts
     - All alerts are dismissible
 
     Usage:
         {{ floating_alerts() }}
 
-    Place this after </main> but inside the page container.
+    Render this inside the sticky <header> (a positioned ancestor) so it anchors
+    just below the chrome and is never covered by it.
     #}
     {% set messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
         <div id="floating-alerts"
-             class="fixed top-6 left-1/2 -translate-x-1/2 z-30 flex flex-col gap-3 w-full max-w-md px-4"
+             class="absolute top-full left-1/2 -translate-x-1/2 mt-3 z-40 flex flex-col gap-3 w-full max-w-md px-4"
              aria-live="polite">
             {% for category, message in messages %}
                 {% if category == "success" %}

--- a/backend/templates/backoffice/components/footer.html
+++ b/backend/templates/backoffice/components/footer.html
@@ -12,9 +12,6 @@ ABOUTME: Site-wide footer with support links and version info
                 <a href="https://www.sortitionfoundation.org" target="_blank" class="text-body-sm transition duration-150 ease-in-out hover:opacity-80" style="color: var(--color-secondary-text);">
                     Sortition Foundation
                 </a>
-                <a href="{{ help_site_data_agreement }}" target="_blank" class="text-body-sm transition duration-150 ease-in-out hover:opacity-80" style="color: var(--color-secondary-text);">
-                    {{ _("User Data Agreement") }}
-                </a>
                 <a href="{{ help_site_cookies }}" target="_blank" class="text-body-sm transition duration-150 ease-in-out hover:opacity-80" style="color: var(--color-secondary-text);">
                     {{ _("Cookies") }}
                 </a>

--- a/backend/templates/backoffice/components/navigation.html
+++ b/backend/templates/backoffice/components/navigation.html
@@ -22,29 +22,41 @@ ABOUTME: Horizontal navigation bar with logo, nav links, and account actions
     </svg>
 {% endmacro %}
 
-{% macro navigation(logo_href="#", nav_items=[], account_items=[], cta_text="", cta_href="#") %}
-    <section class="w-full px-8" style="background-color: var(--color-tables-cards);">
-        <div class="container flex flex-col flex-wrap items-center justify-between py-5 mx-auto md:flex-row max-w-screen-2xl">
-            <div class="relative flex flex-col md:flex-row">
-                <a href="{{ logo_href }}" class="flex items-center mb-5 lg:w-auto lg:items-center lg:justify-center md:mb-0">
-                    {{ sortition_logo() }}
-                </a>
-                {% if nav_items %}
-                    <nav class="flex flex-wrap items-center mb-5 text-base md:mb-0 md:pl-8 md:ml-8 md:border-l" style="border-color: var(--color-borders-dividers);">
-                        {% for item in nav_items %}
-                            {% if item.isVisible is not defined or item.isVisible %}
-                                <a href="{{ item.href }}"{% for key, value in item.items() if key not in ['label', 'href', 'isVisible'] %} {{ key }}="{{ value }}"{% endfor %} class="mr-5 text-body-md transition duration-150 ease-in-out hover:opacity-80" style="color: var(--color-body-text);">{{ item.label }}</a>
-                            {% endif %}
-                        {% endfor %}
-                    </nav>
+{% from "backoffice/components/_nav_icons.html" import icon_question_circle %}
+{% from "backoffice/components/account_menu.html" import account_menu %}
+
+{% macro navigation(logo_href="#", help_href="", help_label="", account_items=None, account_initials="", account_label="") %}
+    {#
+    Top navigation bar: logo on the left; a help icon and an account dropdown on
+    the right. The old centre nav links and the standalone "Sign out" CTA have
+    been retired — account actions now live inside the account menu.
+
+    Args:
+        logo_href: Where the logo links to (typically the dashboard).
+        help_href: URL for the help icon (opens in a new tab). Hidden if empty.
+        help_label: Accessible label for the help icon (default "Help").
+        account_items: List of account-menu item dicts (see account_menu macro).
+        account_initials: Initials shown in the account avatar (e.g. "AS").
+        account_label: Accessible name for the account trigger (display name).
+    #}
+    <section class="w-full px-8" style="background-color: var(--color-tables-cards); border-bottom: 1px solid var(--color-borders-dividers);">
+        <div class="flex items-center justify-between gap-4 py-3 mx-auto max-w-screen-2xl">
+            <a href="{{ logo_href }}" class="flex items-center shrink-0 transition-opacity hover:opacity-80">
+                {{ sortition_logo() }}
+            </a>
+            <div class="inline-flex items-center gap-4">
+                {% if help_href %}
+                    <a href="{{ help_href }}"
+                       target="_blank"
+                       rel="noopener"
+                       class="inline-flex items-center justify-center w-9 h-9 rounded-md transition-opacity hover:opacity-80"
+                       style="color: var(--color-body-text);"
+                       aria-label="{{ help_label if help_label else _('Help') }}">
+                        {{ icon_question_circle(classes="w-6 h-6") }}
+                    </a>
                 {% endif %}
-            </div>
-            <div class="inline-flex items-center ml-5 space-x-6 lg:justify-end">
-                {% for item in account_items %}
-                    <a href="{{ item.href }}" class="text-body-md transition duration-150 ease-in-out hover:opacity-80" style="color: var(--color-body-text);">{{ item.label }}</a>
-                {% endfor %}
-                {% if cta_text %}
-                    <a href="{{ cta_href }}" class="inline-flex items-center justify-center px-4 py-2 text-button-lg rounded-md shadow-sm transition duration-150 ease-in-out hover:opacity-90" style="background-color: var(--color-primary-action); color: var(--color-page-background);">{{ cta_text }}</a>
+                {% if account_items %}
+                    {{ account_menu(items=account_items, initials=account_initials, label=account_label) }}
                 {% endif %}
             </div>
         </div>

--- a/backend/templates/backoffice/components/page_header.html
+++ b/backend/templates/backoffice/components/page_header.html
@@ -1,0 +1,35 @@
+{#
+ABOUTME: Page header component - back arrow + page title, replacing the breadcrumb
+ABOUTME: Used at the top of detail pages (e.g. assembly pages) above the tab bar
+#}
+{% from "backoffice/components/_nav_icons.html" import icon_arrow_back %}
+
+{% macro page_header(title="", back_href="", back_label="", actions="") %}
+    {#
+    Compact page header: an optional back arrow, the page title, and an optional
+    trailing actions slot. Deliberately has no status chip (out of scope for 680).
+
+    Args:
+        title: The page title (rendered as the page <h1>).
+        back_href: If set, renders a back arrow link to this URL.
+        back_label: Accessible label for the back arrow (default "Back").
+        actions: Optional raw HTML rendered right-aligned (e.g. an action button).
+
+    Accessibility:
+        - The back arrow is a real link with an aria-label (icon-only control).
+    #}
+    <div class="flex items-center gap-4">
+        {% if back_href %}
+            <a href="{{ back_href }}"
+               class="inline-flex items-center justify-center shrink-0 rounded-md p-1 transition-opacity hover:opacity-80"
+               style="color: var(--color-primary-action);"
+               aria-label="{{ back_label if back_label else _('Back') }}">
+                {{ icon_arrow_back(classes="w-6 h-6") }}
+            </a>
+        {% endif %}
+        <h1 class="text-display-sm" style="color: var(--color-headings);">{{ title }}</h1>
+        {% if actions %}
+            <div class="ml-auto flex items-center gap-2">{{ actions | safe }}</div>
+        {% endif %}
+    </div>
+{% endmacro %}

--- a/backend/templates/backoffice/create_assembly.html
+++ b/backend/templates/backoffice/create_assembly.html
@@ -3,19 +3,9 @@ ABOUTME: Backoffice create assembly page
 ABOUTME: Uses assembly_form macro for creating new assemblies
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 {% from "backoffice/assembly_form.html" import assembly_form %}
 
 {% block title %}{{ _("Create Assembly") }}{% endblock %}
-
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": _("Create Assembly")}
-        ]) }}
-    </div>
-{% endblock %}
 
 {% block page_content %}
     {# Page Heading #}

--- a/backend/templates/backoffice/dev_dashboard.html
+++ b/backend/templates/backoffice/dev_dashboard.html
@@ -4,18 +4,8 @@ ABOUTME: Links to service docs, frontend patterns, and component showcase
 #}
 {% extends "backoffice/base_page.html" %}
 {% from "backoffice/components/card.html" import link_card %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 
 {% block title %}{{ _("Developer Tools") }}{% endblock %}
-
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": _("Developer Tools")}
-        ]) }}
-    </div>
-{% endblock %}
 
 {% block page_content %}
     <h1 style="color: var(--color-headings);" class="text-display-lg mb-2">

--- a/backend/templates/backoffice/edit_assembly.html
+++ b/backend/templates/backoffice/edit_assembly.html
@@ -3,7 +3,6 @@ ABOUTME: Backoffice edit assembly page
 ABOUTME: Uses assembly_form macro for editing assembly details
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 {% from "backoffice/components/alert.html" import alert %}
 {% from "backoffice/assembly_form.html" import assembly_form %}
 
@@ -53,16 +52,6 @@ Args:
 {% endmacro %}
 
 {% block title %}{{ _("Edit Assembly") }} - {{ assembly.title }}{% endblock %}
-
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Edit")}
-        ]) }}
-    </div>
-{% endblock %}
 
 {% block page_content %}
     {# Page Heading #}

--- a/backend/templates/backoffice/patterns.html
+++ b/backend/templates/backoffice/patterns.html
@@ -4,21 +4,10 @@ ABOUTME: Documents Alpine.js patterns, form handling, and AJAX with live example
 #}
 {% extends "backoffice/base_page.html" %}
 
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 {% from "backoffice/components/card.html" import card, card_body %}
 {% from "backoffice/components/tabs.html" import tabs %}
 
 {% block title %}{{ _("Frontend Patterns") }}{% endblock %}
-
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": _("Developer Tools"), "href": url_for('dev.dev_dashboard')},
-        {"label": _("Patterns")}
-        ]) }}
-    </div>
-{% endblock %}
 
 {% block page_content %}
     <div x-data="patternsController()" x-cloak>

--- a/backend/templates/backoffice/patterns/_floating_alerts.html
+++ b/backend/templates/backoffice/patterns/_floating_alerts.html
@@ -91,7 +91,7 @@ ABOUTME: Partial template included by patterns.html
             <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
                 <h4 class="text-heading-sm mb-2" style="color: var(--color-warning-600);">⚠️ {{ _("Key Points") }}</h4>
                 <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
-                    <li><strong>z-[45]</strong> — {{ _("Above the sticky header (z-40), below modal dialogs (z-50)") }}</li>
+                    <li><strong>{{ _("Layering") }}</strong> — {{ _("z-index 45 (set in main.css, documented next to the modal z-indexes) — above the sticky header (z-40), below modal dialogs (z-50)") }}</li>
                     <li><strong>{{ _("Auto-dismiss") }}</strong> — {{ _("success 4s, info 6s, warning 10s; errors stay until closed. Hover pauses the countdown.") }}</li>
                     <li><strong>aria-live=\"polite\"</strong> — {{ _("Screen readers announce new alerts without interrupting") }}</li>
                     <li><strong>{{ _("Dismissible") }}</strong> — {{ _("All floating alerts have a close button") }}</li>

--- a/backend/templates/backoffice/patterns/_floating_alerts.html
+++ b/backend/templates/backoffice/patterns/_floating_alerts.html
@@ -8,7 +8,7 @@ ABOUTME: Partial template included by patterns.html
         {% call card_body() %}
                         {# Description #}
             <p class="text-body-md mb-4" style="color: var(--color-body-text);">
-                {{ _("Flash messages in the backoffice appear as floating alerts at the bottom-right of the viewport. This ensures users see feedback without scrolling to the top of the page.") }}
+                {{ _("Flash messages in the backoffice appear as floating alerts at the top-centre of the viewport, just below the top. This ensures users see feedback without scrolling. They sit above the sticky header and below modal dialogs.") }}
             </p>
 
                         {# Philosophy #}
@@ -16,7 +16,8 @@ ABOUTME: Partial template included by patterns.html
                 <h4 class="text-heading-sm mb-2" style="color: var(--color-info-600);">{{ _("Design Philosophy") }}</h4>
                 <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
                     <li><strong>{{ _("Visible anywhere") }}:</strong> {{ _("Users don't need to scroll to see feedback messages") }}</li>
-                    <li><strong>{{ _("Non-blocking") }}:</strong> {{ _("Positioned at bottom-right to avoid covering content") }}</li>
+                    <li><strong>{{ _("Non-blocking") }}:</strong> {{ _("A top-centre overlay that clears the sticky header and never covers modal dialogs") }}</li>
+                    <li><strong>{{ _("Self-clearing") }}:</strong> {{ _("Low-severity alerts auto-dismiss so they don't pile up; errors stay until acknowledged") }}</li>
                     <li><strong>{{ _("Dismissible") }}:</strong> {{ _("All floating alerts can be closed by the user") }}</li>
                     <li><strong>{{ _("Accessible") }}:</strong> {{ _("Uses aria-live='polite' for screen reader announcements") }}</li>
                 </ul>
@@ -39,7 +40,7 @@ ABOUTME: Partial template included by patterns.html
         {% call card_body() %}
                         {# Description #}
             <p class="text-body-md mb-4" style="color: var(--color-body-text);">
-                {{ _("Click the buttons below to trigger flash messages. The alerts will appear at the bottom-right of the viewport.") }}
+                {{ _("Click the buttons below to trigger flash messages. The alerts appear at the top-centre and, except for errors, dismiss themselves after a few seconds (hover to pause the countdown).") }}
             </p>
 
                         {# Test Buttons #}
@@ -90,11 +91,60 @@ ABOUTME: Partial template included by patterns.html
             <div class="mb-6 p-4 rounded-lg" style="background-color: var(--color-warning-100); border: 1px solid var(--color-warning-400);">
                 <h4 class="text-heading-sm mb-2" style="color: var(--color-warning-600);">⚠️ {{ _("Key Points") }}</h4>
                 <ul class="list-disc list-inside text-body-sm space-y-1" style="color: var(--color-body-text);">
-                    <li><strong>z-30</strong> — {{ _("Below modals (z-40/z-50) but above page content") }}</li>
+                    <li><strong>z-[45]</strong> — {{ _("Above the sticky header (z-40), below modal dialogs (z-50)") }}</li>
+                    <li><strong>{{ _("Auto-dismiss") }}</strong> — {{ _("success 4s, info 6s, warning 10s; errors stay until closed. Hover pauses the countdown.") }}</li>
                     <li><strong>aria-live=\"polite\"</strong> — {{ _("Screen readers announce new alerts without interrupting") }}</li>
                     <li><strong>{{ _("Dismissible") }}</strong> — {{ _("All floating alerts have a close button") }}</li>
                     <li><strong>{{ _("No bottom margin") }}</strong> — {{ _("Uses floating=true parameter; gap handled by container") }}</li>
                 </ul>
+            </div>
+        {% endcall %}
+    {% endcall %}
+
+                {# Auto-dismiss behaviour #}
+    {% call card(title="Auto-dismiss by severity", composed=true) %}
+        {% call card_body() %}
+            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                {{ _("Floating alerts clear themselves based on severity, so transient confirmations don't linger while important errors stay put. Hovering an alert pauses its countdown.") }}
+            </p>
+            <div class="overflow-x-auto">
+                <table class="w-full text-body-sm" style="color: var(--color-body-text);">
+                    <thead>
+                        <tr style="border-bottom: 1px solid var(--color-borders-dividers);">
+                            <th class="text-left py-2 pr-4">{{ _("Variant") }}</th>
+                            <th class="text-left py-2 pr-4">{{ _("Auto-dismiss") }}</th>
+                            <th class="text-left py-2">{{ _("Rationale") }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr style="border-bottom: 1px solid var(--color-borders-dividers);">
+                            <td class="py-2 pr-4"><strong style="color: var(--color-success-600);">✓ {{ _("Success") }}</strong></td>
+                            <td class="py-2 pr-4">4s</td>
+                            <td class="py-2">{{ _("A confirmation the user rarely needs to re-read") }}</td>
+                        </tr>
+                        <tr style="border-bottom: 1px solid var(--color-borders-dividers);">
+                            <td class="py-2 pr-4"><strong style="color: var(--color-info-600);">ℹ {{ _("Info") }}</strong></td>
+                            <td class="py-2 pr-4">6s</td>
+                            <td class="py-2">{{ _("Contextual, slightly longer to read") }}</td>
+                        </tr>
+                        <tr style="border-bottom: 1px solid var(--color-borders-dividers);">
+                            <td class="py-2 pr-4"><strong style="color: var(--color-warning-600);">⚠ {{ _("Warning") }}</strong></td>
+                            <td class="py-2 pr-4">10s</td>
+                            <td class="py-2">{{ _("Deserves attention but is not blocking") }}</td>
+                        </tr>
+                        <tr>
+                            <td class="py-2 pr-4"><strong style="color: var(--color-error-600);">✕ {{ _("Error") }}</strong></td>
+                            <td class="py-2 pr-4">{{ _("Never — until closed") }}</td>
+                            <td class="py-2">{{ _("Must be acknowledged by the user") }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="mt-4 p-4 rounded-lg" style="background-color: var(--color-subtle-background-panels);">
+                <h4 class="text-heading-sm mb-2" style="color: var(--color-headings);">{{ _("How it works") }}</h4>
+                <p class="text-body-sm" style="color: var(--color-body-text);">
+                    {{ _("Durations live in floating_alerts.html. The alert() macro takes an auto_dismiss_ms parameter and, when set, uses the autoDismissAlert Alpine component — a CSP-safe setTimeout wrapper that pauses on hover.") }}
+                </p>
             </div>
         {% endcall %}
     {% endcall %}
@@ -141,7 +191,10 @@ def save_item():
 {{ alert("Message", variant="success") }}
 
 {# Floating alert (no bottom margin, used in floating_alerts.html) #}
-{{ alert("Message", variant="success", dismissible=true, floating=true) }}{% endraw %}</pre>
+{{ alert("Message", variant="success", dismissible=true, floating=true) }}
+
+{# Auto-dismiss after 4s (0 = stays until closed); pauses on hover #}
+{{ alert("Saved", variant="success", dismissible=true, floating=true, auto_dismiss_ms=4000) }}{% endraw %}</pre>
             </div>
         {% endcall %}
     {% endcall %}

--- a/backend/templates/backoffice/respondent_field_schema/view.html
+++ b/backend/templates/backoffice/respondent_field_schema/view.html
@@ -3,32 +3,30 @@ ABOUTME: Backoffice page for viewing and editing the respondent field schema
 ABOUTME: Grouped field list with per-field label edit, move up/down, and delete actions
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
+{% from "backoffice/components/page_header.html" import page_header %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
 {% block title %}{{ _("Fields") }} - {{ assembly.title }}{% endblock %}
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard") , "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Fields")}
-        ]) }}
+{% block page_header %}
+    <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
+        {{ page_header(
+        title=assembly.title,
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")
+        ) }}
+        <div class="mt-4">
+            {{ assembly_tabs(assembly=assembly,
+            active_tab="fields",
+            data_source=data_source|default("") ,
+            gsheet=gsheet|default(none),
+            targets_enabled=targets_enabled|default(false),
+            respondents_enabled=respondents_enabled|default(false),
+            selection_enabled=selection_enabled|default(false)
+            ) }}
+        </div>
     </div>
 {% endblock %}
 {% block page_content %}
-    <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ assembly.title }}</h1>
-    <p class="text-body-lg mb-6" style="color: var(--color-secondary-text);">
-        {{ _("Group, order, and label the fields that describe your respondents. These settings drive how respondent details are displayed and will seed the registration form when it is created.") }}
-    </p>
-    {{ assembly_tabs(assembly=assembly,
-    active_tab="fields",
-    data_source=data_source|default("") ,
-    gsheet=gsheet|default(none),
-    targets_enabled=targets_enabled|default(false),
-    respondents_enabled=respondents_enabled|default(false),
-    selection_enabled=selection_enabled|default(false)
-    ) }}
     {% if data_source == "gsheet" and gsheet %}
         {# Google Sheet source - fields come from the spreadsheet columns, not from this UI. #}
         <section class="mb-8">

--- a/backend/templates/backoffice/respondents/confirm_upload_diff.html
+++ b/backend/templates/backoffice/respondents/confirm_upload_diff.html
@@ -3,21 +3,9 @@ ABOUTME: Confirmation page for a CSV upload that would change the respondent fie
 ABOUTME: Lists added / absent columns and id-column changes; user confirms or cancels
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 {% from "backoffice/components/button.html" import button %}
 
 {% block title %}{{ _("Confirm upload") }} - {{ assembly.title }}{% endblock %}
-
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard"), "href": url_for('backoffice.dashboard')},
-        {"label": assembly.title, "href": url_for('backoffice.view_assembly', assembly_id=assembly.id)},
-        {"label": _("Data"), "href": url_for('backoffice.view_assembly_data', assembly_id=assembly.id, source='csv')},
-        {"label": _("Confirm upload")}
-        ]) }}
-    </div>
-{% endblock %}
 
 {% block page_content %}
     <h1 class="text-display-lg mb-2" style="color: var(--color-headings);">{{ _("Confirm CSV upload") }}</h1>

--- a/backend/templates/backoffice/service_docs.html
+++ b/backend/templates/backoffice/service_docs.html
@@ -3,21 +3,11 @@ ABOUTME: Interactive service layer documentation page for CSV upload services
 ABOUTME: Provides testing console with code references, sample data, and execution
 #}
 {% extends "backoffice/base_page.html" %}
-{% from "backoffice/components/breadcrumbs.html" import breadcrumbs %}
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/card.html" import card, card_body, card_footer %}
 {% from "backoffice/components/alert.html" import alert %}
 {% from "backoffice/components/tabs.html" import tabs %}
 {% block title %}{{ _("Service Layer Documentation") }}{% endblock %}
-{% block breadcrumb_section %}
-    <div class="mb-6">
-        {{ breadcrumbs([
-        {"label": _("Dashboard") , "href": url_for('backoffice.dashboard')},
-        {"label": _("Developer Tools"), "href": url_for('dev.dev_dashboard')},
-        {"label": _("Service Docs")}
-        ]) }}
-    </div>
-{% endblock %}
 {% block page_content %}
     {# Main Alpine.js controller for the entire page #}
     <div x-data="serviceDocsController()" x-cloak>

--- a/backend/templates/backoffice/showcase.html
+++ b/backend/templates/backoffice/showcase.html
@@ -14,6 +14,9 @@
 {% from "backoffice/showcase/card_component.html" import card_section %}
 {% from "backoffice/showcase/section_component.html" import section_section %}
 {% from "backoffice/showcase/navigation_component.html" import navigation_section %}
+{% from "backoffice/showcase/avatar_component.html" import avatar_section %}
+{% from "backoffice/showcase/account_menu_component.html" import account_menu_section %}
+{% from "backoffice/showcase/page_header_component.html" import page_header_section %}
 {% from "backoffice/showcase/breadcrumb_component.html" import breadcrumb_section %}
 {% from "backoffice/showcase/tabs_component.html" import tabs_section %}
 {% from "backoffice/showcase/stepper_component.html" import stepper_section %}
@@ -97,6 +100,9 @@
                 <option value="components:table">Table</option>
                 <option value="components:pagination">Pagination</option>
                 <option value="components:navigation">Navigation</option>
+                <option value="components:avatar">Avatar</option>
+                <option value="components:account-menu">Account Menu</option>
+                <option value="components:page-header">Page Header</option>
                 <option value="components:breadcrumb">Breadcrumb</option>
                 <option value="components:tabs">Tabs</option>
                 <option value="components:stepper">Stepper</option>
@@ -134,6 +140,9 @@
             <div id="table" data-tab="components" style="scroll-margin-top: 6rem;">{{ table_section() }}</div>
             <div id="pagination" data-tab="components" style="scroll-margin-top: 6rem;">{{ pagination_section() }}</div>
             <div id="navigation" data-tab="components" style="scroll-margin-top: 6rem;">{{ navigation_section() }}</div>
+            <div id="avatar" data-tab="components" style="scroll-margin-top: 6rem;">{{ avatar_section() }}</div>
+            <div id="account-menu" data-tab="components" style="scroll-margin-top: 6rem;">{{ account_menu_section() }}</div>
+            <div id="page-header" data-tab="components" style="scroll-margin-top: 6rem;">{{ page_header_section() }}</div>
             <div id="breadcrumb" data-tab="components" style="scroll-margin-top: 6rem;">{{ breadcrumb_section() }}</div>
             <div id="tabs" data-tab="components" style="scroll-margin-top: 6rem;">{{ tabs_section() }}</div>
             <div id="stepper" data-tab="components" style="scroll-margin-top: 6rem;">{{ stepper_section() }}</div>

--- a/backend/templates/backoffice/showcase/account_menu_component.html
+++ b/backend/templates/backoffice/showcase/account_menu_component.html
@@ -1,24 +1,22 @@
 {#
-ABOUTME: Showcase section for navigation component
-ABOUTME: Displays the top bar with logo, help icon, and account dropdown
+ABOUTME: Showcase section for the account menu component
+ABOUTME: Displays the avatar-triggered account dropdown with icon rows and dividers
 #}
 {% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_example, showcase_tokens %}
-{% from "backoffice/components/navigation.html" import navigation %}
+{% from "backoffice/components/account_menu.html" import account_menu %}
 {% from "backoffice/components/_nav_icons.html" import icon_user, icon_switch, icon_data_agreement, icon_logout %}
 
-{% macro navigation_section() %}
+{% macro account_menu_section() %}
     {% call showcase_section() %}
-        {{ showcase_title("Navigation Component") }}
-        {{ showcase_description("Top navigation bar: logo on the left; a help icon (links to the knowledge hub) and an account dropdown on the right. Account actions live inside the dropdown.") }}
+        {{ showcase_title("Account Menu") }}
+        {{ showcase_description("Avatar + chevron trigger opening a dropdown of account links. Items support leading icons, dividers, role gating (isVisible) and new-tab attributes. Escape or click-outside closes it.") }}
 
-        {% call showcase_example('{% from "backoffice/components/navigation.html" import navigation %}
+        {% call showcase_example('{% from "backoffice/components/account_menu.html" import account_menu %}
 
-            {{ navigation(
-            logo_href="/backoffice",
-            help_href="https://democraticlottery.org/knowledge-hub",
-            account_initials="AS",
-            account_label="Ada Smith",
-            account_items=[
+            {{ account_menu(
+            initials="AS",
+            label="Ada Smith",
+            items=[
             {"label": "My account", "href": "/account", "icon": icon_user()},
             {"label": "Switch to site admin", "href": "/admin", "icon": icon_switch(), "target": "_blank", "rel": "noopener"},
             {"divider": true},
@@ -27,13 +25,11 @@ ABOUTME: Displays the top bar with logo, help icon, and account dropdown
             {"label": "Sign out", "href": "/logout", "icon": icon_logout()}
             ]
             ) }}') %}
-            <div class="rounded-lg overflow-hidden shadow-md" style="border: 1px solid var(--color-borders-dividers);">
-                {{ navigation(
-                logo_href="#",
-                help_href="#",
-                account_initials="AS",
-                account_label="Ada Smith",
-                account_items=[
+            <div class="flex justify-end p-4" style="min-height: 18rem;">
+                {{ account_menu(
+                initials="AS",
+                label="Ada Smith",
+                items=[
                 {"label": "My account", "href": "#", "icon": icon_user()},
                 {"label": "Switch to site admin", "href": "#", "icon": icon_switch(), "target": "_blank", "rel": "noopener"},
                 {"divider": true},
@@ -49,7 +45,7 @@ ABOUTME: Displays the top bar with logo, help icon, and account dropdown
         "--color-tables-cards",
         "--color-borders-dividers",
         "--color-body-text",
-        "--color-navigation-bars",
+        "--color-secondary-text",
         ".menu",
         ".menu-item"
         ]) }}

--- a/backend/templates/backoffice/showcase/avatar_component.html
+++ b/backend/templates/backoffice/showcase/avatar_component.html
@@ -1,0 +1,30 @@
+{#
+ABOUTME: Showcase section for the avatar component
+ABOUTME: Displays the circular initials badge in its three sizes
+#}
+{% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_example, showcase_tokens %}
+{% from "backoffice/components/avatar.html" import avatar %}
+
+{% macro avatar_section() %}
+    {% call showcase_section() %}
+        {{ showcase_title("Avatar") }}
+        {{ showcase_description("Circular badge showing a user's initials. Used as the account menu trigger. Sizes: sm (24px), md (32px), lg (40px).") }}
+
+        {% call showcase_example('{% from "backoffice/components/avatar.html" import avatar %}
+
+            {{ avatar(initials="AS", size="sm") }}
+            {{ avatar(initials="AS", size="md", label="Ada Smith") }}
+            {{ avatar(initials="AS", size="lg") }}') %}
+            <div class="flex items-center gap-4">
+                {{ avatar(initials="AS", size="sm") }}
+                {{ avatar(initials="AS", size="md", label="Ada Smith") }}
+                {{ avatar(initials="AS", size="lg") }}
+            </div>
+        {% endcall %}
+
+        {{ showcase_tokens([
+        "--color-navigation-bars",
+        "--color-neutral-50"
+        ]) }}
+    {% endcall %}
+{% endmacro %}

--- a/backend/templates/backoffice/showcase/page_header_component.html
+++ b/backend/templates/backoffice/showcase/page_header_component.html
@@ -1,0 +1,36 @@
+{#
+ABOUTME: Showcase section for the page header component
+ABOUTME: Displays the back-arrow + title header that replaces breadcrumbs on detail pages
+#}
+{% from "backoffice/components/showcase_section.html" import showcase_section, showcase_title, showcase_description, showcase_example, showcase_tokens %}
+{% from "backoffice/components/page_header.html" import page_header %}
+
+{% macro page_header_section() %}
+    {% call showcase_section() %}
+        {{ showcase_title("Page Header") }}
+        {{ showcase_description("Compact detail-page header: an optional back arrow plus the page title. Replaces the breadcrumb on assembly pages and sits above the tab bar (both are sticky in the app layout).") }}
+
+        {% call showcase_example('{% from "backoffice/components/page_header.html" import page_header %}
+
+            {{ page_header(
+            title="Climate Assembly",
+            back_href="/backoffice",
+            back_label="Back to dashboard"
+            ) }}') %}
+            <div class="space-y-6">
+                {{ page_header(
+                title="Climate Assembly",
+                back_href="#",
+                back_label="Back to dashboard"
+                ) }}
+                {{ page_header(title="Page without a back arrow") }}
+            </div>
+        {% endcall %}
+
+        {{ showcase_tokens([
+        "--color-headings",
+        "--color-primary-action",
+        ".text-display-sm"
+        ]) }}
+    {% endcall %}
+{% endmacro %}

--- a/backend/tests/bdd/test_accessibility.py
+++ b/backend/tests/bdd/test_accessibility.py
@@ -355,43 +355,6 @@ def inactive_tabs_tabindex(page_with_tabs: Page):
 
 
 # =============================================================================
-# Given/Then Steps - Breadcrumb
-# =============================================================================
-
-
-@given("the user is on the assembly details page")
-def user_on_assembly_details(logged_in_page: Page, existing_assembly):
-    """Navigate to assembly details page."""
-    page = logged_in_page
-    page.goto(f"http://localhost:5002/backoffice/assembly/{existing_assembly.id}")
-    page.wait_for_load_state("networkidle")
-
-
-@then("the breadcrumb should have a nav element with aria-label")
-def breadcrumb_has_nav_aria(logged_in_page: Page):
-    """Verify breadcrumb has nav with aria-label."""
-    page = logged_in_page
-    nav = page.locator('nav[aria-label*="Breadcrumb"], nav[aria-label*="breadcrumb"]')
-    expect(nav).to_be_visible()
-
-
-@then("the breadcrumb items should be in an ordered list")
-def breadcrumb_has_ordered_list(logged_in_page: Page):
-    """Verify breadcrumb uses ol element."""
-    page = logged_in_page
-    ol = page.locator('nav[aria-label*="Breadcrumb"] ol, nav[aria-label*="breadcrumb"] ol')
-    expect(ol).to_be_visible()
-
-
-@then('the current page breadcrumb should have aria-current="page"')
-def breadcrumb_has_aria_current(logged_in_page: Page):
-    """Verify current breadcrumb has aria-current=page."""
-    page = logged_in_page
-    current = page.locator('[aria-current="page"]')
-    expect(current).to_be_visible()
-
-
-# =============================================================================
 # Given/Then Steps - Button Accessibility
 # =============================================================================
 

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -556,13 +556,6 @@ def submitting_preview_form_does_nothing(page: Page):
     assert "section=preview" in page.url
 
 
-@when(parsers.parse('I visit the read-only registration form view for "{title}"'))
-def visit_registration_form_view(page: Page, title: str, test_database):
-    """Open the registration form step in its default read-only mode."""
-    assembly_id = _assembly_name_id_cache.find_title(title, test_database)
-    page.goto(f"{Urls.base}/backoffice/assembly/{assembly_id}/registration?section=form")
-
-
 def _wait_until_scrolled(page: Page, timeout_ms: int = 5000) -> None:
     """Poll window.scrollY (via CDP evaluate) until it is greater than 0.
 
@@ -578,23 +571,19 @@ def _wait_until_scrolled(page: Page, timeout_ms: int = 5000) -> None:
     raise AssertionError("window did not scroll (scrollY stayed 0)")
 
 
-@when("I scroll down the page")
-def scroll_down_the_page(page: Page):
-    page.evaluate("window.scrollTo(0, 400)")
+@when(parsers.parse('I open the read-only registration form view for "{title}" with a saved scroll of {pos:d}'))
+def visit_registration_form_view_with_scroll(page: Page, title: str, pos: int, test_database):
+    """Open the read-only registration view with a ?scroll= param, exercising the
+    DOMContentLoaded scroll-restore leg of scroll preservation (the leg that
+    x-preserve-scroll-on-submit / x-scroll-preserve-links append on navigation)."""
+    assembly_id = _assembly_name_id_cache.find_title(title, test_database)
+    page.goto(f"{Urls.base}/backoffice/assembly/{assembly_id}/registration?section=form&scroll={pos}")
+
+
+@then("the page should be scrolled down")
+def page_is_scrolled_down(page: Page):
+    """The saved scroll position was restored on load (scrollY > 0)."""
     _wait_until_scrolled(page)
-
-
-@when("I click the Edit button in the editor header")
-def click_editor_edit(page: Page):
-    """Edit renders as a link-button in the editor card header."""
-    page.get_by_role("button", name="Edit", exact=True).click()
-
-
-@then("the editor should be in edit mode with the page still scrolled down")
-def edit_mode_with_scroll_preserved(page: Page):
-    """x-scroll-preserve-links carries the scroll position across the Edit reload."""
-    page.wait_for_url(lambda url: "edit=1" in url, timeout=PLAYWRIGHT_TIMEOUT)
-    _wait_until_scrolled(page, timeout_ms=PLAYWRIGHT_TIMEOUT)
 
 
 @then("the wizard Next button should be disabled")

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -563,10 +563,25 @@ def visit_registration_form_view(page: Page, title: str, test_database):
     page.goto(f"{Urls.base}/backoffice/assembly/{assembly_id}/registration?section=form")
 
 
+def _wait_until_scrolled(page: Page, timeout_ms: int = 5000) -> None:
+    """Poll window.scrollY (via CDP evaluate) until it is greater than 0.
+
+    We deliberately avoid page.wait_for_function here: its string predicate is
+    compiled with eval in the page's own context, which our strict-dynamic CSP
+    (no 'unsafe-eval') rejects. page.evaluate runs in Playwright's utility world,
+    so it is not subject to the page CSP.
+    """
+    for _ in range(max(1, timeout_ms // 100)):
+        if page.evaluate("window.scrollY") > 0:
+            return
+        page.wait_for_timeout(100)
+    raise AssertionError("window did not scroll (scrollY stayed 0)")
+
+
 @when("I scroll down the page")
 def scroll_down_the_page(page: Page):
     page.evaluate("window.scrollTo(0, 400)")
-    page.wait_for_function("window.scrollY > 0")
+    _wait_until_scrolled(page)
 
 
 @when("I click the Edit button in the editor header")
@@ -579,7 +594,7 @@ def click_editor_edit(page: Page):
 def edit_mode_with_scroll_preserved(page: Page):
     """x-scroll-preserve-links carries the scroll position across the Edit reload."""
     page.wait_for_url(lambda url: "edit=1" in url, timeout=PLAYWRIGHT_TIMEOUT)
-    page.wait_for_function("window.scrollY > 0", timeout=PLAYWRIGHT_TIMEOUT)
+    _wait_until_scrolled(page, timeout_ms=PLAYWRIGHT_TIMEOUT)
 
 
 @then("the wizard Next button should be disabled")
@@ -788,20 +803,6 @@ def see_page_heading(page: Page, title: str):
     """Verify the page heading contains the expected title."""
     heading = page.locator("h1")
     expect(heading).to_contain_text(title)
-
-
-@then("I should see the breadcrumbs")
-def see_breadcrumbs(page: Page):
-    """Verify the breadcrumbs navigation is visible."""
-    breadcrumbs = page.locator("nav[aria-label='Breadcrumb']")
-    expect(breadcrumbs).to_be_visible()
-
-
-@then(parsers.parse('the breadcrumbs should contain "{text}"'))
-def breadcrumbs_contain_text(page: Page, text: str):
-    """Verify the breadcrumbs contain specific text."""
-    breadcrumbs = page.locator("nav[aria-label='Breadcrumb']")
-    expect(breadcrumbs).to_contain_text(text)
 
 
 @then("I should see the assembly question section")

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -738,16 +738,6 @@ def footer_has_sortition_link(page: Page):
     expect(sf_link).to_have_attribute("target", "_blank")
 
 
-@then("the footer should contain User Data Agreement link")
-def footer_has_user_data_agreement_link(page: Page):
-    """Verify the footer contains a User Data Agreement link pointing at the external help site."""
-    footer = page.locator("footer")
-    uda_link = footer.locator("a", has_text="User Data Agreement")
-    expect(uda_link).to_be_visible()
-    expect(uda_link).to_have_attribute("href", re.compile(r"^https?://.*data-agreement"))
-    expect(uda_link).to_have_attribute("target", "_blank")
-
-
 @then("the footer should display the version")
 def footer_has_version(page: Page):
     """Verify the footer displays the OpenDLP version."""

--- a/backend/tests/unit/test_floating_alerts.py
+++ b/backend/tests/unit/test_floating_alerts.py
@@ -132,16 +132,17 @@ class TestFloatingAlertsMacro:
         assert "Please review settings" in html
 
     def test_floating_alerts_has_fixed_positioning(self) -> None:
-        """Alerts float at the top-center of the viewport."""
+        """Alerts are anchored just below the sticky header, horizontally centred."""
         html = _render_floating_alerts_with_flash([("info", "Test")])
-        assert "fixed" in html
-        assert "top-6" in html
+        assert "absolute" in html
+        assert "top-full" in html
         assert "left-1/2" in html
         assert "-translate-x-1/2" in html
 
     def test_floating_alerts_has_z_index(self) -> None:
         html = _render_floating_alerts_with_flash([("info", "Test")])
-        assert "z-30" in html
+        # Above the sticky header (z-40), below modals (z-50).
+        assert "z-40" in html
 
     def test_floating_alerts_are_dismissible(self) -> None:
         """All floating alerts should be dismissible."""

--- a/backend/tests/unit/test_floating_alerts.py
+++ b/backend/tests/unit/test_floating_alerts.py
@@ -132,17 +132,36 @@ class TestFloatingAlertsMacro:
         assert "Please review settings" in html
 
     def test_floating_alerts_has_fixed_positioning(self) -> None:
-        """Alerts are anchored just below the sticky header, horizontally centred."""
+        """Alerts float at the top-centre of the viewport."""
         html = _render_floating_alerts_with_flash([("info", "Test")])
-        assert "absolute" in html
-        assert "top-full" in html
+        assert "fixed" in html
+        assert "top-6" in html
         assert "left-1/2" in html
         assert "-translate-x-1/2" in html
 
     def test_floating_alerts_has_z_index(self) -> None:
         html = _render_floating_alerts_with_flash([("info", "Test")])
-        # Above the sticky header (z-40), below modals (z-50).
-        assert "z-40" in html
+        # Above the sticky header (z-40), below modal dialogs (z-50).
+        assert "z-[45]" in html
+
+    def test_success_alert_auto_dismisses(self) -> None:
+        """Success flashes auto-dismiss after a few seconds, pausing on hover."""
+        html = _render_floating_alerts_with_flash([("success", "Saved")])
+        assert "autoDismissAlert" in html
+        assert "4000" in html
+        assert "pause()" in html
+        assert "resume()" in html
+
+    def test_warning_alert_auto_dismisses_more_slowly(self) -> None:
+        html = _render_floating_alerts_with_flash([("warning", "Careful")])
+        assert "autoDismissAlert" in html
+        assert "10000" in html
+
+    def test_error_alert_stays_until_closed(self) -> None:
+        """Error flashes never auto-dismiss."""
+        html = _render_floating_alerts_with_flash([("error", "Boom")])
+        assert "autoDismissAlert" not in html
+        assert 'x-data="{ show: true }"' in html
 
     def test_floating_alerts_are_dismissible(self) -> None:
         """All floating alerts should be dismissible."""

--- a/backend/tests/unit/test_floating_alerts.py
+++ b/backend/tests/unit/test_floating_alerts.py
@@ -139,10 +139,12 @@ class TestFloatingAlertsMacro:
         assert "left-1/2" in html
         assert "-translate-x-1/2" in html
 
-    def test_floating_alerts_has_z_index(self) -> None:
+    def test_floating_alerts_uses_layering_id(self) -> None:
+        """Layering (z-index 45) is set in main.css via the #floating-alerts id
+        (above the sticky header z-40, below modal dialogs z-50), so the container
+        must carry that id."""
         html = _render_floating_alerts_with_flash([("info", "Test")])
-        # Above the sticky header (z-40), below modal dialogs (z-50).
-        assert "z-[45]" in html
+        assert 'id="floating-alerts"' in html
 
     def test_success_alert_auto_dismisses(self) -> None:
         """Success flashes auto-dismiss after a few seconds, pausing on hover."""

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-29 09:51+0200\n"
+"POT-Creation-Date: 2026-08-06 14:15+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -79,7 +79,7 @@ msgid "About you"
 msgstr ""
 
 #: src/opendlp/domain/respondent_field_schema.py:75
-#: templates/backoffice/assembly_view_respondent.html:177
+#: templates/backoffice/assembly_view_respondent.html:169
 #: templates/respondents/view_respondents.html:165
 msgid "Consent"
 msgstr ""
@@ -121,9 +121,9 @@ msgstr "Módosítsa a számot."
 #: src/opendlp/domain/respondent_field_schema.py:112
 #: templates/admin/invite_view.html:47 templates/admin/invites.html:66
 #: templates/admin/user_view.html:22 templates/admin/users.html:113
-#: templates/backoffice/assembly_members.html:53
-#: templates/backoffice/assembly_respondents.html:134
-#: templates/backoffice/assembly_view_respondent.html:168
+#: templates/backoffice/assembly_members.html:48
+#: templates/backoffice/assembly_respondents.html:129
+#: templates/backoffice/assembly_view_respondent.html:160
 #: templates/main/view_assembly_members.html:11
 #: templates/respondents/view_respondents.html:163
 msgid "Email"
@@ -166,11 +166,11 @@ msgstr "Az oldal eléréséhez kérjük jelentkezz be."
 
 #: src/opendlp/entrypoints/edit_respondent_form.py:41
 #: src/opendlp/entrypoints/edit_respondent_form.py:45
-#: templates/backoffice/assembly_edit_respondent.html:64
-#: templates/backoffice/assembly_edit_respondent.html:72
-#: templates/backoffice/assembly_view_respondent.html:59
-#: templates/backoffice/assembly_view_respondent.html:68
-#: templates/backoffice/assembly_view_respondent.html:170
+#: templates/backoffice/assembly_edit_respondent.html:59
+#: templates/backoffice/assembly_edit_respondent.html:67
+#: templates/backoffice/assembly_view_respondent.html:58
+#: templates/backoffice/assembly_view_respondent.html:67
+#: templates/backoffice/assembly_view_respondent.html:162
 #: templates/backoffice/components/input.html:327
 #: templates/backoffice/components/table.html:246
 #: templates/backoffice/patterns/_custom.html:78
@@ -182,11 +182,11 @@ msgstr ""
 
 #: src/opendlp/entrypoints/edit_respondent_form.py:41
 #: src/opendlp/entrypoints/edit_respondent_form.py:45
-#: templates/backoffice/assembly_edit_respondent.html:64
-#: templates/backoffice/assembly_edit_respondent.html:72
-#: templates/backoffice/assembly_view_respondent.html:59
-#: templates/backoffice/assembly_view_respondent.html:68
-#: templates/backoffice/assembly_view_respondent.html:171
+#: templates/backoffice/assembly_edit_respondent.html:59
+#: templates/backoffice/assembly_edit_respondent.html:67
+#: templates/backoffice/assembly_view_respondent.html:58
+#: templates/backoffice/assembly_view_respondent.html:67
+#: templates/backoffice/assembly_view_respondent.html:163
 #: templates/backoffice/components/input.html:327
 #: templates/backoffice/components/table.html:248
 #: templates/backoffice/patterns/_custom.html:98
@@ -196,9 +196,9 @@ msgid "No"
 msgstr ""
 
 #: src/opendlp/entrypoints/edit_respondent_form.py:45
-#: templates/backoffice/assembly_edit_respondent.html:72
-#: templates/backoffice/assembly_view_respondent.html:68
-#: templates/backoffice/assembly_view_respondent.html:172
+#: templates/backoffice/assembly_edit_respondent.html:67
+#: templates/backoffice/assembly_view_respondent.html:67
+#: templates/backoffice/assembly_view_respondent.html:164
 #: templates/gsheets/components/view_config.html:41
 #: templates/profile/view.html:18 templates/profile/view.html:24
 #: templates/profile/view.html:42
@@ -211,13 +211,13 @@ msgid "The current value for '%(label)s' is not in the options list: %(value)s."
 msgstr ""
 
 #: src/opendlp/entrypoints/edit_respondent_form.py:85
-#: templates/backoffice/assembly_edit_respondent.html:77
-#: templates/backoffice/assembly_edit_respondent.html:93
+#: templates/backoffice/assembly_edit_respondent.html:72
+#: templates/backoffice/assembly_edit_respondent.html:88
 msgid "— none —"
 msgstr ""
 
 #: src/opendlp/entrypoints/edit_respondent_form.py:173
-#: templates/backoffice/assembly_edit_respondent.html:130
+#: templates/backoffice/assembly_edit_respondent.html:125
 #, fuzzy
 msgid "Change note"
 msgstr "Új jelszó"
@@ -348,7 +348,7 @@ msgid "Enter the title for this assembly"
 msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
 
 #: src/opendlp/entrypoints/forms.py:215
-#: templates/backoffice/assembly_details.html:44
+#: templates/backoffice/assembly_details.html:40
 #: templates/main/view_assembly_details.html:6
 msgid "Assembly Question"
 msgstr "A gyűlés fő témája"
@@ -358,7 +358,7 @@ msgid "Optional - the key question this assembly will address"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:222
-#: templates/backoffice/assembly_details.html:68
+#: templates/backoffice/assembly_details.html:64
 #: templates/main/view_assembly_details.html:20
 msgid "First Assembly Date"
 msgstr "Első gyűlés időpontja"
@@ -368,7 +368,7 @@ msgid "Optional - when the first assembly meeting will take place"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:228
-#: templates/backoffice/assembly_details.html:77
+#: templates/backoffice/assembly_details.html:73
 #: templates/main/view_assembly_details.html:27
 msgid "Number to Select"
 msgstr "Kiválasztandó emberek száma"
@@ -435,8 +435,8 @@ msgid "Name of the tab containing already selected people (used for Replacements
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:317 src/opendlp/entrypoints/forms.py:627
-#: templates/backoffice/assembly_data.html:175
-#: templates/backoffice/assembly_data.html:432
+#: templates/backoffice/assembly_data.html:170
+#: templates/backoffice/assembly_data.html:427
 #: templates/gsheets/components/view_config.html:48
 msgid "Check Same Address"
 msgstr "Címegyezés ellenőrzése"
@@ -446,7 +446,7 @@ msgid "Enable checking for participants with the same address"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:323
-#: templates/backoffice/assembly_data.html:181
+#: templates/backoffice/assembly_data.html:176
 #: templates/gsheets/components/view_config.html:54
 msgid "Generate Remaining Tab"
 msgstr "Fennmaradó résztvevők lap generálása"
@@ -456,28 +456,28 @@ msgid "Create a tab with remaining participants after selection"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:329
-#: templates/backoffice/assembly_data.html:191
+#: templates/backoffice/assembly_data.html:186
 #, fuzzy
 msgid "Team Configuration"
 msgstr "Google Táblázat beállításainak eltávolítása"
 
 #: src/opendlp/entrypoints/forms.py:331
-#: templates/backoffice/assembly_data.html:193
+#: templates/backoffice/assembly_data.html:188
 msgid "UK Team"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:332
-#: templates/backoffice/assembly_data.html:194
+#: templates/backoffice/assembly_data.html:189
 msgid "EU Team"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:333
-#: templates/backoffice/assembly_data.html:195
+#: templates/backoffice/assembly_data.html:190
 msgid "Australia Team"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:334
-#: templates/backoffice/assembly_data.html:196
+#: templates/backoffice/assembly_data.html:191
 #, fuzzy
 msgid "Custom configuration"
 msgstr "Beállítások mentése"
@@ -489,9 +489,9 @@ msgid ""
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:344 src/opendlp/entrypoints/forms.py:615
-#: templates/backoffice/assembly_data.html:209
-#: templates/backoffice/assembly_data.html:239
-#: templates/backoffice/assembly_data.html:397
+#: templates/backoffice/assembly_data.html:204
+#: templates/backoffice/assembly_data.html:234
+#: templates/backoffice/assembly_data.html:392
 #: templates/backoffice/service_docs/_config.html:257
 #: templates/gsheets/components/view_config.html:60
 msgid "ID Column"
@@ -504,8 +504,8 @@ msgid ""
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:353
-#: templates/backoffice/assembly_data.html:217
-#: templates/backoffice/assembly_data.html:245
+#: templates/backoffice/assembly_data.html:212
+#: templates/backoffice/assembly_data.html:240
 #: templates/gsheets/components/view_config.html:66
 msgid "Address Columns"
 msgstr "Cím oszlopok"
@@ -518,8 +518,8 @@ msgid ""
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:362
-#: templates/backoffice/assembly_data.html:225
-#: templates/backoffice/assembly_data.html:251
+#: templates/backoffice/assembly_data.html:220
+#: templates/backoffice/assembly_data.html:246
 #: templates/gsheets/components/view_config.html:72
 msgid "Columns to Keep"
 msgstr "Megtartandó oszlopok"
@@ -621,9 +621,9 @@ msgid "Current Password"
 msgstr "Új jelszó"
 
 #: src/opendlp/entrypoints/forms.py:545 src/opendlp/entrypoints/forms.py:597
-#: templates/backoffice/assembly_data.html:339
-#: templates/backoffice/assembly_data.html:391
-#: templates/backoffice/assembly_targets.html:193
+#: templates/backoffice/assembly_data.html:334
+#: templates/backoffice/assembly_data.html:386
+#: templates/backoffice/assembly_targets.html:188
 #: templates/backoffice/patterns/_file_upload.html:37
 msgid "CSV File"
 msgstr ""
@@ -694,7 +694,7 @@ msgid ""
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:618
-#: templates/backoffice/assembly_data.html:400
+#: templates/backoffice/assembly_data.html:395
 msgid ""
 "Name of column containing unique identifiers. If blank, the first column "
 "in the CSV will be used."
@@ -705,7 +705,7 @@ msgid "Prevent selecting multiple participants from the same address"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:633
-#: templates/backoffice/assembly_data.html:461
+#: templates/backoffice/assembly_data.html:456
 #, fuzzy
 msgid "Address Attributes"
 msgstr "Cím oszlopok"
@@ -715,7 +715,7 @@ msgid "Comma-separated respondent attribute names used for address matching"
 msgstr ""
 
 #: src/opendlp/entrypoints/forms.py:639
-#: templates/backoffice/assembly_data.html:470
+#: templates/backoffice/assembly_data.html:465
 #, fuzzy
 msgid "Attributes to Keep"
 msgstr "Megtartandó oszlopok"
@@ -1430,8 +1430,8 @@ msgstr ""
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:797
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:832
-#: templates/backoffice/assembly_registration.html:1588
-#: templates/backoffice/assembly_registration.html:1727
+#: templates/backoffice/assembly_registration.html:1583
+#: templates/backoffice/assembly_registration.html:1722
 msgid "Alt text is required for accessibility"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgid "An error occurred while uploading the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:931
-#: templates/backoffice/assembly_registration.html:1906
+#: templates/backoffice/assembly_registration.html:1901
 msgid "Label is required"
 msgstr ""
 
@@ -1509,7 +1509,7 @@ msgstr "Hiba történt a betöltés indítása közben"
 
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:103
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:182
-#: templates/backoffice/assembly_selection.html:58
+#: templates/backoffice/assembly_selection.html:55
 msgid "Please review and save the selection settings before running selection."
 msgstr ""
 
@@ -2062,7 +2062,7 @@ msgid "Too many registrations from your location. Please try again later."
 msgstr "Hiba történt a bejelentkezés során. Kérjük, próbáld újra."
 
 #: src/opendlp/entrypoints/blueprints/respondent_field_schema.py:132
-#: templates/backoffice/respondent_field_schema/view.html:188
+#: templates/backoffice/respondent_field_schema/view.html:186
 msgid "Not shown"
 msgstr ""
 
@@ -2280,7 +2280,7 @@ msgid "Selected or confirmed"
 msgstr "Új jelszó"
 
 #: src/opendlp/entrypoints/blueprints/respondents.py:443
-#: templates/backoffice/assembly_respondents.html:109
+#: templates/backoffice/assembly_respondents.html:104
 #: templates/backoffice/components/table.html:200
 #: templates/respondents/view_respondents.html:131
 msgid "Pool"
@@ -2288,8 +2288,8 @@ msgstr ""
 
 #: src/opendlp/entrypoints/blueprints/respondents.py:444
 #: src/opendlp/service_layer/selection_report.py:211
-#: templates/backoffice/assembly_respondents.html:110
-#: templates/backoffice/assembly_view_respondent.html:234
+#: templates/backoffice/assembly_respondents.html:105
+#: templates/backoffice/assembly_view_respondent.html:226
 #: templates/backoffice/components/table.html:206
 #: templates/backoffice/patterns/_file_upload.html:56
 #: templates/backoffice/targets/category_block.html:107
@@ -2299,7 +2299,7 @@ msgid "Selected"
 msgstr "Kiválasztás"
 
 #: src/opendlp/entrypoints/blueprints/respondents.py:445
-#: templates/backoffice/assembly_respondents.html:111
+#: templates/backoffice/assembly_respondents.html:106
 #: templates/backoffice/components/table.html:203
 #: templates/respondents/view_respondents.html:133
 #, fuzzy
@@ -2307,7 +2307,7 @@ msgid "Confirmed"
 msgstr "Új jelszó"
 
 #: src/opendlp/entrypoints/blueprints/respondents.py:446
-#: templates/backoffice/assembly_respondents.html:112
+#: templates/backoffice/assembly_respondents.html:107
 #: templates/backoffice/components/table.html:209
 #: templates/respondents/view_respondents.html:134
 msgid "Withdrawn"
@@ -3034,7 +3034,7 @@ msgstr ""
 
 #: src/opendlp/service_layer/selection_report.py:193
 #: templates/backoffice/patterns/_dropdown.html:148
-#: templates/backoffice/service_docs.html:41
+#: templates/backoffice/service_docs.html:31
 #: templates/backoffice/service_docs/_config.html:64
 #: templates/backoffice/service_docs/_config.html:245
 #: templates/backoffice/service_docs/_emails.html:62
@@ -3217,56 +3217,37 @@ msgstr "Menü"
 msgid "Close menu"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_data.html:15
-#: templates/backoffice/assembly_details.html:17
-#: templates/backoffice/assembly_edit_respondent.html:17
-#: templates/backoffice/assembly_members.html:18
-#: templates/backoffice/assembly_registration.html:19
-#: templates/backoffice/assembly_respondents.html:19
-#: templates/backoffice/assembly_selection.html:16
-#: templates/backoffice/assembly_targets.html:17
-#: templates/backoffice/assembly_view_respondent.html:18
-#: templates/backoffice/base_page.html:16
-#: templates/backoffice/create_assembly.html:14
-#: templates/backoffice/dev_dashboard.html:14
-#: templates/backoffice/edit_assembly.html:60
-#: templates/backoffice/patterns.html:16
-#: templates/backoffice/respondent_field_schema/view.html:13
-#: templates/backoffice/respondents/confirm_upload_diff.html:14
-#: templates/backoffice/service_docs.html:15 templates/base.html:58
-#: templates/errors/400.html:25 templates/errors/403.html:23
-#: templates/errors/404.html:24 templates/errors/413.html:20
-#: templates/errors/500.html:24 templates/main/create_assembly.html:11
-#: templates/main/dashboard.html:2 templates/main/dashboard.html:7
-#: templates/main/view_assembly_base.html:8
+#: templates/base.html:58 templates/errors/400.html:25
+#: templates/errors/403.html:23 templates/errors/404.html:24
+#: templates/errors/413.html:20 templates/errors/500.html:24
+#: templates/main/create_assembly.html:11 templates/main/dashboard.html:2
+#: templates/main/dashboard.html:7 templates/main/view_assembly_base.html:8
 msgid "Dashboard"
 msgstr "Irányító pult"
 
 #: templates/admin/invite_create.html:10 templates/admin/invite_view.html:10
 #: templates/admin/invites.html:7 templates/admin/user_2fa_audit_log.html:10
 #: templates/admin/user_edit.html:10 templates/admin/user_view.html:10
-#: templates/admin/users.html:7 templates/backoffice/base_page.html:17
-#: templates/base.html:62
+#: templates/admin/users.html:7 templates/base.html:62
 msgid "Site Admin"
 msgstr ""
 
-#: templates/backoffice/base_page.html:18 templates/base.html:68
-#: templates/base.html:107
+#: templates/base.html:68 templates/base.html:107
 msgid "Sortition Lab"
 msgstr "Sortition Lab"
 
-#: templates/backoffice/base_page.html:19 templates/base.html:73
+#: templates/backoffice/components/navigation.html:54 templates/base.html:73
 #: templates/base.html:112
 msgid "Help"
 msgstr ""
 
-#: templates/backoffice/base_page.html:22 templates/base.html:76
-#: templates/profile/view.html:2 templates/profile/view.html:6
+#: templates/base.html:76 templates/profile/view.html:2
+#: templates/profile/view.html:6
 #, fuzzy
 msgid "My Account"
 msgstr "Hozzon létre fiókot"
 
-#: templates/backoffice/base_page.html:24 templates/base.html:79
+#: templates/backoffice/base_page.html:37 templates/base.html:79
 msgid "Sign out"
 msgstr "Kilépés"
 
@@ -3289,7 +3270,7 @@ msgstr "Hozzon létre fiókot"
 
 #: templates/admin/invite_create.html:22 templates/admin/user_edit.html:26
 #: templates/backoffice/assembly_form.html:21
-#: templates/backoffice/assembly_targets.html:176 templates/base.html:127
+#: templates/backoffice/assembly_targets.html:171 templates/base.html:127
 #: templates/gsheets/create_config.html:14
 #: templates/gsheets/edit_config.html:14 templates/main/create_assembly.html:19
 #: templates/main/edit_assembly.html:8
@@ -3298,6 +3279,7 @@ msgstr "Hozzon létre fiókot"
 msgid "There is a problem"
 msgstr "Valami probléma van"
 
+#: templates/backoffice/patterns/_floating_alerts.html:121
 #: templates/base.html:140 templates/profile/2fa_backup_codes.html:9
 msgid "Success"
 msgstr "Sikerült"
@@ -3306,12 +3288,12 @@ msgstr "Sikerült"
 msgid "Important"
 msgstr "Fontos"
 
-#: templates/backoffice/components/footer.html:16 templates/base.html:176
+#: templates/backoffice/base_page.html:35 templates/base.html:176
 #: templates/base_public.html:40
 msgid "User Data Agreement"
 msgstr "Felhasználói Adatkezelési Megállapodás"
 
-#: templates/backoffice/components/footer.html:19 templates/base.html:181
+#: templates/backoffice/components/footer.html:16 templates/base.html:181
 #: templates/base_public.html:45
 msgid "Cookies"
 msgstr ""
@@ -3325,7 +3307,7 @@ msgstr "Irányító pult"
 msgid "OpenDLP Version"
 msgstr ""
 
-#: templates/backoffice/components/footer.html:33 templates/base.html:195
+#: templates/backoffice/components/footer.html:30 templates/base.html:195
 msgid ""
 "OpenDLP is an open source platform for Democratic Lottery and Citizens' "
 "Assembly management."
@@ -3377,15 +3359,7 @@ msgstr ""
 msgid "Manage Invites"
 msgstr ""
 
-#: templates/admin/index.html:30 templates/backoffice/assembly_data.html:60
-#: templates/backoffice/assembly_details.html:177
-#: templates/backoffice/assembly_members.html:147
-#: templates/backoffice/assembly_respondents.html:189
-#: templates/backoffice/assembly_selection.html:270
-#: templates/backoffice/assembly_selection.html:277
-#: templates/backoffice/assembly_selection.html:460
-#: templates/backoffice/assembly_targets.html:205
-#: templates/main/view_assembly_base.html:79
+#: templates/admin/index.html:30 templates/main/view_assembly_base.html:79
 msgid "Back to Dashboard"
 msgstr "Vissza az irányító pulthoz"
 
@@ -3406,20 +3380,20 @@ msgid "Generate a new invite code for user registration"
 msgstr "Add meg a meghívókódodat a regisztrációhoz"
 
 #: templates/admin/invite_create.html:96 templates/admin/user_edit.html:135
-#: templates/backoffice/assembly_data.html:264
-#: templates/backoffice/assembly_data.html:508
-#: templates/backoffice/assembly_edit_respondent.html:139
+#: templates/backoffice/assembly_data.html:259
+#: templates/backoffice/assembly_data.html:503
+#: templates/backoffice/assembly_edit_respondent.html:134
 #: templates/backoffice/assembly_form.html:96
-#: templates/backoffice/assembly_registration.html:160
-#: templates/backoffice/assembly_registration.html:476
-#: templates/backoffice/assembly_registration.html:882
-#: templates/backoffice/assembly_registration.html:1043
-#: templates/backoffice/assembly_registration.html:1132
-#: templates/backoffice/assembly_registration.html:1271
-#: templates/backoffice/assembly_view_respondent.html:310
+#: templates/backoffice/assembly_registration.html:155
+#: templates/backoffice/assembly_registration.html:471
+#: templates/backoffice/assembly_registration.html:877
+#: templates/backoffice/assembly_registration.html:1038
+#: templates/backoffice/assembly_registration.html:1127
+#: templates/backoffice/assembly_registration.html:1266
+#: templates/backoffice/assembly_view_respondent.html:302
 #: templates/backoffice/components/edit_number_to_select_modal.html:40
 #: templates/backoffice/components/respondent_status_form.html:87
-#: templates/backoffice/respondents/confirm_upload_diff.html:107
+#: templates/backoffice/respondents/confirm_upload_diff.html:95
 #: templates/backoffice/respondents/export_modal.html:77
 #: templates/backoffice/showcase/modal_component.html:25
 #: templates/backoffice/targets/category_block.html:47
@@ -3457,9 +3431,9 @@ msgid "Copy Code"
 msgstr ""
 
 #: templates/admin/invite_view.html:34
-#: templates/backoffice/assembly_details.html:112
-#: templates/backoffice/assembly_registration.html:648
-#: templates/backoffice/edit_assembly.html:100
+#: templates/backoffice/assembly_details.html:108
+#: templates/backoffice/assembly_registration.html:643
+#: templates/backoffice/edit_assembly.html:89
 #, fuzzy
 msgid "Registration URL"
 msgstr "Vissza a regisztrációhoz"
@@ -3473,7 +3447,7 @@ msgid "Copy URL"
 msgstr ""
 
 #: templates/admin/invite_view.html:52 templates/admin/invites.html:67
-#: templates/admin/users.html:114 templates/backoffice/assembly_members.html:54
+#: templates/admin/users.html:114 templates/backoffice/assembly_members.html:49
 #: templates/main/view_assembly_members.html:12 templates/profile/view.html:28
 #, fuzzy
 msgid "Role"
@@ -3494,16 +3468,16 @@ msgstr ""
 #: templates/admin/invite_view.html:59 templates/admin/invites.html:87
 #: templates/admin/user_2fa_audit_log.html:65 templates/admin/user_view.html:55
 #: templates/admin/users.html:74 templates/admin/users.html:138
-#: templates/backoffice/assembly_members.html:52
+#: templates/backoffice/assembly_members.html:47
 #: templates/main/view_assembly_members.html:10
 msgid "User"
 msgstr ""
 
 #: templates/admin/invite_view.html:64 templates/admin/invites.html:68
-#: templates/admin/users.html:115 templates/backoffice/assembly_details.html:57
-#: templates/backoffice/assembly_respondents.html:131
-#: templates/backoffice/assembly_selection.html:174
-#: templates/backoffice/assembly_selection.html:359
+#: templates/admin/users.html:115 templates/backoffice/assembly_details.html:53
+#: templates/backoffice/assembly_respondents.html:126
+#: templates/backoffice/assembly_selection.html:171
+#: templates/backoffice/assembly_selection.html:351
 #: templates/backoffice/respondents/export_modal.html:38
 #: templates/main/view_assembly_data.html:54
 #: templates/main/view_assembly_details.html:13
@@ -3557,13 +3531,14 @@ msgid "Used At"
 msgstr "Elkezdve"
 
 #: templates/admin/invite_view.html:100
-#: templates/backoffice/assembly_selection.html:203
-#: templates/backoffice/assembly_selection.html:388
+#: templates/backoffice/assembly_selection.html:200
+#: templates/backoffice/assembly_selection.html:380
 #: templates/main/view_assembly_data.html:84
 msgid "Unknown"
 msgstr ""
 
 #: templates/admin/invite_view.html:110 templates/admin/user_edit.html:127
+#: templates/backoffice/patterns/_floating_alerts.html:131
 #: templates/backoffice/targets/category_block.html:250
 #: templates/db_selection/components/progress.html:91
 #: templates/db_selection/select.html:24 templates/db_selection/select.html:54
@@ -3649,9 +3624,9 @@ msgid "Code"
 msgstr ""
 
 #: templates/admin/invites.html:69 templates/admin/users.html:117
-#: templates/backoffice/assembly_details.html:85
-#: templates/backoffice/assembly_view_respondent.html:231
-#: templates/backoffice/assembly_view_respondent.html:274
+#: templates/backoffice/assembly_details.html:81
+#: templates/backoffice/assembly_view_respondent.html:223
+#: templates/backoffice/assembly_view_respondent.html:266
 #: templates/main/dashboard.html:46
 #: templates/main/view_assembly_details.html:33
 msgid "Created"
@@ -3662,11 +3637,11 @@ msgid "Expires"
 msgstr ""
 
 #: templates/admin/invites.html:71 templates/admin/users.html:118
-#: templates/backoffice/assembly_members.html:56
-#: templates/backoffice/assembly_respondents.html:135
-#: templates/backoffice/assembly_selection.html:186
-#: templates/backoffice/assembly_selection.html:371
-#: templates/backoffice/respondent_field_schema/view.html:140
+#: templates/backoffice/assembly_members.html:51
+#: templates/backoffice/assembly_respondents.html:130
+#: templates/backoffice/assembly_selection.html:183
+#: templates/backoffice/assembly_selection.html:363
+#: templates/backoffice/respondent_field_schema/view.html:138
 #: templates/backoffice/targets/category_block.html:111
 #: templates/main/view_assembly_data.html:60
 #: templates/main/view_assembly_members.html:13
@@ -3676,9 +3651,9 @@ msgid "Actions"
 msgstr "Kiválasztás"
 
 #: templates/admin/invites.html:103 templates/admin/users.html:160
-#: templates/backoffice/assembly_respondents.html:145
-#: templates/backoffice/assembly_selection.html:222
-#: templates/backoffice/assembly_selection.html:406
+#: templates/backoffice/assembly_respondents.html:140
+#: templates/backoffice/assembly_selection.html:219
+#: templates/backoffice/assembly_selection.html:398
 #: templates/main/view_assembly_data.html:110
 msgid "View"
 msgstr ""
@@ -3717,7 +3692,7 @@ msgid "Timestamp"
 msgstr ""
 
 #: templates/admin/user_2fa_audit_log.html:32
-#: templates/backoffice/assembly_view_respondent.html:248
+#: templates/backoffice/assembly_view_respondent.html:240
 #, fuzzy
 msgid "Action"
 msgstr "Kiválasztás"
@@ -3727,7 +3702,7 @@ msgid "Performed By"
 msgstr ""
 
 #: templates/admin/user_2fa_audit_log.html:34
-#: templates/backoffice/assembly_details.html:53
+#: templates/backoffice/assembly_details.html:49
 #: templates/backoffice/components/assembly_tabs.html:30
 #: templates/main/view_assembly_base.html:30
 #, fuzzy
@@ -3793,16 +3768,14 @@ msgid "Edit User"
 msgstr "Módosítsa a számot."
 
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
-#: templates/backoffice/assembly_edit_respondent.html:21
-#: templates/backoffice/assembly_registration.html:163
-#: templates/backoffice/assembly_registration.html:479
-#: templates/backoffice/assembly_respondents.html:148
-#: templates/backoffice/assembly_selection.html:81
-#: templates/backoffice/assembly_selection.html:299
-#: templates/backoffice/assembly_view_respondent.html:95
-#: templates/backoffice/assembly_view_respondent.html:232
-#: templates/backoffice/assembly_view_respondent.html:318
-#: templates/backoffice/edit_assembly.html:62
+#: templates/backoffice/assembly_registration.html:158
+#: templates/backoffice/assembly_registration.html:474
+#: templates/backoffice/assembly_respondents.html:143
+#: templates/backoffice/assembly_selection.html:78
+#: templates/backoffice/assembly_selection.html:291
+#: templates/backoffice/assembly_view_respondent.html:20
+#: templates/backoffice/assembly_view_respondent.html:224
+#: templates/backoffice/assembly_view_respondent.html:310
 #: templates/backoffice/targets/category_block.html:146
 #: templates/main/edit_assembly.html:3
 #: templates/targets/components/category_block.html:102
@@ -3833,7 +3806,7 @@ msgid ""
 msgstr ""
 
 #: templates/admin/user_edit.html:133
-#: templates/backoffice/edit_assembly.html:76
+#: templates/backoffice/edit_assembly.html:65
 #: templates/gsheets/edit_config.html:232 templates/main/edit_assembly.html:80
 msgid "Save Changes"
 msgstr "Módosítások mentése"
@@ -3970,7 +3943,7 @@ msgid "Filter by status"
 msgstr ""
 
 #: templates/admin/users.html:87
-#: templates/backoffice/assembly_respondents.html:108
+#: templates/backoffice/assembly_respondents.html:103
 #: templates/backoffice/service_docs/_respondents.html:500
 #: templates/respondents/view_respondents.html:130
 #, fuzzy
@@ -3991,7 +3964,7 @@ msgid "Showing %(start)s to %(end)s of %(total)s users"
 msgstr ""
 
 #: templates/admin/users.html:112
-#: templates/backoffice/assembly_respondents.html:132
+#: templates/backoffice/assembly_respondents.html:127
 #: templates/backoffice/service_docs/_emails.html:70
 #, fuzzy
 msgid "Name"
@@ -4170,8 +4143,9 @@ msgstr "Adatkezelési megállapodás megtekintése"
 #: templates/auth/register.html:154 templates/auth/register_google.html:20
 #: templates/auth/register_google.html:41
 #: templates/auth/register_microsoft.html:20
-#: templates/auth/register_microsoft.html:41 templates/profile/edit.html:17
-#: templates/profile/edit.html:32
+#: templates/auth/register_microsoft.html:41
+#: templates/backoffice/patterns/_floating_alerts.html:136
+#: templates/profile/edit.html:17 templates/profile/edit.html:32
 msgid "Error"
 msgstr "Hiba történt"
 
@@ -4267,60 +4241,66 @@ msgid "Back to sign in"
 msgstr "Vissza a közösségi gyűléshez"
 
 #: templates/backoffice/assembly_data.html:11
-#: templates/backoffice/assembly_data.html:17
 #: templates/backoffice/components/assembly_tabs.html:36
-#: templates/backoffice/respondents/confirm_upload_diff.html:16
 msgid "Data"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:24
+#: templates/backoffice/assembly_data.html:17
+#: templates/backoffice/assembly_details.html:19
+#: templates/backoffice/assembly_members.html:20
+#: templates/backoffice/assembly_registration.html:21
+#: templates/backoffice/assembly_respondents.html:21
+#: templates/backoffice/assembly_selection.html:18
+#: templates/backoffice/assembly_targets.html:19
+#: templates/backoffice/respondent_field_schema/view.html:15
+#: templates/profile/view.html:223
 #, fuzzy
-msgid "Manage data for this assembly"
-msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
+msgid "Back to dashboard"
+msgstr "Vissza az irányító pulthoz"
 
-#: templates/backoffice/assembly_data.html:39
+#: templates/backoffice/assembly_data.html:38
 #, fuzzy
 msgid "Data Source"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_data.html:41
-#: templates/backoffice/assembly_respondents.html:91
+#: templates/backoffice/assembly_data.html:40
+#: templates/backoffice/assembly_respondents.html:86
 #: templates/main/view_assembly_data.html:4
 #, fuzzy
 msgid "Google Spreadsheet"
 msgstr "Google Táblázat teljes linkje"
 
-#: templates/backoffice/assembly_data.html:42
+#: templates/backoffice/assembly_data.html:41
 msgid "CSV file"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:45
+#: templates/backoffice/assembly_data.html:44
 msgid "Select Data Source"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:46
+#: templates/backoffice/assembly_data.html:45
 msgid ""
 "Data source is locked because a configuration already exists. Delete the "
 "configuration to change the data source."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:46
+#: templates/backoffice/assembly_data.html:45
 #, fuzzy
 msgid "Choose how you want to import participant data for this assembly."
 msgstr "Frissítse a közösségi gyűléshez tartozó Google Táblázat beállításait."
 
-#: templates/backoffice/assembly_data.html:70
+#: templates/backoffice/assembly_data.html:65
 #: templates/gsheets/components/view_config_collapsed.html:4
 msgid "Google Spreadsheet Configuration"
 msgstr "Google táblázat beállításai"
 
-#: templates/backoffice/assembly_data.html:73
+#: templates/backoffice/assembly_data.html:68
 #, fuzzy
 msgid "Edit Configuration"
 msgstr "Google Táblázat beállításainak eltávolítása"
 
-#: templates/backoffice/assembly_data.html:80
-#: templates/backoffice/assembly_data.html:278
+#: templates/backoffice/assembly_data.html:75
+#: templates/backoffice/assembly_data.html:273
 #, fuzzy
 msgid ""
 "Are you sure you want to delete this Google Spreadsheet configuration? "
@@ -4329,7 +4309,7 @@ msgstr ""
 "Biztos, hogy el akarja távolítani ehhez a Google Táblázathoz tartozó "
 "beállításokat? Ez a művelet nem vonható vissza."
 
-#: templates/backoffice/assembly_data.html:82
+#: templates/backoffice/assembly_data.html:77
 #: templates/backoffice/service_docs/_emails.html:365
 #: templates/backoffice/showcase/modal_component.html:26
 #: templates/backoffice/targets/category_block.html:32
@@ -4340,247 +4320,246 @@ msgstr ""
 msgid "Delete"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_data.html:89
+#: templates/backoffice/assembly_data.html:84
 #, fuzzy
 msgid ""
 "Configure a Google Spreadsheet to import and manage participant data for "
 "this assembly."
 msgstr "Frissítse a közösségi gyűléshez tartozó Google Táblázat beállításait."
 
-#: templates/backoffice/assembly_data.html:102
+#: templates/backoffice/assembly_data.html:97
 #: templates/backoffice/respondents/export_modal.html:53
 #: templates/gsheets/components/view_config.html:3
 msgid "Spreadsheet URL"
 msgstr "Google Táblázat teljes linkje"
 
-#: templates/backoffice/assembly_data.html:106
+#: templates/backoffice/assembly_data.html:101
 #, fuzzy
 msgid "Enter the full URL of your Google Spreadsheet."
 msgstr "Adja meg a Google táblázat beállításait"
 
-#: templates/backoffice/assembly_data.html:106
+#: templates/backoffice/assembly_data.html:101
 #: templates/gsheets/components/view_config.html:11
 #: templates/gsheets/create_config.html:46
 #: templates/gsheets/edit_config.html:44
 msgid "Ensure it is shared with:"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:110
+#: templates/backoffice/assembly_data.html:105
 #: templates/gsheets/components/view_config.html:8
 msgid "View Spreadsheet"
 msgstr "Táblázat megtekintése"
 
-#: templates/backoffice/assembly_data.html:115
+#: templates/backoffice/assembly_data.html:110
 #: templates/gsheets/components/view_config.html:21
 #: templates/gsheets/create_config.html:60
 #: templates/gsheets/edit_config.html:58
 msgid "Initial/Test Selection"
 msgstr "Kezdeti/Teszt kiválasztás"
 
-#: templates/backoffice/assembly_data.html:117
+#: templates/backoffice/assembly_data.html:112
 msgid "Configure the tabs used for the initial selection process."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:121
-#: templates/backoffice/assembly_data.html:146
+#: templates/backoffice/assembly_data.html:116
+#: templates/backoffice/assembly_data.html:141
 #: templates/gsheets/components/view_config.html:27
 msgid "Respondents Tab"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_data.html:123
-#: templates/backoffice/assembly_data.html:148
+#: templates/backoffice/assembly_data.html:118
+#: templates/backoffice/assembly_data.html:143
 #, fuzzy
 msgid "e.g., Respondents"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_data.html:124
+#: templates/backoffice/assembly_data.html:119
 msgid "Tab containing respondent data for selection."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:129
-#: templates/backoffice/assembly_data.html:154
+#: templates/backoffice/assembly_data.html:124
+#: templates/backoffice/assembly_data.html:149
 #: templates/gsheets/components/view_config.html:32
 msgid "Categories Tab"
 msgstr "Kategóriákat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_data.html:131
-#: templates/backoffice/assembly_data.html:156
+#: templates/backoffice/assembly_data.html:126
+#: templates/backoffice/assembly_data.html:151
 #, fuzzy
 msgid "e.g., Categories"
 msgstr "Kategóriákat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_data.html:132
+#: templates/backoffice/assembly_data.html:127
 msgid "Tab containing selection categories/targets."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:140
+#: templates/backoffice/assembly_data.html:135
 #: templates/gsheets/components/view_config.html:22
 #: templates/gsheets/create_config.html:93
 #: templates/gsheets/edit_config.html:91
 msgid "Replacement"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_data.html:142
+#: templates/backoffice/assembly_data.html:137
 #, fuzzy
 msgid "Configure the tabs used for replacement selections."
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_data.html:149
+#: templates/backoffice/assembly_data.html:144
 msgid "Tab containing respondent data for replacements."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:157
+#: templates/backoffice/assembly_data.html:152
 msgid "Tab containing replacement categories/targets."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:163
+#: templates/backoffice/assembly_data.html:158
 #, fuzzy
 msgid "Already Selected Tab"
 msgstr "Táblázat lapfülei"
 
-#: templates/backoffice/assembly_data.html:165
+#: templates/backoffice/assembly_data.html:160
 msgid "e.g., Selected"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:166
+#: templates/backoffice/assembly_data.html:161
 msgid ""
 "Tab containing previously selected participants (for exclusion during "
 "replacement)."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:173
+#: templates/backoffice/assembly_data.html:168
 #, fuzzy
 msgid "Options"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_data.html:177
-#: templates/backoffice/assembly_data.html:434
+#: templates/backoffice/assembly_data.html:172
+#: templates/backoffice/assembly_data.html:429
 msgid "Prevent selecting multiple participants from the same address."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:183
+#: templates/backoffice/assembly_data.html:178
 msgid "Automatically generate a tab with remaining (unselected) participants."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:199
+#: templates/backoffice/assembly_data.html:194
 msgid "Choose a preset or configure custom column settings."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:211
-#: templates/backoffice/assembly_data.html:399
+#: templates/backoffice/assembly_data.html:206
+#: templates/backoffice/assembly_data.html:394
 msgid "e.g., ID"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:212
-#: templates/backoffice/assembly_data.html:241
+#: templates/backoffice/assembly_data.html:207
+#: templates/backoffice/assembly_data.html:236
 msgid "Column name containing unique participant identifiers."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:219
-#: templates/backoffice/assembly_data.html:463
+#: templates/backoffice/assembly_data.html:214
+#: templates/backoffice/assembly_data.html:458
 msgid "e.g., Street, City, PostCode"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:220
-#: templates/backoffice/assembly_data.html:247
+#: templates/backoffice/assembly_data.html:215
+#: templates/backoffice/assembly_data.html:242
 msgid "Comma-separated column names used for address matching."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:227
-#: templates/backoffice/assembly_data.html:472
+#: templates/backoffice/assembly_data.html:222
+#: templates/backoffice/assembly_data.html:467
 msgid "e.g., Name, Email, Phone"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:228
-#: templates/backoffice/assembly_data.html:253
+#: templates/backoffice/assembly_data.html:223
+#: templates/backoffice/assembly_data.html:248
 msgid "Comma-separated column names to include in output."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:237
+#: templates/backoffice/assembly_data.html:232
 #, fuzzy
 msgid "Column Configuration"
 msgstr "Beállítások mentése"
 
-#: templates/backoffice/assembly_data.html:262
+#: templates/backoffice/assembly_data.html:257
 #: templates/gsheets/create_config.html:234
 msgid "Save Configuration"
 msgstr "Beállítások mentése"
 
-#: templates/backoffice/assembly_data.html:280
+#: templates/backoffice/assembly_data.html:275
 #, fuzzy
 msgid "Delete Configuration"
 msgstr "Google Táblázat beállításainak eltávolítása"
 
-#: templates/backoffice/assembly_data.html:294
+#: templates/backoffice/assembly_data.html:289
 msgid "CSV Files Upload"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:296
+#: templates/backoffice/assembly_data.html:291
 msgid "Upload CSV files to import targets and people data."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:303
+#: templates/backoffice/assembly_data.html:298
 #: templates/backoffice/assembly_targets.html:12
-#: templates/backoffice/assembly_targets.html:19
 #: templates/backoffice/components/assembly_tabs.html:48
-#: templates/backoffice/service_docs.html:45
+#: templates/backoffice/service_docs.html:35
 #: templates/main/view_assembly_base.html:36
 #: templates/targets/view_targets.html:2
 #, fuzzy
 msgid "Targets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_data.html:305
+#: templates/backoffice/assembly_data.html:300
 #, fuzzy
 msgid "Upload target categories for selection criteria."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_data.html:320
+#: templates/backoffice/assembly_data.html:315
 #, python-format
 msgid "%(count)d categories uploaded"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:328
+#: templates/backoffice/assembly_data.html:323
 #, fuzzy
 msgid "Are you sure you want to delete all targets? This action cannot be undone."
 msgstr ""
 "Biztos, hogy el akarja távolítani ehhez a Google Táblázathoz tartozó "
 "beállításokat? Ez a művelet nem vonható vissza."
 
-#: templates/backoffice/assembly_data.html:330
+#: templates/backoffice/assembly_data.html:325
 #, fuzzy
 msgid "Delete Targets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_data.html:342
+#: templates/backoffice/assembly_data.html:337
 msgid "Select a CSV file with target categories."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:344
-#: templates/backoffice/assembly_data.html:402
-#: templates/backoffice/assembly_registration.html:213
-#: templates/backoffice/assembly_registration.html:292
-#: templates/backoffice/assembly_registration.html:883
-#: templates/backoffice/assembly_registration.html:1133
+#: templates/backoffice/assembly_data.html:339
+#: templates/backoffice/assembly_data.html:397
+#: templates/backoffice/assembly_registration.html:208
+#: templates/backoffice/assembly_registration.html:287
+#: templates/backoffice/assembly_registration.html:878
+#: templates/backoffice/assembly_registration.html:1128
 msgid "Upload"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:352
+#: templates/backoffice/assembly_data.html:347
 #, fuzzy
 msgid "People"
 msgstr "Szereped/jogosultságod"
 
-#: templates/backoffice/assembly_data.html:354
+#: templates/backoffice/assembly_data.html:349
 #, fuzzy
 msgid "Upload respondent data for selection."
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_data.html:369
+#: templates/backoffice/assembly_data.html:364
 #, fuzzy, python-format
 msgid "%(count)d respondents uploaded"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_data.html:377
+#: templates/backoffice/assembly_data.html:372
 #, fuzzy
 msgid ""
 "Are you sure you want to delete all respondents? This action cannot be "
@@ -4589,16 +4568,16 @@ msgstr ""
 "Biztos, hogy el akarja távolítani ehhez a Google Táblázathoz tartozó "
 "beállításokat? Ez a művelet nem vonható vissza."
 
-#: templates/backoffice/assembly_data.html:379
+#: templates/backoffice/assembly_data.html:374
 #, fuzzy
 msgid "Delete Respondents"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_data.html:394
+#: templates/backoffice/assembly_data.html:389
 msgid "Select a CSV file with respondent data."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:416
+#: templates/backoffice/assembly_data.html:411
 #: templates/db_selection/select.html:121
 #: templates/db_selection/settings.html:2
 #: templates/db_selection/settings.html:11
@@ -4606,183 +4585,165 @@ msgstr ""
 msgid "Selection Settings"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_data.html:419
+#: templates/backoffice/assembly_data.html:414
 #, fuzzy
 msgid "Configure how the selection algorithm runs for this assembly."
 msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
 
-#: templates/backoffice/assembly_data.html:443
+#: templates/backoffice/assembly_data.html:438
 #: templates/db_selection/settings.html:33
 msgid "Available respondent attributes"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:447
+#: templates/backoffice/assembly_data.html:442
 #: templates/db_selection/settings.html:36
 msgid ""
 "The following attribute names are available from the uploaded respondent "
 "data:"
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:455
+#: templates/backoffice/assembly_data.html:450
 #: templates/db_selection/settings.html:42
 msgid ""
 "No respondent data has been uploaded yet. Attribute validation will be "
 "skipped."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:464
+#: templates/backoffice/assembly_data.html:459
 msgid "Comma-separated respondent attribute names used for address matching."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:473
+#: templates/backoffice/assembly_data.html:468
 msgid "Comma-separated respondent attribute names to include in CSV output."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:491
+#: templates/backoffice/assembly_data.html:486
 msgid "Settings have been confirmed. You can run selection."
 msgstr ""
 
-#: templates/backoffice/assembly_data.html:498
+#: templates/backoffice/assembly_data.html:493
 #, fuzzy
 msgid "Please review and save these settings before running selection."
 msgstr "Kezdje a Google táblázat beállításainak megadásával."
 
-#: templates/backoffice/assembly_data.html:506
+#: templates/backoffice/assembly_data.html:501
 #: templates/db_selection/settings.html:75
 #, fuzzy
 msgid "Save Settings"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_data.html:515
+#: templates/backoffice/assembly_data.html:510
 #, fuzzy
 msgid "Edit Settings"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_details.html:27
-#, fuzzy
-msgid "Assembly Details"
-msgstr "Közösségi gyűlés"
-
-#: templates/backoffice/assembly_details.html:93
+#: templates/backoffice/assembly_details.html:89
 #: templates/main/view_assembly_details.html:39
 msgid "Last Updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_details.html:105
+#: templates/backoffice/assembly_details.html:101
 #, fuzzy
 msgid "Registration Page Details"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_details.html:113
-#: templates/backoffice/assembly_registration.html:649
+#: templates/backoffice/assembly_details.html:109
+#: templates/backoffice/assembly_registration.html:644
 msgid "The URL for your registration form"
 msgstr ""
 
-#: templates/backoffice/assembly_details.html:120
-#: templates/backoffice/assembly_registration.html:656
+#: templates/backoffice/assembly_details.html:116
+#: templates/backoffice/assembly_registration.html:651
 msgid "Short URL"
 msgstr ""
 
-#: templates/backoffice/assembly_details.html:121
-#: templates/backoffice/assembly_registration.html:657
-#: templates/backoffice/edit_assembly.html:112
+#: templates/backoffice/assembly_details.html:117
+#: templates/backoffice/assembly_registration.html:652
+#: templates/backoffice/edit_assembly.html:101
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
-#: templates/backoffice/assembly_details.html:129
-#: templates/backoffice/assembly_registration.html:666
+#: templates/backoffice/assembly_details.html:125
+#: templates/backoffice/assembly_registration.html:661
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_details.html:131
-#: templates/backoffice/assembly_registration.html:668
+#: templates/backoffice/assembly_details.html:127
+#: templates/backoffice/assembly_registration.html:663
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
-#: templates/backoffice/assembly_details.html:138
-#: templates/backoffice/assembly_registration.html:674
+#: templates/backoffice/assembly_details.html:134
+#: templates/backoffice/assembly_registration.html:669
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_details.html:151
-#: templates/backoffice/assembly_registration.html:686
+#: templates/backoffice/assembly_details.html:147
+#: templates/backoffice/assembly_registration.html:681
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
-#: templates/backoffice/assembly_details.html:154
-#: templates/backoffice/assembly_registration.html:689
+#: templates/backoffice/assembly_details.html:150
+#: templates/backoffice/assembly_registration.html:684
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
-#: templates/backoffice/assembly_details.html:164
+#: templates/backoffice/assembly_details.html:160
 #, fuzzy
 msgid "No registration page has been created for this assembly."
 msgstr "Vissza a közösségi gyűléshez"
 
-#: templates/backoffice/assembly_details.html:169
+#: templates/backoffice/assembly_details.html:165
 #, fuzzy
 msgid "Create Registration Page"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_details.html:178
-#: templates/backoffice/edit_assembly.html:55
-#: templates/backoffice/edit_assembly.html:69
+#: templates/backoffice/assembly_details.html:173
+#: templates/backoffice/edit_assembly.html:54
+#: templates/backoffice/edit_assembly.html:58
 #: templates/main/edit_assembly.html:2 templates/main/edit_assembly.html:23
 #: templates/main/view_assembly_details.html:48
 msgid "Edit Assembly"
 msgstr "Közösségi gyűlés szerkesztése"
 
 #: templates/backoffice/assembly_edit_respondent.html:13
-#: templates/backoffice/assembly_edit_respondent.html:26
 #, fuzzy
 msgid "Edit respondent"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
 #: templates/backoffice/assembly_edit_respondent.html:19
-#: templates/backoffice/assembly_respondents.html:14
-#: templates/backoffice/assembly_respondents.html:21
-#: templates/backoffice/assembly_respondents.html:86
-#: templates/backoffice/assembly_view_respondent.html:20
-#: templates/backoffice/components/assembly_tabs.html:61
-#: templates/backoffice/respondents/export_modal.html:65
-#: templates/backoffice/service_docs.html:44
-#: templates/backoffice/targets/category_block.html:103
-#: templates/db_selection/select.html:43
-#: templates/main/view_assembly_base.html:42
-#: templates/respondents/view_respondents.html:2
-#: templates/targets/components/category_block.html:73
 #, fuzzy
-msgid "Respondents"
+msgid "Back to respondent"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_edit_respondent.html:36
+#: templates/backoffice/assembly_edit_respondent.html:31
 msgid "This assembly has no respondent fields configured yet."
 msgstr ""
 
-#: templates/backoffice/assembly_edit_respondent.html:38
+#: templates/backoffice/assembly_edit_respondent.html:33
 msgid "Initialise the field schema first"
 msgstr ""
 
-#: templates/backoffice/assembly_edit_respondent.html:41
+#: templates/backoffice/assembly_edit_respondent.html:36
+#: templates/backoffice/components/page_header.html:26
 msgid "Back"
 msgstr ""
 
-#: templates/backoffice/assembly_edit_respondent.html:131
+#: templates/backoffice/assembly_edit_respondent.html:126
 msgid "Why are you making this change?"
 msgstr ""
 
-#: templates/backoffice/assembly_edit_respondent.html:138
+#: templates/backoffice/assembly_edit_respondent.html:133
 #: templates/profile/edit.html:40
 #, fuzzy
 msgid "Save changes"
 msgstr "Módosítások mentése"
 
 #: templates/backoffice/assembly_members.html:13
-#: templates/backoffice/assembly_members.html:20
-#: templates/backoffice/assembly_members.html:44
+#: templates/backoffice/assembly_members.html:39
 #: templates/backoffice/components/assembly_tabs.html:75
 #: templates/main/view_assembly_base.html:68
 #: templates/main/view_assembly_members.html:2
@@ -4791,136 +4752,119 @@ msgstr "Módosítások mentése"
 msgid "Team Members"
 msgstr "Maradjak bejelentkezve"
 
-#: templates/backoffice/assembly_members.html:29
-#, fuzzy
-msgid "Manage team members for this assembly"
-msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
-
-#: templates/backoffice/assembly_members.html:77
+#: templates/backoffice/assembly_members.html:72
 #: templates/main/view_assembly_members.html:30
 #, python-format
 msgid "Are you sure you want to remove %(user)s from this assembly?"
 msgstr ""
 
-#: templates/backoffice/assembly_members.html:83
-#: templates/backoffice/respondent_field_schema/view.html:239
-#: templates/backoffice/respondent_field_schema/view.html:280
+#: templates/backoffice/assembly_members.html:78
+#: templates/backoffice/respondent_field_schema/view.html:237
+#: templates/backoffice/respondent_field_schema/view.html:278
 #: templates/main/view_assembly_members.html:31 templates/profile/view.html:57
 msgid "Remove"
 msgstr ""
 
-#: templates/backoffice/assembly_members.html:95
+#: templates/backoffice/assembly_members.html:90
 #, fuzzy
 msgid "No team members have been added to this assembly yet."
 msgstr "Vissza a közösségi gyűléshez"
 
-#: templates/backoffice/assembly_members.html:96
+#: templates/backoffice/assembly_members.html:91
 #, fuzzy
 msgid "Admin users can still manage this assembly."
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: templates/backoffice/assembly_members.html:104
-#: templates/backoffice/assembly_members.html:139
+#: templates/backoffice/assembly_members.html:99
+#: templates/backoffice/assembly_members.html:134
 #: templates/main/view_assembly_members.html:48
 #: templates/main/view_assembly_members.html:95
 #, fuzzy
 msgid "Add User to Assembly"
 msgstr "Vissza a közösségi gyűléshez"
 
-#: templates/backoffice/assembly_members.html:116
+#: templates/backoffice/assembly_members.html:111
 #: templates/main/view_assembly_members.html:61
 msgid "Type to search by email or name..."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:21
-#: templates/backoffice/components/assembly_tabs.html:55
-#: templates/backoffice/service_docs.html:42
-#, fuzzy
-msgid "Registration"
-msgstr "Vissza a regisztrációhoz"
-
-#: templates/backoffice/assembly_registration.html:31
-#, fuzzy
-msgid "Registration Form Configuration"
-msgstr "Beállítások mentése"
-
-#: templates/backoffice/assembly_registration.html:53
+#: templates/backoffice/assembly_registration.html:48
 #, fuzzy
 msgid "Registration page not created"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:56
+#: templates/backoffice/assembly_registration.html:51
 msgid ""
 "Before you can configure the registration form, you need to create a "
 "registration page from the Details tab."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:59
+#: templates/backoffice/assembly_registration.html:54
 #, fuzzy
 msgid "Go to Details tab"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_registration.html:75
+#: templates/backoffice/assembly_registration.html:70
 #: templates/backoffice/patterns/_stepper.html:28
 #: templates/backoffice/patterns/_stepper.html:102
 #, fuzzy
 msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:76
-#: templates/backoffice/assembly_registration.html:420
+#: templates/backoffice/assembly_registration.html:71
+#: templates/backoffice/assembly_registration.html:415
 #: templates/backoffice/patterns/_stepper.html:29
 #: templates/backoffice/patterns/_stepper.html:103
 #, fuzzy
 msgid "Auto-reply email"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/assembly_registration.html:77
+#: templates/backoffice/assembly_registration.html:72
 #: templates/backoffice/patterns/_stepper.html:30
 #: templates/backoffice/patterns/_stepper.html:104
 #, fuzzy
 msgid "Preview and publish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:79
+#: templates/backoffice/assembly_registration.html:74
 #, fuzzy
 msgid "Registration setup steps"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:92
+#: templates/backoffice/assembly_registration.html:87
 #, fuzzy
 msgid "Test mode"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:93
+#: templates/backoffice/assembly_registration.html:88
 msgid ""
 "Submissions are recorded as test entries and don't enter the selection "
 "pool. Publish the registration when you're ready to go live."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:101
+#: templates/backoffice/assembly_registration.html:96
 #, fuzzy
 msgid "Registration closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:102
+#: templates/backoffice/assembly_registration.html:97
 msgid "Visitors who follow the form URL are redirected to the closed page."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:110
+#: templates/backoffice/assembly_registration.html:105
 msgid "Published"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:128
+#: templates/backoffice/assembly_registration.html:123
 #, fuzzy
 msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:128
-#: templates/backoffice/assembly_registration.html:477
+#: templates/backoffice/assembly_registration.html:123
+#: templates/backoffice/assembly_registration.html:472
 #: templates/backoffice/components/edit_number_to_select_modal.html:41
-#: templates/backoffice/respondent_field_schema/view.html:230
-#: templates/backoffice/respondent_field_schema/view.html:271
+#: templates/backoffice/respondent_field_schema/view.html:228
+#: templates/backoffice/respondent_field_schema/view.html:269
 #: templates/backoffice/targets/category_block.html:46
 #: templates/backoffice/targets/category_block.html:227
 #: templates/backoffice/targets/category_name_edit.html:22
@@ -4930,225 +4874,225 @@ msgstr "Módosítások mentése"
 msgid "Save"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:140
+#: templates/backoffice/assembly_registration.html:135
 #, fuzzy
 msgid "Registration Form HTML"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:154
+#: templates/backoffice/assembly_registration.html:149
 msgid "Show Form Skeleton"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:170
+#: templates/backoffice/assembly_registration.html:165
 msgid ""
 "Paste your HTML form code below. The only required placeholders are {{ "
 "form_action }} for the form's action attribute and {{ csrf_form_element "
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:203
+#: templates/backoffice/assembly_registration.html:198
 #, fuzzy
 msgid "Assets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:211
-#: templates/backoffice/service_docs.html:48
+#: templates/backoffice/assembly_registration.html:206
+#: templates/backoffice/service_docs.html:38
 #, fuzzy
 msgid "Images"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:227
+#: templates/backoffice/assembly_registration.html:222
 #, python-format
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:234
+#: templates/backoffice/assembly_registration.html:229
 #, fuzzy
 msgid "No images uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:290
-#: templates/backoffice/service_docs.html:49
+#: templates/backoffice/assembly_registration.html:285
+#: templates/backoffice/service_docs.html:39
 #, fuzzy
 msgid "Documents"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:306
-#: templates/backoffice/assembly_registration.html:1088
+#: templates/backoffice/assembly_registration.html:301
+#: templates/backoffice/assembly_registration.html:1083
 #, python-format
 msgid "PDF files only. Maximum file size: %(max)s MB per document."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:313
+#: templates/backoffice/assembly_registration.html:308
 #, fuzzy
 msgid "No documents uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:379
-#: templates/backoffice/assembly_registration.html:589
+#: templates/backoffice/assembly_registration.html:374
+#: templates/backoffice/assembly_registration.html:584
 msgid "Editing in progress — save or cancel to continue"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:381
-#: templates/backoffice/assembly_registration.html:383
-#: templates/backoffice/assembly_registration.html:437
-#: templates/backoffice/assembly_registration.html:592
-#: templates/backoffice/assembly_registration.html:595
+#: templates/backoffice/assembly_registration.html:376
+#: templates/backoffice/assembly_registration.html:378
+#: templates/backoffice/assembly_registration.html:432
+#: templates/backoffice/assembly_registration.html:587
+#: templates/backoffice/assembly_registration.html:590
 #, fuzzy
 msgid "Next →"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:409
+#: templates/backoffice/assembly_registration.html:404
 #, fuzzy
 msgid "Auto-reply cannot be sent"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:409
+#: templates/backoffice/assembly_registration.html:404
 msgid "Heads up"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:423
+#: templates/backoffice/assembly_registration.html:418
 msgid ""
 "Automatically send a confirmation email to people after they register. "
 "Templates support variables like the respondent's first name and the "
 "assembly title."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:428
+#: templates/backoffice/assembly_registration.html:423
 msgid "Set up auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:436
-#: templates/backoffice/assembly_registration.html:587
-#: templates/backoffice/assembly_registration.html:594
-#: templates/backoffice/assembly_registration.html:709
+#: templates/backoffice/assembly_registration.html:431
+#: templates/backoffice/assembly_registration.html:582
+#: templates/backoffice/assembly_registration.html:589
+#: templates/backoffice/assembly_registration.html:704
 msgid "← Back"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:459
+#: templates/backoffice/assembly_registration.html:454
 msgid "Auto-reply email template"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:471
+#: templates/backoffice/assembly_registration.html:466
 msgid "Send auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:492
+#: templates/backoffice/assembly_registration.html:487
 msgid "Email subject"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:494
+#: templates/backoffice/assembly_registration.html:489
 msgid "Jinja variables allowed, e.g. {{ assembly.title }}."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:504
+#: templates/backoffice/assembly_registration.html:499
 msgid "HTML body"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:506
+#: templates/backoffice/assembly_registration.html:501
 msgid ""
 "Jinja + HTML. A plain-text version is generated automatically for email "
 "clients that need it."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:527
+#: templates/backoffice/assembly_registration.html:522
 #, fuzzy
 msgid "Available variables"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:530
+#: templates/backoffice/assembly_registration.html:525
 msgid ""
 "Click a variable to select it, then copy and paste into the subject or "
 "body. Missing values render as an empty string."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:533
+#: templates/backoffice/assembly_registration.html:528
 #, fuzzy
 msgid "Assembly title"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/assembly_registration.html:534
+#: templates/backoffice/assembly_registration.html:529
 #, fuzzy
 msgid "Assembly question"
 msgstr "A gyűlés fő témája"
 
-#: templates/backoffice/assembly_registration.html:535
+#: templates/backoffice/assembly_registration.html:530
 #, fuzzy
 msgid "First assembly date (ISO)"
 msgstr "Első gyűlés időpontja"
 
-#: templates/backoffice/assembly_registration.html:536
+#: templates/backoffice/assembly_registration.html:531
 #, fuzzy
 msgid "Respondent first name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:537
+#: templates/backoffice/assembly_registration.html:532
 msgid "First name, or 'Friend' as a fallback"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:538
+#: templates/backoffice/assembly_registration.html:533
 #, fuzzy
 msgid "Respondent full name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:539
+#: templates/backoffice/assembly_registration.html:534
 #, fuzzy
 msgid "Respondent email address"
 msgstr "Email cím hiányzik"
 
-#: templates/backoffice/assembly_registration.html:562
+#: templates/backoffice/assembly_registration.html:557
 msgid "Variable copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:566
+#: templates/backoffice/assembly_registration.html:561
 #, python-format
 msgid "Copy %(label)s variable"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:615
+#: templates/backoffice/assembly_registration.html:610
 msgid "Form preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:618
+#: templates/backoffice/assembly_registration.html:613
 msgid ""
 "This is the last saved version of your registration form, shown exactly "
 "as visitors will see it. You can try the fields and dropdowns, but the "
 "form cannot be submitted from here."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:627
+#: templates/backoffice/assembly_registration.html:622
 #, fuzzy
 msgid "Registration form preview"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:641
+#: templates/backoffice/assembly_registration.html:636
 msgid "Share your form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:717
+#: templates/backoffice/assembly_registration.html:712
 msgid "Publish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:726
+#: templates/backoffice/assembly_registration.html:721
 msgid "Unpublish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:728
-#: templates/backoffice/assembly_registration.html:1314
+#: templates/backoffice/assembly_registration.html:723
+#: templates/backoffice/assembly_registration.html:1309
 #, fuzzy
 msgid "Close registration"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:757
+#: templates/backoffice/assembly_registration.html:752
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:763
-#: templates/backoffice/assembly_registration.html:826
-#: templates/backoffice/assembly_registration.html:917
-#: templates/backoffice/assembly_registration.html:1079
-#: templates/backoffice/assembly_registration.html:1167
+#: templates/backoffice/assembly_registration.html:758
+#: templates/backoffice/assembly_registration.html:821
+#: templates/backoffice/assembly_registration.html:912
+#: templates/backoffice/assembly_registration.html:1074
+#: templates/backoffice/assembly_registration.html:1162
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:106
@@ -5159,385 +5103,394 @@ msgstr "Rétegzett kiválasztás"
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:772
+#: templates/backoffice/assembly_registration.html:767
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:776
+#: templates/backoffice/assembly_registration.html:771
 msgid "Form skeleton preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:792
+#: templates/backoffice/assembly_registration.html:787
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:819
+#: templates/backoffice/assembly_registration.html:814
 #, fuzzy
 msgid "Upload image"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:835
+#: templates/backoffice/assembly_registration.html:830
 #, python-format
 msgid ""
 "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
 "Files are downscaled and re-encoded to PNG on upload."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:841
+#: templates/backoffice/assembly_registration.html:836
 msgid "Image file"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:857
-#: templates/backoffice/assembly_registration.html:1016
+#: templates/backoffice/assembly_registration.html:852
+#: templates/backoffice/assembly_registration.html:1011
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:869
-#: templates/backoffice/assembly_registration.html:1028
+#: templates/backoffice/assembly_registration.html:864
+#: templates/backoffice/assembly_registration.html:1023
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:910
+#: templates/backoffice/assembly_registration.html:905
 #, fuzzy
 msgid "Image details"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:936
+#: templates/backoffice/assembly_registration.html:931
 msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:943
-#: templates/backoffice/assembly_registration.html:1180
+#: templates/backoffice/assembly_registration.html:938
+#: templates/backoffice/assembly_registration.html:1175
 msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:948
+#: templates/backoffice/assembly_registration.html:943
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:953
+#: templates/backoffice/assembly_registration.html:948
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:956
-#: templates/backoffice/assembly_registration.html:1185
+#: templates/backoffice/assembly_registration.html:951
+#: templates/backoffice/assembly_registration.html:1180
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:964
-#: templates/backoffice/assembly_registration.html:1192
+#: templates/backoffice/assembly_registration.html:959
+#: templates/backoffice/assembly_registration.html:1187
 #, fuzzy
 msgid "File name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:977
-#: templates/backoffice/assembly_registration.html:1205
+#: templates/backoffice/assembly_registration.html:972
+#: templates/backoffice/assembly_registration.html:1200
 msgid "File name copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:981
-#: templates/backoffice/assembly_registration.html:1209
+#: templates/backoffice/assembly_registration.html:976
+#: templates/backoffice/assembly_registration.html:1204
 #, fuzzy
 msgid "Copy file name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:992
+#: templates/backoffice/assembly_registration.html:987
 #, fuzzy
 msgid "Image snippet"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:1006
+#: templates/backoffice/assembly_registration.html:1001
 msgid "Copy image snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1041
+#: templates/backoffice/assembly_registration.html:1036
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1044
+#: templates/backoffice/assembly_registration.html:1039
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:1072
+#: templates/backoffice/assembly_registration.html:1067
 #, fuzzy
 msgid "Upload document"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1094
+#: templates/backoffice/assembly_registration.html:1089
 #, fuzzy
 msgid "PDF file"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1110
-#: templates/backoffice/assembly_registration.html:1244
+#: templates/backoffice/assembly_registration.html:1105
+#: templates/backoffice/assembly_registration.html:1239
 #: templates/backoffice/patterns/_progress.html:125
-#: templates/backoffice/respondent_field_schema/view.html:134
-#: templates/backoffice/respondent_field_schema/view.html:360
+#: templates/backoffice/respondent_field_schema/view.html:132
+#: templates/backoffice/respondent_field_schema/view.html:358
 msgid "Label"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1119
+#: templates/backoffice/assembly_registration.html:1114
 msgid ""
 "Shown to registrants as the download link text and used as the file's "
 "display name in the asset list. Defaults to the file name."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1160
+#: templates/backoffice/assembly_registration.html:1155
 #, fuzzy
 msgid "Document details"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1220
+#: templates/backoffice/assembly_registration.html:1215
 #, fuzzy
 msgid "Download link snippet"
 msgstr "Táblázat lapfülei"
 
-#: templates/backoffice/assembly_registration.html:1234
+#: templates/backoffice/assembly_registration.html:1229
 msgid "Copy download link snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1256
+#: templates/backoffice/assembly_registration.html:1251
 msgid ""
 "Shown to registrants as the download link text and used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1269
+#: templates/backoffice/assembly_registration.html:1264
 #, fuzzy
 msgid "Delete document"
 msgstr "Hozzon létre fiókot"
 
-#: templates/backoffice/assembly_registration.html:1272
+#: templates/backoffice/assembly_registration.html:1267
 #, fuzzy
 msgid "Save label"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:1302
+#: templates/backoffice/assembly_registration.html:1297
 #, fuzzy
 msgid "Close registration?"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:1305
+#: templates/backoffice/assembly_registration.html:1300
 msgid ""
 "This permanently stops new registrations. Visitors who follow the form "
 "link will see the 'registration closed' page, and the form cannot be "
 "reopened."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1316
+#: templates/backoffice/assembly_registration.html:1311
 #, fuzzy
 msgid "Keep it open"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1348
+#: templates/backoffice/assembly_registration.html:1343
 #, fuzzy
 msgid "Discard changes?"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1351
+#: templates/backoffice/assembly_registration.html:1346
 msgid ""
 "You have unsaved changes. If you leave this page, your changes will be "
 "lost."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1354
+#: templates/backoffice/assembly_registration.html:1349
 #, fuzzy
 msgid "Discard changes"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1355
+#: templates/backoffice/assembly_registration.html:1350
 #, fuzzy
 msgid "Keep editing"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1537
+#: templates/backoffice/assembly_registration.html:1532
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:1548
-#: templates/backoffice/assembly_registration.html:1673
+#: templates/backoffice/assembly_registration.html:1543
+#: templates/backoffice/assembly_registration.html:1668
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1551
-#: templates/backoffice/assembly_registration.html:1661
-#: templates/backoffice/assembly_registration.html:1674
-#: templates/backoffice/assembly_registration.html:1853
+#: templates/backoffice/assembly_registration.html:1546
+#: templates/backoffice/assembly_registration.html:1656
+#: templates/backoffice/assembly_registration.html:1669
+#: templates/backoffice/assembly_registration.html:1848
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1606
-#: templates/backoffice/assembly_registration.html:1798
+#: templates/backoffice/assembly_registration.html:1601
+#: templates/backoffice/assembly_registration.html:1793
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1617
+#: templates/backoffice/assembly_registration.html:1612
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1620
+#: templates/backoffice/assembly_registration.html:1615
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1629
+#: templates/backoffice/assembly_registration.html:1624
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1640
-#: templates/backoffice/assembly_registration.html:1706
+#: templates/backoffice/assembly_registration.html:1635
+#: templates/backoffice/assembly_registration.html:1701
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1644
-#: templates/backoffice/assembly_registration.html:1713
+#: templates/backoffice/assembly_registration.html:1639
+#: templates/backoffice/assembly_registration.html:1708
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1647
-#: templates/backoffice/assembly_registration.html:1716
+#: templates/backoffice/assembly_registration.html:1642
+#: templates/backoffice/assembly_registration.html:1711
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1656
-#: templates/backoffice/assembly_registration.html:1848
+#: templates/backoffice/assembly_registration.html:1651
+#: templates/backoffice/assembly_registration.html:1843
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1660
-#: templates/backoffice/assembly_registration.html:1852
+#: templates/backoffice/assembly_registration.html:1655
+#: templates/backoffice/assembly_registration.html:1847
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1743
+#: templates/backoffice/assembly_registration.html:1738
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1751
+#: templates/backoffice/assembly_registration.html:1746
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1754
+#: templates/backoffice/assembly_registration.html:1749
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1809
+#: templates/backoffice/assembly_registration.html:1804
 #, fuzzy
 msgid "Document uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1812
+#: templates/backoffice/assembly_registration.html:1807
 #, fuzzy
 msgid "Network error while uploading the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1821
+#: templates/backoffice/assembly_registration.html:1816
 #, fuzzy
 msgid "Delete this document?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1832
-#: templates/backoffice/assembly_registration.html:1885
+#: templates/backoffice/assembly_registration.html:1827
+#: templates/backoffice/assembly_registration.html:1880
 #, fuzzy
 msgid "Failed to delete document"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1836
-#: templates/backoffice/assembly_registration.html:1892
+#: templates/backoffice/assembly_registration.html:1831
+#: templates/backoffice/assembly_registration.html:1887
 #, fuzzy
 msgid "Document deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1839
-#: templates/backoffice/assembly_registration.html:1895
+#: templates/backoffice/assembly_registration.html:1834
+#: templates/backoffice/assembly_registration.html:1890
 #, fuzzy
 msgid "Network error while deleting the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1922
+#: templates/backoffice/assembly_registration.html:1917
 #, fuzzy
 msgid "Failed to update document"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1930
+#: templates/backoffice/assembly_registration.html:1925
 #, fuzzy
 msgid "Document updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1933
+#: templates/backoffice/assembly_registration.html:1928
 #, fuzzy
 msgid "Network error while updating the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_respondents.html:30
+#: templates/backoffice/assembly_respondents.html:14
+#: templates/backoffice/assembly_respondents.html:81
+#: templates/backoffice/components/assembly_tabs.html:61
+#: templates/backoffice/respondents/export_modal.html:65
+#: templates/backoffice/service_docs.html:34
+#: templates/backoffice/targets/category_block.html:103
+#: templates/db_selection/select.html:43
+#: templates/main/view_assembly_base.html:42
+#: templates/respondents/view_respondents.html:2
+#: templates/targets/components/category_block.html:73
 #, fuzzy
-msgid "Manage respondent data for this assembly"
-msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
+msgid "Respondents"
+msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_respondents.html:54
+#: templates/backoffice/assembly_respondents.html:49
 #, fuzzy
 msgid "Respondents are configured in Google Sheets"
 msgstr "Adja meg a Google táblázat beállításait"
 
-#: templates/backoffice/assembly_respondents.html:56
+#: templates/backoffice/assembly_respondents.html:51
 msgid ""
 "Respondent data (participant information) is stored in your Google "
 "Spreadsheet."
 msgstr ""
 
-#: templates/backoffice/assembly_respondents.html:61
-#: templates/backoffice/respondent_field_schema/view.html:58
+#: templates/backoffice/assembly_respondents.html:56
+#: templates/backoffice/respondent_field_schema/view.html:56
 #, fuzzy
 msgid "Initial Selection Respondents Tab:"
 msgstr "Kezdeti/Teszt kiválasztás"
 
-#: templates/backoffice/assembly_respondents.html:63
-#: templates/backoffice/assembly_respondents.html:69
-#: templates/backoffice/assembly_targets.html:61
-#: templates/backoffice/assembly_targets.html:67
-#: templates/backoffice/respondent_field_schema/view.html:61
-#: templates/backoffice/respondent_field_schema/view.html:68
+#: templates/backoffice/assembly_respondents.html:58
+#: templates/backoffice/assembly_respondents.html:64
+#: templates/backoffice/assembly_targets.html:56
+#: templates/backoffice/assembly_targets.html:62
+#: templates/backoffice/respondent_field_schema/view.html:59
+#: templates/backoffice/respondent_field_schema/view.html:66
 #, fuzzy
 msgid "Not configured"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_respondents.html:67
-#: templates/backoffice/respondent_field_schema/view.html:65
+#: templates/backoffice/assembly_respondents.html:62
+#: templates/backoffice/respondent_field_schema/view.html:63
 #, fuzzy
 msgid "Replacement Respondents Tab:"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_respondents.html:75
-#: templates/backoffice/assembly_targets.html:73
-#: templates/backoffice/respondent_field_schema/view.html:73
+#: templates/backoffice/assembly_respondents.html:70
+#: templates/backoffice/assembly_targets.html:68
+#: templates/backoffice/respondent_field_schema/view.html:71
 #, fuzzy
 msgid "View Data Configuration"
 msgstr "Google Táblázat beállításainak eltávolítása"
 
-#: templates/backoffice/assembly_respondents.html:89
+#: templates/backoffice/assembly_respondents.html:84
 #, fuzzy
 msgid "Exported to Google Spreadsheet"
 msgstr "Google táblázat módosítása"
 
-#: templates/backoffice/assembly_respondents.html:101
+#: templates/backoffice/assembly_respondents.html:96
 #: templates/backoffice/components/db_selection_progress_modal.html:20
 #: templates/backoffice/components/manage_tabs_progress_modal.html:18
 #: templates/backoffice/components/replacement_modal.html:49
@@ -5547,53 +5500,52 @@ msgstr "Google táblázat módosítása"
 msgid "Status:"
 msgstr "Állapot"
 
-#: templates/backoffice/assembly_respondents.html:113
-#: templates/backoffice/assembly_view_respondent.html:235
+#: templates/backoffice/assembly_respondents.html:108
+#: templates/backoffice/assembly_view_respondent.html:227
 #: templates/backoffice/components/table.html:212
 #, fuzzy
 msgid "Deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_respondents.html:123
+#: templates/backoffice/assembly_respondents.html:118
 #: templates/backoffice/respondents/export_modal.html:78
 #, fuzzy
 msgid "Export"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_respondents.html:133
+#: templates/backoffice/assembly_respondents.html:128
 msgid "ID"
 msgstr ""
 
-#: templates/backoffice/assembly_respondents.html:166
+#: templates/backoffice/assembly_respondents.html:161
 #: templates/backoffice/showcase/pagination_component.html:33
 #, fuzzy
 msgid "respondents"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_respondents.html:170
+#: templates/backoffice/assembly_respondents.html:165
 msgid "No respondents match the selected status filter."
 msgstr ""
 
-#: templates/backoffice/assembly_respondents.html:172
+#: templates/backoffice/assembly_respondents.html:167
 #, fuzzy
 msgid "No respondents uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_respondents.html:180
+#: templates/backoffice/assembly_respondents.html:175
 #, fuzzy
 msgid "Please configure a data source in the Data tab first."
 msgstr "Adja meg a Google táblázat beállításait"
 
-#: templates/backoffice/assembly_respondents.html:182
-#: templates/backoffice/assembly_selection.html:276
+#: templates/backoffice/assembly_respondents.html:177
+#: templates/backoffice/assembly_selection.html:269
 #, fuzzy
 msgid "Configure Data Source"
 msgstr "További beállítások"
 
 #: templates/backoffice/assembly_selection.html:12
-#: templates/backoffice/assembly_selection.html:18
 #: templates/backoffice/components/assembly_tabs.html:68
-#: templates/backoffice/service_docs.html:47
+#: templates/backoffice/service_docs.html:37
 #: templates/db_selection/select.html:7 templates/gsheets/select.html:2
 #: templates/gsheets/select.html:8 templates/gsheets/select.html:11
 #: templates/main/view_assembly_data.html:13
@@ -5601,58 +5553,54 @@ msgstr "További beállítások"
 msgid "Selection"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_selection.html:26
-msgid "Run selection and manage generated outputs"
-msgstr ""
-
-#: templates/backoffice/assembly_selection.html:60
+#: templates/backoffice/assembly_selection.html:57
 #, fuzzy
 msgid "Go to Data Settings"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_selection.html:65
-#: templates/backoffice/assembly_selection.html:283
+#: templates/backoffice/assembly_selection.html:62
+#: templates/backoffice/assembly_selection.html:275
 #, fuzzy
 msgid "Initial Selection"
 msgstr "Kezdeti/Teszt kiválasztás"
 
-#: templates/backoffice/assembly_selection.html:68
+#: templates/backoffice/assembly_selection.html:65
 msgid ""
 "Run the sortition algorithm to select participants from the uploaded CSV "
 "data based on demographic targets."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:76
-#: templates/backoffice/assembly_selection.html:294
+#: templates/backoffice/assembly_selection.html:73
+#: templates/backoffice/assembly_selection.html:286
 #, fuzzy
 msgid "Number to select:"
 msgstr "Kiválasztandó emberek száma"
 
-#: templates/backoffice/assembly_selection.html:91
+#: templates/backoffice/assembly_selection.html:88
 #, python-format
 msgid "%(count)s respondents have been selected"
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:94
+#: templates/backoffice/assembly_selection.html:91
 msgid ""
 "A selection has already been run. To run a new initial selection, you "
 "must first reset all respondents to Pool status."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:99
+#: templates/backoffice/assembly_selection.html:96
 #, fuzzy
 msgid ""
 "Use 'Check Data' to validate your data before running the actual "
 "selection."
 msgstr "Kezdje a Google táblázat beállításainak megadásával."
 
-#: templates/backoffice/assembly_selection.html:106
-#: templates/backoffice/assembly_selection.html:308
+#: templates/backoffice/assembly_selection.html:103
+#: templates/backoffice/assembly_selection.html:300
 #, fuzzy
 msgid "View Running Selection"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_selection.html:116
+#: templates/backoffice/assembly_selection.html:113
 #, fuzzy
 msgid ""
 "Are you sure you want to reset all selected respondents to Pool status? "
@@ -5661,40 +5609,40 @@ msgstr ""
 "Biztos, hogy el akarja távolítani ehhez a Google Táblázathoz tartozó "
 "beállításokat? Ez a művelet nem vonható vissza."
 
-#: templates/backoffice/assembly_selection.html:118
+#: templates/backoffice/assembly_selection.html:115
 #, fuzzy
 msgid "Reset Selected People"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_selection.html:124
-#: templates/backoffice/assembly_selection.html:131
+#: templates/backoffice/assembly_selection.html:121
+#: templates/backoffice/assembly_selection.html:128
 msgid "Check Data"
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:137
-#: templates/backoffice/assembly_selection.html:322
+#: templates/backoffice/assembly_selection.html:134
+#: templates/backoffice/assembly_selection.html:314
 #: templates/db_selection/select.html:92 templates/gsheets/select.html:33
 #, fuzzy
 msgid "Run Test Selection"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_selection.html:143
-#: templates/backoffice/assembly_selection.html:328
+#: templates/backoffice/assembly_selection.html:140
+#: templates/backoffice/assembly_selection.html:320
 #: templates/db_selection/select.html:87 templates/gsheets/select.html:27
 #, fuzzy
 msgid "Run Selection"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_selection.html:149
-#: templates/backoffice/assembly_selection.html:334
+#: templates/backoffice/assembly_selection.html:146
+#: templates/backoffice/assembly_selection.html:326
 #: templates/backoffice/components/replacement_modal.html:28
 #: templates/db_selection/replace.html:11
 #, fuzzy
 msgid "Replacement Selection"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_selection.html:152
-#: templates/backoffice/assembly_selection.html:337
+#: templates/backoffice/assembly_selection.html:149
+#: templates/backoffice/assembly_selection.html:329
 #: templates/backoffice/components/replacement_modal.html:36
 #: templates/backoffice/components/replacement_modal.html:55
 msgid ""
@@ -5702,36 +5650,36 @@ msgid ""
 "cannot participate."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:155
+#: templates/backoffice/assembly_selection.html:152
 msgid "Replacement selection for CSV data will be available in a future update."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:159
+#: templates/backoffice/assembly_selection.html:156
 msgid "Coming Soon"
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:165
-#: templates/backoffice/assembly_selection.html:350
+#: templates/backoffice/assembly_selection.html:162
+#: templates/backoffice/assembly_selection.html:342
 #, fuzzy
 msgid "Selection History"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_selection.html:176
-#: templates/backoffice/assembly_selection.html:361
+#: templates/backoffice/assembly_selection.html:173
+#: templates/backoffice/assembly_selection.html:353
 #: templates/main/view_assembly_data.html:55
 #, fuzzy
 msgid "Task Type"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_selection.html:178
-#: templates/backoffice/assembly_selection.html:363
+#: templates/backoffice/assembly_selection.html:175
+#: templates/backoffice/assembly_selection.html:355
 #: templates/main/view_assembly_data.html:56
 #, fuzzy
 msgid "Started By"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_selection.html:180
-#: templates/backoffice/assembly_selection.html:365
+#: templates/backoffice/assembly_selection.html:177
+#: templates/backoffice/assembly_selection.html:357
 #: templates/backoffice/components/db_selection_progress_modal.html:91
 #: templates/backoffice/components/replacement_modal.html:143
 #: templates/backoffice/components/selection_progress_modal.html:63
@@ -5741,8 +5689,8 @@ msgstr "Elkezdve"
 msgid "Started At"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_selection.html:182
-#: templates/backoffice/assembly_selection.html:367
+#: templates/backoffice/assembly_selection.html:179
+#: templates/backoffice/assembly_selection.html:359
 #: templates/backoffice/components/db_selection_progress_modal.html:94
 #: templates/backoffice/components/replacement_modal.html:146
 #: templates/backoffice/components/selection_progress_modal.html:66
@@ -5752,73 +5700,73 @@ msgstr "Elkezdve"
 msgid "Completed At"
 msgstr "Befejezve"
 
-#: templates/backoffice/assembly_selection.html:184
-#: templates/backoffice/assembly_selection.html:369
-#: templates/backoffice/assembly_view_respondent.html:249
+#: templates/backoffice/assembly_selection.html:181
+#: templates/backoffice/assembly_selection.html:361
+#: templates/backoffice/assembly_view_respondent.html:241
 #: templates/main/view_assembly_data.html:59
 msgid "Comment"
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:226
+#: templates/backoffice/assembly_selection.html:223
 #, fuzzy
 msgid "Download selected CSV"
 msgstr "Táblázat lapfülei"
 
-#: templates/backoffice/assembly_selection.html:254
-#: templates/backoffice/assembly_selection.html:419
+#: templates/backoffice/assembly_selection.html:251
+#: templates/backoffice/assembly_selection.html:411
 #: templates/backoffice/showcase/pagination_component.html:66
 msgid "runs"
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:259
-#: templates/backoffice/assembly_selection.html:424
+#: templates/backoffice/assembly_selection.html:256
+#: templates/backoffice/assembly_selection.html:416
 #, fuzzy
 msgid "No selection runs yet"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_selection.html:261
-#: templates/backoffice/assembly_selection.html:426
+#: templates/backoffice/assembly_selection.html:258
+#: templates/backoffice/assembly_selection.html:418
 msgid "Run your first selection above to see the history here."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:274
+#: templates/backoffice/assembly_selection.html:267
 #, fuzzy
 msgid ""
 "Please use the Data tab to tell us about your data, before running a "
 "selection."
 msgstr "Kezdje a Google táblázat beállításainak megadásával."
 
-#: templates/backoffice/assembly_selection.html:286
+#: templates/backoffice/assembly_selection.html:278
 msgid ""
 "Run the sortition algorithm to select participants from the initial pool "
 "based on demographic targets."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:303
+#: templates/backoffice/assembly_selection.html:295
 msgid ""
 "Use 'Check Spreadsheet' to validate your data before running the actual "
 "selection."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:316
+#: templates/backoffice/assembly_selection.html:308
 #: templates/backoffice/components/replacement_modal.html:44
 #: templates/gsheets/replace.html:22 templates/gsheets/select.html:40
 #, fuzzy
 msgid "Check Spreadsheet"
 msgstr "Táblázat megtekintése"
 
-#: templates/backoffice/assembly_selection.html:340
+#: templates/backoffice/assembly_selection.html:332
 msgid ""
 "First check the spreadsheet to see how many replacement participants are "
 "available, then specify how many to select."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:344
+#: templates/backoffice/assembly_selection.html:336
 #, fuzzy
 msgid "Go to Replacement Selection"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_selection.html:439
+#: templates/backoffice/assembly_selection.html:431
 #: templates/gsheets/manage_tabs.html:2 templates/gsheets/manage_tabs.html:8
 #: templates/gsheets/manage_tabs.html:11 templates/gsheets/replace.html:16
 #: templates/gsheets/select.html:47 templates/main/view_assembly_data.html:21
@@ -5826,232 +5774,227 @@ msgstr "Kieső emberek pótlása új kiválasztással"
 msgid "Manage Generated Tabs"
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:442
+#: templates/backoffice/assembly_selection.html:434
 #, fuzzy
 msgid "View and delete old selection output tabs from your Google Spreadsheet."
 msgstr ""
 "Futtassa a demokratikus sorsolást ehhez a gyűléshez Google Táblázat "
 "adatainak felhasználásával."
 
-#: templates/backoffice/assembly_selection.html:445
+#: templates/backoffice/assembly_selection.html:437
 msgid ""
 "Each selection run creates new tabs in your spreadsheet. Use this to "
 "clean up old tabs that are no longer needed."
 msgstr ""
 
-#: templates/backoffice/assembly_selection.html:453
+#: templates/backoffice/assembly_selection.html:445
 #: templates/gsheets/manage_tabs.html:41
 msgid "List Old Tabs"
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:28
-#, fuzzy
-msgid "Configure selection targets for this assembly"
-msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
-
-#: templates/backoffice/assembly_targets.html:52
+#: templates/backoffice/assembly_targets.html:47
 #, fuzzy
 msgid "Targets are configured in Google Sheets"
 msgstr "Adja meg a Google táblázat beállításait"
 
-#: templates/backoffice/assembly_targets.html:54
+#: templates/backoffice/assembly_targets.html:49
 msgid ""
 "Selection targets (demographic categories and quotas) are defined in your"
 " Google Spreadsheet."
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:59
+#: templates/backoffice/assembly_targets.html:54
 #, fuzzy
 msgid "Initial Selection Categories Tab:"
 msgstr "Kezdeti/Teszt kiválasztás"
 
-#: templates/backoffice/assembly_targets.html:65
+#: templates/backoffice/assembly_targets.html:60
 #, fuzzy
 msgid "Replacement Categories Tab:"
 msgstr "Kategóriákat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_targets.html:84
+#: templates/backoffice/assembly_targets.html:79
 #: templates/targets/view_targets.html:4
 #, fuzzy
 msgid "Target Categories"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_targets.html:87
+#: templates/backoffice/assembly_targets.html:82
 #: templates/targets/view_targets.html:6
 #, python-format
 msgid "%(count)s categories defined."
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:91
+#: templates/backoffice/assembly_targets.html:86
 #: templates/targets/view_targets.html:8
 #, fuzzy
 msgid "No target categories defined yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_targets.html:99
+#: templates/backoffice/assembly_targets.html:94
 #: templates/targets/view_targets.html:18
 #, fuzzy
 msgid "Check targets in detail"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_targets.html:109
+#: templates/backoffice/assembly_targets.html:104
 #, python-format
 msgid ""
 "All checks passed. Found %(num_features)s target categories and "
 "%(num_people)s eligible respondents. Targets are ready for selection."
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:118
+#: templates/backoffice/assembly_targets.html:113
 #: templates/targets/view_targets.html:41
 #: templates/targets/view_targets.html:52
 #: templates/targets/view_targets.html:61
 msgid "Target check found problems"
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:126
+#: templates/backoffice/assembly_targets.html:121
 msgid ""
 "Target check found problems. See details below next to the affected "
 "targets."
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:159
+#: templates/backoffice/assembly_targets.html:154
 #: templates/targets/view_targets.html:198
 msgid "Import from CSV"
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:163
+#: templates/backoffice/assembly_targets.html:158
 #: templates/targets/view_targets.html:202
 msgid "Upload a CSV file with columns either:"
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:166
+#: templates/backoffice/assembly_targets.html:161
 #: templates/targets/view_targets.html:204
 msgid "category, name, min, max."
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:167
+#: templates/backoffice/assembly_targets.html:162
 #: templates/targets/view_targets.html:206
 msgid "feature, value, min, max."
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:170
+#: templates/backoffice/assembly_targets.html:165
 #: templates/targets/view_targets.html:213
 msgid "Uploading a CSV will replace all existing target categories."
 msgstr ""
 
-#: templates/backoffice/assembly_targets.html:195
+#: templates/backoffice/assembly_targets.html:190
 #: templates/respondents/view_respondents.html:78
 #: templates/targets/view_targets.html:252
 msgid "Upload CSV"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:36
+#: templates/backoffice/assembly_view_respondent.html:19
+#, fuzzy
+msgid "Back to respondents"
+msgstr "Válaszadókat tartalmazó lapful neve"
+
+#: templates/backoffice/assembly_view_respondent.html:35
 msgid "(derivation not yet implemented)"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:98
-#, fuzzy
-msgid "Respondent details"
-msgstr "Válaszadókat tartalmazó lapful neve"
-
-#: templates/backoffice/assembly_view_respondent.html:102
+#: templates/backoffice/assembly_view_respondent.html:94
 msgid "Personal data deleted"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:106
+#: templates/backoffice/assembly_view_respondent.html:98
 #, python-format
 msgid "Deleted on %(date)s by %(who)s"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:110
+#: templates/backoffice/assembly_view_respondent.html:102
 #, fuzzy, python-format
 msgid "Deleted on %(date)s"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_view_respondent.html:119
+#: templates/backoffice/assembly_view_respondent.html:111
 msgid "External ID:"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:165
+#: templates/backoffice/assembly_view_respondent.html:157
 msgid "Contact and eligibility"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:175
+#: templates/backoffice/assembly_view_respondent.html:167
 #: templates/respondents/view_respondents.html:166
 msgid "Eligible"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:176
+#: templates/backoffice/assembly_view_respondent.html:168
 msgid "Can attend"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:178
+#: templates/backoffice/assembly_view_respondent.html:170
 msgid "Stay on database"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:204
+#: templates/backoffice/assembly_view_respondent.html:196
 #, fuzzy
 msgid "Attributes"
 msgstr "Megtartandó oszlopok"
 
-#: templates/backoffice/assembly_view_respondent.html:212
+#: templates/backoffice/assembly_view_respondent.html:204
 #, fuzzy
 msgid "No attributes recorded."
 msgstr "Megtartandó oszlopok"
 
-#: templates/backoffice/assembly_view_respondent.html:223
+#: templates/backoffice/assembly_view_respondent.html:215
 #, fuzzy
 msgid "Activity"
 msgstr "Aktív gyűlések"
 
-#: templates/backoffice/assembly_view_respondent.html:233
+#: templates/backoffice/assembly_view_respondent.html:225
 #, fuzzy
 msgid "Status change"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_view_respondent.html:238
+#: templates/backoffice/assembly_view_respondent.html:230
 #, fuzzy
 msgid "CSV import"
 msgstr "Fontos"
 
-#: templates/backoffice/assembly_view_respondent.html:239
+#: templates/backoffice/assembly_view_respondent.html:231
 msgid "manual entry"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:240
+#: templates/backoffice/assembly_view_respondent.html:232
 #, fuzzy
 msgid "registration form"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_view_respondent.html:241
+#: templates/backoffice/assembly_view_respondent.html:233
 msgid "NationBuilder sync"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:246
+#: templates/backoffice/assembly_view_respondent.html:238
 msgid "When"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:247
+#: templates/backoffice/assembly_view_respondent.html:239
 msgid "Author"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:275
+#: templates/backoffice/assembly_view_respondent.html:267
 #, fuzzy, python-format
 msgid "Created via %(source)s"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_view_respondent.html:281
+#: templates/backoffice/assembly_view_respondent.html:273
 #, fuzzy
 msgid "No activity recorded."
 msgstr "Megtartandó oszlopok"
 
-#: templates/backoffice/assembly_view_respondent.html:289
-#: templates/backoffice/assembly_view_respondent.html:294
+#: templates/backoffice/assembly_view_respondent.html:281
+#: templates/backoffice/assembly_view_respondent.html:286
 #, fuzzy
 msgid "Delete personal data"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_view_respondent.html:291
+#: templates/backoffice/assembly_view_respondent.html:283
 msgid ""
 "Under GDPR, a person may request that their personal data be deleted. "
 "This action blanks the respondent's contact details, attribute values, "
@@ -6059,36 +6002,48 @@ msgid ""
 "selection can still reference them. This action is irreversible."
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:301
+#: templates/backoffice/assembly_view_respondent.html:293
 #: templates/backoffice/components/respondent_status_form.html:78
 msgid "Reason (required)"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:307
+#: templates/backoffice/assembly_view_respondent.html:299
 msgid "e.g. GDPR deletion request from the participant"
 msgstr ""
 
-#: templates/backoffice/assembly_view_respondent.html:309
+#: templates/backoffice/assembly_view_respondent.html:301
 #, fuzzy
 msgid "Confirm delete"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_view_respondent.html:320
+#: templates/backoffice/assembly_view_respondent.html:312
 #, fuzzy
 msgid "Back to Respondents"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/create_assembly.html:9
-#: templates/backoffice/create_assembly.html:15
-#: templates/backoffice/create_assembly.html:22
-#: templates/backoffice/create_assembly.html:29
+#: templates/backoffice/base_page.html:28
+msgid "Help (knowledge hub)"
+msgstr ""
+
+#: templates/backoffice/base_page.html:32
+#, fuzzy
+msgid "My account"
+msgstr "Hozzon létre fiókot"
+
+#: templates/backoffice/base_page.html:33
+msgid "Switch to site admin"
+msgstr ""
+
+#: templates/backoffice/create_assembly.html:8
+#: templates/backoffice/create_assembly.html:12
+#: templates/backoffice/create_assembly.html:19
 #: templates/main/create_assembly.html:2 templates/main/create_assembly.html:13
 #: templates/main/create_assembly.html:34
 #: templates/main/create_assembly.html:95 templates/main/dashboard.html:24
 msgid "Create Assembly"
 msgstr "Hozzon létre közösségi gyűlést"
 
-#: templates/backoffice/create_assembly.html:24
+#: templates/backoffice/create_assembly.html:14
 #, fuzzy
 msgid "Set up a new citizens' assembly."
 msgstr "Közösségi gyűlések"
@@ -6118,257 +6073,256 @@ msgstr ""
 msgid "Create Your First Assembly"
 msgstr "Hozzon létre közösségi gyűlést"
 
-#: templates/backoffice/dev_dashboard.html:9
-#: templates/backoffice/dev_dashboard.html:15
-#: templates/backoffice/dev_dashboard.html:22
-#: templates/backoffice/patterns.html:17
-#: templates/backoffice/service_docs.html:16
+#: templates/backoffice/dev_dashboard.html:8
+#: templates/backoffice/dev_dashboard.html:12
 msgid "Developer Tools"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:25
+#: templates/backoffice/dev_dashboard.html:15
 msgid "Interactive documentation and testing tools for development."
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:31
+#: templates/backoffice/dev_dashboard.html:21
 msgid "Development Only"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:32
+#: templates/backoffice/dev_dashboard.html:22
 msgid "These tools are disabled in production and only available to admin users."
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:38
+#: templates/backoffice/dev_dashboard.html:28
 msgid "Documentation & Testing"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:44
+#: templates/backoffice/dev_dashboard.html:34
 msgid "Service Layer Docs"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:45
+#: templates/backoffice/dev_dashboard.html:35
 msgid "CSV Upload Services"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:49
+#: templates/backoffice/dev_dashboard.html:39
 msgid ""
 "Interactive documentation for CSV upload service layer functions. Test "
 "import_respondents, import_targets, and CSV config services."
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:52
+#: templates/backoffice/dev_dashboard.html:42
 msgid "4 services documented"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:59
-#: templates/backoffice/patterns.html:11 templates/backoffice/patterns.html:28
+#: templates/backoffice/dev_dashboard.html:49
+#: templates/backoffice/patterns.html:10 templates/backoffice/patterns.html:17
 msgid "Frontend Patterns"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:60
+#: templates/backoffice/dev_dashboard.html:50
 msgid "Alpine.js & CSP Guidelines"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:64
+#: templates/backoffice/dev_dashboard.html:54
 msgid ""
 "Living documentation for CSP-compatible Alpine.js patterns. Includes "
 "dropdown bindings, form state, and AJAX with working examples."
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:67
+#: templates/backoffice/dev_dashboard.html:57
 msgid "Patterns with implementation index"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:74
+#: templates/backoffice/dev_dashboard.html:64
 msgid "Component Showcase"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:75
+#: templates/backoffice/dev_dashboard.html:65
 msgid "Design System Reference"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:79
+#: templates/backoffice/dev_dashboard.html:69
 msgid ""
 "Visual reference for all backoffice UI components. Buttons, cards, forms,"
 " modals, typography, and color tokens."
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:82
+#: templates/backoffice/dev_dashboard.html:72
 msgid "All components in one place"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:90
+#: templates/backoffice/dev_dashboard.html:80
 msgid "Quick Reference"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:95
+#: templates/backoffice/dev_dashboard.html:85
 msgid "Project guidance for AI assistants (includes Alpine.js CSP constraints)"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:99
+#: templates/backoffice/dev_dashboard.html:89
 msgid "Agent-specific documentation for frontend, testing, and code quality"
 msgstr ""
 
-#: templates/backoffice/dev_dashboard.html:103
+#: templates/backoffice/dev_dashboard.html:93
 msgid "Reusable Alpine.js components (urlSelect, autocomplete, modal)"
 msgstr ""
 
-#: templates/backoffice/edit_assembly.html:71
+#: templates/backoffice/edit_assembly.html:60
 #: templates/main/edit_assembly.html:24
 msgid "Update the details for this citizens' assembly."
 msgstr "Frissítse a közösségi gyűlés részleteit."
 
-#: templates/backoffice/edit_assembly.html:82
+#: templates/backoffice/edit_assembly.html:71
 #, fuzzy
 msgid "Registration URLs"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/edit_assembly.html:84
+#: templates/backoffice/edit_assembly.html:73
 msgid "Configure the URLs for your public registration form."
 msgstr ""
 
-#: templates/backoffice/edit_assembly.html:90
+#: templates/backoffice/edit_assembly.html:79
 msgid ""
 "These URLs are locked while the registration page is published or closed,"
 " so links shared in invites, QR codes, and elsewhere keep working. Switch"
 " the form back to test mode from the Registration tab to edit them."
 msgstr ""
 
-#: templates/backoffice/edit_assembly.html:101
+#: templates/backoffice/edit_assembly.html:90
 msgid "The URL path for your registration form"
 msgstr ""
 
-#: templates/backoffice/edit_assembly.html:111
+#: templates/backoffice/edit_assembly.html:100
 #, fuzzy
 msgid "Short URL (optional)"
 msgstr "Email cím"
 
-#: templates/backoffice/patterns.html:18
-msgid "Patterns"
-msgstr ""
-
-#: templates/backoffice/patterns.html:31
+#: templates/backoffice/patterns.html:20
 msgid ""
 "Living documentation for Alpine.js patterns used in the backoffice. Each "
 "pattern includes working examples, code snippets, and links to "
 "implementations."
 msgstr ""
 
-#: templates/backoffice/patterns.html:34
+#: templates/backoffice/patterns.html:23
 msgid "Tip"
 msgstr ""
 
-#: templates/backoffice/patterns.html:35
+#: templates/backoffice/patterns.html:24
 msgid "These patterns are CSP-compatible and work with the Alpine.js CSP build."
 msgstr ""
 
-#: templates/backoffice/patterns.html:43
+#: templates/backoffice/patterns.html:32
 msgid "Dropdown"
 msgstr ""
 
-#: templates/backoffice/patterns.html:44
+#: templates/backoffice/patterns.html:33
 #, fuzzy
 msgid "Form State"
 msgstr "Keresztnév"
 
-#: templates/backoffice/patterns.html:45
+#: templates/backoffice/patterns.html:34
 msgid "AJAX"
 msgstr ""
 
-#: templates/backoffice/patterns.html:46
+#: templates/backoffice/patterns.html:35
 msgid "File Upload"
 msgstr ""
 
-#: templates/backoffice/patterns.html:47
+#: templates/backoffice/patterns.html:36
 #, fuzzy
 msgid "Progress"
 msgstr "Feladat folyamatban"
 
-#: templates/backoffice/patterns.html:48
+#: templates/backoffice/patterns.html:37
 #, fuzzy
 msgid "Pagination"
 msgstr "Google Táblázat beállításainak eltávolítása"
 
-#: templates/backoffice/patterns.html:49
+#: templates/backoffice/patterns.html:38
 #, fuzzy
 msgid "Scroll"
 msgstr "Szereped/jogosultságod"
 
-#: templates/backoffice/patterns.html:50
+#: templates/backoffice/patterns.html:39
 msgid "Focus"
 msgstr ""
 
-#: templates/backoffice/patterns.html:51
+#: templates/backoffice/patterns.html:40
 msgid "Floating Alerts"
 msgstr ""
 
-#: templates/backoffice/patterns.html:52
+#: templates/backoffice/patterns.html:41
 #, fuzzy
 msgid "Custom Components"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/patterns.html:53
+#: templates/backoffice/patterns.html:42
 #: templates/backoffice/patterns/_stepper.html:12
 msgid "Stepper"
 msgstr ""
 
-#: templates/backoffice/patterns.html:55
+#: templates/backoffice/patterns.html:44
 #, fuzzy
 msgid "Pattern categories"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/service_docs.html:11
-#: templates/backoffice/service_docs.html:27
+#: templates/backoffice/service_docs.html:10
+#: templates/backoffice/service_docs.html:17
 #, fuzzy
 msgid "Service Layer Documentation"
 msgstr "Csapat beállítás"
 
-#: templates/backoffice/service_docs.html:17
-msgid "Service Docs"
-msgstr ""
-
-#: templates/backoffice/service_docs.html:30
+#: templates/backoffice/service_docs.html:20
 msgid ""
 "Interactive testing console for service layer functions. Execute services"
 " directly and inspect responses."
 msgstr ""
 
-#: templates/backoffice/service_docs.html:33
+#: templates/backoffice/service_docs.html:23
 msgid "Admin Only"
 msgstr ""
 
-#: templates/backoffice/service_docs.html:34
+#: templates/backoffice/service_docs.html:24
 msgid "This page allows direct database modifications. Use with caution."
 msgstr ""
 
+#: templates/backoffice/components/assembly_tabs.html:55
+#: templates/backoffice/service_docs.html:32
+#, fuzzy
+msgid "Registration"
+msgstr "Vissza a regisztrációhoz"
+
 #: templates/backoffice/components/assembly_tabs.html:42
 #: templates/backoffice/respondent_field_schema/view.html:9
-#: templates/backoffice/respondent_field_schema/view.html:15
-#: templates/backoffice/service_docs.html:43
+#: templates/backoffice/service_docs.html:33
 msgid "Fields"
 msgstr ""
 
-#: templates/backoffice/service_docs.html:46
+#: templates/backoffice/service_docs.html:36
 #, fuzzy
 msgid "CSV Config"
 msgstr "Beállítások mentése"
 
-#: templates/backoffice/service_docs.html:50
+#: templates/backoffice/service_docs.html:40
 #, fuzzy
 msgid "Emails"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/service_docs.html:52
+#: templates/backoffice/service_docs.html:42
 #, fuzzy
 msgid "Service categories"
 msgstr "Feladat állapota"
 
-#: templates/backoffice/showcase.html:63 templates/backoffice/showcase.html:78
+#: templates/backoffice/showcase.html:66 templates/backoffice/showcase.html:81
 #, fuzzy
 msgid "Jump to section"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/components/alert.html:84
+#: templates/backoffice/components/account_menu.html:43
+#, fuzzy
+msgid "Account menu"
+msgstr "Feladat állapota"
+
+#: templates/backoffice/components/alert.html:86
 msgid "Dismiss"
 msgstr ""
 
@@ -6509,12 +6463,12 @@ msgstr "Kiválasztandó emberek száma"
 msgid "Enter a positive number"
 msgstr ""
 
-#: templates/backoffice/components/footer.html:23
+#: templates/backoffice/components/footer.html:20
 #, fuzzy
 msgid "Old Dashboard"
 msgstr "Irányító pult"
 
-#: templates/backoffice/components/footer.html:27
+#: templates/backoffice/components/footer.html:24
 msgid "Version"
 msgstr ""
 
@@ -7090,7 +7044,7 @@ msgid "Flask Route Code"
 msgstr ""
 
 #: templates/backoffice/patterns/_file_upload.html:155
-#: templates/backoffice/patterns/_floating_alerts.html:91
+#: templates/backoffice/patterns/_floating_alerts.html:92
 #: templates/backoffice/patterns/_focus.html:152
 #: templates/backoffice/patterns/_pagination.html:108
 #: templates/backoffice/patterns/_scroll.html:237
@@ -7132,9 +7086,10 @@ msgstr ""
 
 #: templates/backoffice/patterns/_floating_alerts.html:11
 msgid ""
-"Flash messages in the backoffice appear as floating alerts at the bottom-"
-"right of the viewport. This ensures users see feedback without scrolling "
-"to the top of the page."
+"Flash messages in the backoffice appear as floating alerts at the top-"
+"centre of the viewport, just below the top. This ensures users see "
+"feedback without scrolling. They sit above the sticky header and below "
+"modal dialogs."
 msgstr ""
 
 #: templates/backoffice/patterns/_floating_alerts.html:16
@@ -7155,106 +7110,188 @@ msgid "Non-blocking"
 msgstr ""
 
 #: templates/backoffice/patterns/_floating_alerts.html:19
-msgid "Positioned at bottom-right to avoid covering content"
+msgid ""
+"A top-centre overlay that clears the sticky header and never covers modal"
+" dialogs"
 msgstr ""
 
 #: templates/backoffice/patterns/_floating_alerts.html:20
-#: templates/backoffice/patterns/_floating_alerts.html:95
-msgid "Dismissible"
+msgid "Self-clearing"
 msgstr ""
 
 #: templates/backoffice/patterns/_floating_alerts.html:20
-msgid "All floating alerts can be closed by the user"
+msgid ""
+"Low-severity alerts auto-dismiss so they don't pile up; errors stay until"
+" acknowledged"
 msgstr ""
 
 #: templates/backoffice/patterns/_floating_alerts.html:21
+#: templates/backoffice/patterns/_floating_alerts.html:97
+msgid "Dismissible"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:21
+msgid "All floating alerts can be closed by the user"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:22
 #, fuzzy
 msgid "Accessible"
 msgstr "Hozzáférés megtagadva"
 
-#: templates/backoffice/patterns/_floating_alerts.html:21
+#: templates/backoffice/patterns/_floating_alerts.html:22
 msgid "Uses aria-live='polite' for screen reader announcements"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:27
+#: templates/backoffice/patterns/_floating_alerts.html:28
 #: templates/backoffice/patterns/_scroll.html:66
 #, fuzzy
 msgid "Source Files"
 msgstr "Sikerült"
 
-#: templates/backoffice/patterns/_floating_alerts.html:29
+#: templates/backoffice/patterns/_floating_alerts.html:30
 msgid "Floating alerts macro"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:30
+#: templates/backoffice/patterns/_floating_alerts.html:31
 msgid "Alert component with floating parameter"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:31
+#: templates/backoffice/patterns/_floating_alerts.html:32
 msgid "Includes floating_alerts() after main content"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:42
+#: templates/backoffice/patterns/_floating_alerts.html:43
 msgid ""
-"Click the buttons below to trigger flash messages. The alerts will appear"
-" at the bottom-right of the viewport."
+"Click the buttons below to trigger flash messages. The alerts appear at "
+"the top-centre and, except for errors, dismiss themselves after a few "
+"seconds (hover to pause the countdown)."
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:54
+#: templates/backoffice/patterns/_floating_alerts.html:55
 #, fuzzy
 msgid "Success Alert"
 msgstr "Sikerült"
 
-#: templates/backoffice/patterns/_floating_alerts.html:64
+#: templates/backoffice/patterns/_floating_alerts.html:65
 #, fuzzy
 msgid "Warning Alert"
 msgstr "Folyamatban"
 
-#: templates/backoffice/patterns/_floating_alerts.html:74
+#: templates/backoffice/patterns/_floating_alerts.html:75
 #, fuzzy
 msgid "Error Alert"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/patterns/_floating_alerts.html:84
+#: templates/backoffice/patterns/_floating_alerts.html:85
 msgid "Info Alert"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:93
-msgid "Below modals (z-40/z-50) but above page content"
-msgstr ""
+#: templates/backoffice/patterns/_floating_alerts.html:94
+#, fuzzy
+msgid "Layering"
+msgstr "Folyamatban"
 
 #: templates/backoffice/patterns/_floating_alerts.html:94
-msgid "Screen readers announce new alerts without interrupting"
+msgid ""
+"z-index 45 (set in main.css, documented next to the modal z-indexes) — "
+"above the sticky header (z-40), below modal dialogs (z-50)"
 msgstr ""
 
 #: templates/backoffice/patterns/_floating_alerts.html:95
+#: templates/backoffice/patterns/_floating_alerts.html:115
+msgid "Auto-dismiss"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:95
+msgid ""
+"success 4s, info 6s, warning 10s; errors stay until closed. Hover pauses "
+"the countdown."
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:96
+msgid "Screen readers announce new alerts without interrupting"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:97
 msgid "All floating alerts have a close button"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:96
+#: templates/backoffice/patterns/_floating_alerts.html:98
 msgid "No bottom margin"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:96
+#: templates/backoffice/patterns/_floating_alerts.html:98
 msgid "Uses floating=true parameter; gap handled by container"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:107
+#: templates/backoffice/patterns/_floating_alerts.html:108
+msgid ""
+"Floating alerts clear themselves based on severity, so transient "
+"confirmations don't linger while important errors stay put. Hovering an "
+"alert pauses its countdown."
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:114
+msgid "Variant"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:116
+#, fuzzy
+msgid "Rationale"
+msgstr "Kiválasztás"
+
+#: templates/backoffice/patterns/_floating_alerts.html:123
+msgid "A confirmation the user rarely needs to re-read"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:126
+msgid "Info"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:128
+msgid "Contextual, slightly longer to read"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:133
+msgid "Deserves attention but is not blocking"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:137
+msgid "Never — until closed"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:138
+msgid "Must be acknowledged by the user"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:144
+msgid "How it works"
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:146
+msgid ""
+"Durations live in floating_alerts.html. The alert() macro takes an "
+"auto_dismiss_ms parameter and, when set, uses the autoDismissAlert Alpine"
+" component — a CSP-safe setTimeout wrapper that pauses on hover."
+msgstr ""
+
+#: templates/backoffice/patterns/_floating_alerts.html:157
 msgid ""
 "Floating alerts are automatically included in "
 "<code>base_page.html</code>. Just use Flask's <code>flash()</code> "
 "function."
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:112
+#: templates/backoffice/patterns/_floating_alerts.html:162
 msgid "Python (Route Handler)"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:124
+#: templates/backoffice/patterns/_floating_alerts.html:174
 msgid "Template (Automatic in base_page.html)"
 msgstr ""
 
-#: templates/backoffice/patterns/_floating_alerts.html:137
+#: templates/backoffice/patterns/_floating_alerts.html:187
 #, fuzzy
 msgid "Alert Component Options"
 msgstr "Kiválasztás"
@@ -8028,26 +8065,19 @@ msgstr ""
 msgid "Panel convention (same as tabs macro)"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:22
-msgid ""
-"Group, order, and label the fields that describe your respondents. These "
-"settings drive how respondent details are displayed and will seed the "
-"registration form when it is created."
-msgstr ""
-
-#: templates/backoffice/respondent_field_schema/view.html:52
+#: templates/backoffice/respondent_field_schema/view.html:50
 #, fuzzy
 msgid "Fields are defined by your Google Spreadsheet"
 msgstr "Adja meg a Google táblázat beállításait"
 
-#: templates/backoffice/respondent_field_schema/view.html:54
+#: templates/backoffice/respondent_field_schema/view.html:52
 msgid ""
 "The fields for this assembly are the columns in the respondent tabs of "
 "your Google Spreadsheet. Edit the spreadsheet to add, remove, or rename "
 "fields."
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:82
+#: templates/backoffice/respondent_field_schema/view.html:80
 msgid ""
 "No schema has been set up for this assembly yet. Upload a CSV of "
 "respondents to seed one automatically from the CSV headers, or click "
@@ -8055,232 +8085,231 @@ msgid ""
 "consent, eligibility, etc)."
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:87
+#: templates/backoffice/respondent_field_schema/view.html:85
 msgid "Initialise empty schema"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:99
+#: templates/backoffice/respondent_field_schema/view.html:97
 msgid "Guess field types from data"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:101
+#: templates/backoffice/respondent_field_schema/view.html:99
 msgid ""
 "Only fields still set to Text will be updated; explicitly-typed fields "
 "are left alone."
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:135
-#: templates/backoffice/respondent_field_schema/view.html:158
-#: templates/backoffice/respondent_field_schema/view.html:336
-#: templates/backoffice/respondent_field_schema/view.html:364
+#: templates/backoffice/respondent_field_schema/view.html:133
+#: templates/backoffice/respondent_field_schema/view.html:156
+#: templates/backoffice/respondent_field_schema/view.html:334
+#: templates/backoffice/respondent_field_schema/view.html:362
 #, fuzzy
 msgid "Section"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/respondent_field_schema/view.html:136
-#: templates/backoffice/respondent_field_schema/view.html:175
-#: templates/backoffice/respondent_field_schema/view.html:337
-#: templates/backoffice/respondent_field_schema/view.html:372
+#: templates/backoffice/respondent_field_schema/view.html:134
+#: templates/backoffice/respondent_field_schema/view.html:173
+#: templates/backoffice/respondent_field_schema/view.html:335
+#: templates/backoffice/respondent_field_schema/view.html:370
 #: templates/backoffice/service_docs/_fields.html:125
 #, fuzzy
 msgid "Field Type"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/respondent_field_schema/view.html:137
-#: templates/backoffice/respondent_field_schema/view.html:338
-#: templates/backoffice/respondent_field_schema/view.html:380
+#: templates/backoffice/respondent_field_schema/view.html:135
+#: templates/backoffice/respondent_field_schema/view.html:336
+#: templates/backoffice/respondent_field_schema/view.html:378
 #, fuzzy
 msgid "On registration form"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/respondent_field_schema/view.html:138
-#: templates/backoffice/respondent_field_schema/view.html:354
+#: templates/backoffice/respondent_field_schema/view.html:136
+#: templates/backoffice/respondent_field_schema/view.html:352
 msgid "Field key"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:139
+#: templates/backoffice/respondent_field_schema/view.html:137
 msgid "Order"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:152
+#: templates/backoffice/respondent_field_schema/view.html:150
 #, python-format
 msgid "Label for %(key)s"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:170
+#: templates/backoffice/respondent_field_schema/view.html:168
 msgid "Fixed"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:184
+#: templates/backoffice/respondent_field_schema/view.html:182
 msgid "Derived"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:193
+#: templates/backoffice/respondent_field_schema/view.html:191
 #, fuzzy, python-format
 msgid "On registration form for %(key)s"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/respondent_field_schema/view.html:215
+#: templates/backoffice/respondent_field_schema/view.html:213
 msgid "Move up"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:224
+#: templates/backoffice/respondent_field_schema/view.html:222
 msgid "Move down"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:237
+#: templates/backoffice/respondent_field_schema/view.html:235
 msgid ""
 "Remove this field from the schema? Respondent data keeps its values; they"
 " just stop being rendered."
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:248
+#: templates/backoffice/respondent_field_schema/view.html:246
 #, python-format
 msgid "Options for %(label)s"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:264
-#: templates/backoffice/respondent_field_schema/view.html:296
+#: templates/backoffice/respondent_field_schema/view.html:262
+#: templates/backoffice/respondent_field_schema/view.html:294
 #, fuzzy
 msgid "Option value"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/respondent_field_schema/view.html:269
-#: templates/backoffice/respondent_field_schema/view.html:301
+#: templates/backoffice/respondent_field_schema/view.html:267
+#: templates/backoffice/respondent_field_schema/view.html:299
 msgid "Option help text"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:270
-#: templates/backoffice/respondent_field_schema/view.html:299
+#: templates/backoffice/respondent_field_schema/view.html:268
+#: templates/backoffice/respondent_field_schema/view.html:297
 #, fuzzy
 msgid "help text (optional)"
 msgstr "Email cím"
 
-#: templates/backoffice/respondent_field_schema/view.html:294
+#: templates/backoffice/respondent_field_schema/view.html:292
 msgid "value"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:302
+#: templates/backoffice/respondent_field_schema/view.html:300
 #, fuzzy
 msgid "Add option"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/respondent_field_schema/view.html:314
+#: templates/backoffice/respondent_field_schema/view.html:312
 msgid "Add a field"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:335
+#: templates/backoffice/respondent_field_schema/view.html:333
 #, fuzzy
 msgid "Field key and label"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/respondent_field_schema/view.html:353
+#: templates/backoffice/respondent_field_schema/view.html:351
 msgid "field_key (e.g. age_range)"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:359
+#: templates/backoffice/respondent_field_schema/view.html:357
 #: templates/backoffice/service_docs/_fields.html:107
 #, fuzzy
 msgid "Label (optional)"
 msgstr "Email cím"
 
-#: templates/backoffice/respondent_field_schema/view.html:389
+#: templates/backoffice/respondent_field_schema/view.html:387
 msgid "Add field"
 msgstr ""
 
-#: templates/backoffice/respondent_field_schema/view.html:395
+#: templates/backoffice/respondent_field_schema/view.html:393
 msgid ""
 "The field key is normalised to lowercase letters, numbers and "
 "underscores. Choice fields start with one placeholder option you can "
 "rename above."
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:9
-#: templates/backoffice/respondents/confirm_upload_diff.html:17
+#: templates/backoffice/respondents/confirm_upload_diff.html:8
 #, fuzzy
 msgid "Confirm upload"
 msgstr "Új jelszó"
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:23
+#: templates/backoffice/respondents/confirm_upload_diff.html:11
 #, fuzzy
 msgid "Confirm CSV upload"
 msgstr "Új jelszó"
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:25
+#: templates/backoffice/respondents/confirm_upload_diff.html:13
 msgid "This upload will change which fields exist in the respondent schema for"
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:27
+#: templates/backoffice/respondents/confirm_upload_diff.html:15
 msgid "Review the changes below, then confirm or cancel."
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:31
+#: templates/backoffice/respondents/confirm_upload_diff.html:19
 msgid "File:"
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:36
+#: templates/backoffice/respondents/confirm_upload_diff.html:24
 #, fuzzy
 msgid "ID column changed"
 msgstr "ID (azonosító) oszlop"
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:38
+#: templates/backoffice/respondents/confirm_upload_diff.html:26
 #, python-format
 msgid "The ID column has changed from %(old)s to %(new)s."
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:41
+#: templates/backoffice/respondents/confirm_upload_diff.html:29
 msgid "Existing respondents will be replaced — make sure this is intentional."
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:49
+#: templates/backoffice/respondents/confirm_upload_diff.html:37
 #, fuzzy
 msgid "New columns"
 msgstr "ID (azonosító) oszlop"
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:52
+#: templates/backoffice/respondents/confirm_upload_diff.html:40
 msgid ""
 "These columns are in the new CSV but not in the existing schema. They'll "
 "be added with the suggested groups; you can re-group them afterwards."
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:57
+#: templates/backoffice/respondents/confirm_upload_diff.html:45
 #, fuzzy
 msgid "Column"
 msgstr "ID (azonosító) oszlop"
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:58
+#: templates/backoffice/respondents/confirm_upload_diff.html:46
 #, fuzzy
 msgid "Suggested group"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:76
+#: templates/backoffice/respondents/confirm_upload_diff.html:64
 msgid "Columns no longer in CSV"
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:79
+#: templates/backoffice/respondents/confirm_upload_diff.html:67
 msgid ""
 "These columns existed in the previous schema but are missing from the new"
 " CSV. The schema entries are kept (so the layout sticks if the column "
 "reappears) but no respondent will have data for them."
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:92
+#: templates/backoffice/respondents/confirm_upload_diff.html:80
 #, fuzzy
 msgid "Unchanged columns:"
 msgstr "Cím oszlopok"
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:98
+#: templates/backoffice/respondents/confirm_upload_diff.html:86
 #, fuzzy
 msgid "Destructive action"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:100
+#: templates/backoffice/respondents/confirm_upload_diff.html:88
 msgid ""
 "Confirming will replace all existing respondents for this assembly with "
 "the contents of the new CSV. This cannot be undone."
 msgstr ""
 
-#: templates/backoffice/respondents/confirm_upload_diff.html:106
+#: templates/backoffice/respondents/confirm_upload_diff.html:94
 #, fuzzy
 msgid "Confirm and import"
 msgstr "Új jelszó"
@@ -10555,11 +10584,6 @@ msgstr "Vezetéknév"
 #: templates/profile/view.html:215
 msgid "Edit profile"
 msgstr ""
-
-#: templates/profile/view.html:223
-#, fuzzy
-msgid "Back to dashboard"
-msgstr "Vissza az irányító pulthoz"
 
 #: templates/register/closed.html:3 templates/register/closed.html:7
 #, fuzzy
@@ -14101,4 +14125,63 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "only meaningful in wizard mode"
+#~ msgstr ""
+
+#~ msgid "Manage data for this assembly"
+#~ msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
+
+#~ msgid "Assembly Details"
+#~ msgstr "Közösségi gyűlés"
+
+#~ msgid "Manage team members for this assembly"
+#~ msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
+
+#~ msgid "Registration Form Configuration"
+#~ msgstr "Beállítások mentése"
+
+#~ msgid "Manage respondent data for this assembly"
+#~ msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
+
+#~ msgid "Run selection and manage generated outputs"
+#~ msgstr ""
+
+#~ msgid "Configure selection targets for this assembly"
+#~ msgstr "Érvénytelen feladat azonosító ehhez a közösségi gyűléshez"
+
+#~ msgid "Respondent details"
+#~ msgstr "Válaszadókat tartalmazó lapful neve"
+
+#~ msgid "Patterns"
+#~ msgstr ""
+
+#~ msgid "Service Docs"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Flash messages in the backoffice appear"
+#~ " as floating alerts at the bottom-"
+#~ "right of the viewport. This ensures "
+#~ "users see feedback without scrolling to"
+#~ " the top of the page."
+#~ msgstr ""
+
+#~ msgid "Positioned at bottom-right to avoid covering content"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Click the buttons below to trigger "
+#~ "flash messages. The alerts will appear"
+#~ " at the bottom-right of the "
+#~ "viewport."
+#~ msgstr ""
+
+#~ msgid "Below modals (z-40/z-50) but above page content"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Group, order, and label the fields "
+#~ "that describe your respondents. These "
+#~ "settings drive how respondent details "
+#~ "are displayed and will seed the "
+#~ "registration form when it is created."
 #~ msgstr ""


### PR DESCRIPTION
## Summary

Reworks the backoffice page frame per the **680 navigation rework** ticket ([Figma: app frame](https://www.figma.com/design/WaG38I99ccF8RMy1655fA2/OpenDLP---UI?node-id=1802-1579&m=dev), [assembly detail](https://www.figma.com/design/WaG38I99ccF8RMy1655fA2/OpenDLP---UI?node-id=2898-2685&m=dev)).

New UI elements were built in the **design-system showcase first**, then wired into the layout.

## What changed

**Top bar**
- Logo on the left; a **help icon** (→ knowledge hub via new `KNOWLEDGE_HUB_URL` config, opens a new tab) and an **account dropdown** on the right.
- Dropped the centre nav links and the standalone Sign-out CTA. Account actions now live in the dropdown: **My account**, **Switch to site admin** (new tab, role-gated), **User Data Agreement**, **Sign out**.

**New components (with showcase demos)**
- `avatar` (initials badge), `account_menu` (avatar-triggered dropdown), `page_header` (back-arrow + title), a shared `_nav_icons` set, and a reworked `navigation` top bar. All registered in `/backoffice/showcase`.

**Sticky chrome**
- The top bar **and** the page-header + tab bar stay pinned while content scrolls.

**Assembly pages**
- Breadcrumb replaced with a **back-arrow page header** (title only); the tab bar moved into the sticky header.
- Removed the **"Back to Dashboard"** button on assembly details.
- Respondent view/edit pages get a back-arrow page header too.

**Breadcrumbs retired** across the backoffice (18 pages). The `breadcrumbs` macro and its **showcase demo are kept**.

## Out of scope (separate tickets)
- **Status chips** on the page header + the dashboard status filter/toggle.
- **Footer removal** — the footer is kept for now, pending team discussion; removal + relocating its links (GitHub → About OpenDLP, Cookies, version) is the deferred final step.

## Testing
- Component + unit suites: **green** across every changed page.
- Backoffice + accessibility **BDD: 91 passed, 1 skipped, 0 failed**.
- `mypy` clean; `ruff` + format clean.
- BDD test updates for the redesign: removed the breadcrumb scenarios/steps; replaced the CSP-fragile `wait_for_function` scroll checks with a CSP-safe CDP poll; **skipped** (`@skip` + TODO) the `Entering edit mode preserves the scroll position` scenario — the Edit control is now top-anchored under the sticky header, so its premise no longer holds (the `?scroll=` restore mechanism still works).

> ⚠️ Running BDD locally needs `FF_OLD_DEFAULT_DASHBOARD=true` in the server env (the repo `.env` sets it `false`); otherwise the login helper's dashboard-URL expectation fails. Pre-existing infra behaviour, documented in the plan.

## Follow-ups
- `just translate-regen` for the new gettext strings (to be handled separately).
- Design/spec plan: `backend/docs/prompts/680-navigation-rework/implementation-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)