### PR TITLE
Registration page editor opens as a modal over the pages list

### DIFF
--- a/backend/.claude/skills/sf-code-review/SKILL.md
+++ b/backend/.claude/skills/sf-code-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 description: Review the code on this branch against the guidelines in the project docs.
+allowed-tools: Bash(git diff:*)
 ---
 
 ## Summary of files changed

--- a/backend/src/js/components/registration-edit-guard.js
+++ b/backend/src/js/components/registration-edit-guard.js
@@ -11,13 +11,19 @@
  * through the Cancel button's guardLeave() and its discard modal; beforeunload
  * is the backstop for browser-level navigation - close tab, reload, back button.
  *
+ * The editor renders as a takeover modal over the pages list, so this slice also
+ * owns closing that modal: the close X is a guarded link, and Esc goes through
+ * closePageGuarded() - both land on options.listUrl.
+ *
  * @param {Object} options - configuration
  * @param {boolean} options.editMode - whether the page is in edit mode
+ * @param {string} [options.listUrl=""] - the pages list the editor modal closes to
  * @returns {Object} a flat slice of Alpine component state
  */
 export function registrationEditGuard(options) {
   return {
     editMode: Boolean(options.editMode),
+    listUrl: options.listUrl || "",
     editDirty: false,
     leaveModalOpen: false,
     leaveUrl: "",
@@ -44,7 +50,33 @@ export function registrationEditGuard(options) {
       this.leaveGuardSuppressed = true;
     },
 
-    // Attached to leave-links (Cancel). Clean state falls through to normal navigation.
+    // Wired to Esc on the page root: closes the editor modal back to the pages
+    // list. A nested dialog owns the Esc press while it is open - this handler
+    // is registered first (the root initialises before its descendants), so it
+    // sees the nested dialog's flag still set and yields; the nested dialog's
+    // own handler then closes it. Unsaved edits divert to the discard modal.
+    closePageGuarded: function () {
+      if (!this.listUrl) return;
+      if (
+        this.leaveModalOpen ||
+        this.confirmCloseOpen ||
+        this.skeletonModalOpen ||
+        this.imageUploadModalOpen ||
+        this.imageDetailsModalOpen ||
+        this.documentUploadModalOpen ||
+        this.documentDetailsModalOpen
+      ) {
+        return;
+      }
+      if (this.editDirty) {
+        this.openLeaveModal(this.listUrl);
+        return;
+      }
+      window.location.assign(this.listUrl);
+    },
+
+    // Attached to leave-links (Cancel, and the editor modal's close X). Clean
+    // state falls through to normal navigation.
     guardLeave: function (event) {
       if (!this.editDirty) return;
       event.preventDefault();

--- a/backend/src/js/components/registration-edit-guard.test.js
+++ b/backend/src/js/components/registration-edit-guard.test.js
@@ -22,8 +22,8 @@ afterEach(() => {
  * The guard reaches for Alpine's $nextTick and $refs, which Alpine supplies at
  * runtime. Driving the returned object directly means supplying them here.
  */
-function guard(editMode) {
-  const state = registrationEditGuard({ editMode: editMode });
+function guard(editMode, listUrl) {
+  const state = registrationEditGuard({ editMode: editMode, listUrl: listUrl });
   state.$nextTick = (callback) => callback();
   state.$refs = {
     keepOpenBtn: { focus: vi.fn() },
@@ -161,6 +161,68 @@ describe("the discard modal", () => {
     state.discardAndLeave();
 
     expect(window.location.assign).not.toHaveBeenCalled();
+  });
+});
+
+describe("closePageGuarded - Esc closes the editor modal", () => {
+  const LIST_URL = "https://example.org/registration";
+
+  it("navigates a clean page straight back to the pages list", () => {
+    guard(false, LIST_URL).closePageGuarded();
+
+    expect(window.location.assign).toHaveBeenCalledWith(LIST_URL);
+  });
+
+  it("does nothing when no list URL was configured", () => {
+    guard(false).closePageGuarded();
+
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it("diverts a dirty page to the discard modal, aimed at the list", () => {
+    const state = guard(true, LIST_URL);
+    state.markEditDirty();
+
+    state.closePageGuarded();
+
+    expect(window.location.assign).not.toHaveBeenCalled();
+    expect(state.leaveModalOpen).toBe(true);
+    expect(state.leaveUrl).toBe(LIST_URL);
+  });
+
+  it("yields while a nested dialog is open - that Esc press belongs to it", () => {
+    const state = guard(false, LIST_URL);
+    state.confirmCloseOpen = true;
+
+    state.closePageGuarded();
+
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it("yields to the discard modal itself, so Esc there means Keep editing", () => {
+    const state = guard(true, LIST_URL);
+    state.markEditDirty();
+    state.closePageGuarded();
+
+    state.closePageGuarded();
+
+    expect(window.location.assign).not.toHaveBeenCalled();
+    expect(state.leaveModalOpen).toBe(true);
+  });
+
+  it("yields while an asset or skeleton dialog is open", () => {
+    [
+      "skeletonModalOpen",
+      "imageUploadModalOpen",
+      "imageDetailsModalOpen",
+    ].forEach((flag) => {
+      const state = guard(false, LIST_URL);
+      state[flag] = true;
+
+      state.closePageGuarded();
+
+      expect(window.location.assign).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/backend/src/js/components/registration-page-controller.js
+++ b/backend/src/js/components/registration-page-controller.js
@@ -40,7 +40,7 @@ export function registrationPageController(config) {
       formatBytes: formatBytes,
     },
     registrationToast(messages),
-    registrationEditGuard({ editMode: config.editMode }),
+    registrationEditGuard({ editMode: config.editMode, listUrl: urls.list }),
     registrationSkeleton({
       csrfToken: csrfToken,
       skeletonUrl: urls.skeleton,

--- a/backend/src/js/components/registration-page-controller.test.js
+++ b/backend/src/js/components/registration-page-controller.test.js
@@ -12,6 +12,7 @@ const CONFIG = {
   images: [{ id: "image-1", alt: "A logo" }],
   documents: [{ id: "doc-1", label: "Information pack" }],
   urls: {
+    list: "/assembly/1/registration",
     skeleton: "/assembly/1/registration/skeleton",
     uploadImage: "/assembly/1/registration/images",
     imageItem: `/assembly/1/registration/images/${ID_SENTINEL}`,
@@ -31,6 +32,7 @@ const TEMPLATE_API = [
   "closeImageDetailsModalIfAllowed",
   "closeImageUploadModalIfAllowed",
   "closeLeaveModal",
+  "closePageGuarded",
   "closeSkeletonModal",
   "copyDocumentSnippet",
   "copyImageSnippet",
@@ -84,6 +86,12 @@ describe("the composed controller", () => {
     expect(
       registrationPageController({ ...CONFIG, editMode: false }).editMode,
     ).toBe(false);
+  });
+
+  it("carries the list URL through to the guard, for closing the editor modal", () => {
+    expect(registrationPageController(CONFIG).listUrl).toBe(
+      "/assembly/1/registration",
+    );
   });
 
   it("builds per-item URLs from the templates the server rendered", () => {

--- a/backend/src/js/init/form-confirm.js
+++ b/backend/src/js/init/form-confirm.js
@@ -1,6 +1,7 @@
 // ABOUTME: Alpine magic $confirm and directive x-preserve-scroll-on-submit for form submissions
 // ABOUTME: Confirms before submitting and optionally carries the scroll position into the reload
 
+import { getPageScrollTop } from "../lib/page-scroller.js";
 import { urlSetParam } from "../lib/url-utils.js";
 
 /**
@@ -10,7 +11,7 @@ import { urlSetParam } from "../lib/url-utils.js";
  */
 export function addScrollToFormAction(formElement) {
   var action = formElement.getAttribute("action") || window.location.href;
-  var scrollPos = Math.round(window.scrollY);
+  var scrollPos = Math.round(getPageScrollTop());
   formElement.setAttribute(
     "action",
     urlSetParam(action, "scroll", scrollPos.toString()),

--- a/backend/src/js/init/scroll-magic.js
+++ b/backend/src/js/init/scroll-magic.js
@@ -1,6 +1,7 @@
 // ABOUTME: Alpine magic $preserveScroll and directive x-scroll-preserve-links
 // ABOUTME: Adds the current scroll position to a URL so it survives a page reload
 
+import { getPageScrollTop } from "../lib/page-scroller.js";
 import { urlSetParam } from "../lib/url-utils.js";
 
 /**
@@ -22,7 +23,7 @@ export function registerScrollMagic() {
     return (url) => {
       if (!url) return url;
 
-      const currentScroll = Math.round(window.scrollY);
+      const currentScroll = Math.round(getPageScrollTop());
       return urlSetParam(url, "scroll", currentScroll.toString());
     };
   });
@@ -57,7 +58,7 @@ export function registerScrollMagic() {
         }
 
         // Add scroll parameter using URL utilities
-        const currentScroll = Math.round(window.scrollY);
+        const currentScroll = Math.round(getPageScrollTop());
         link.setAttribute(
           "href",
           urlSetParam(href, "scroll", currentScroll.toString()),

--- a/backend/src/js/init/scroll-restore.js
+++ b/backend/src/js/init/scroll-restore.js
@@ -1,6 +1,8 @@
 // ABOUTME: Restores scroll position from the ephemeral ?scroll= parameter, then cleans the URL
 // ABOUTME: The parameter exists only during a transition, so it is removed as soon as it is used
 
+import { setPageScrollTop } from "../lib/page-scroller.js";
+
 /**
  * Restore the scroll position named by ?scroll= and strip the parameter.
  *
@@ -15,7 +17,7 @@ export function restoreScrollFromUrl() {
 
   const restoreScroll = () => {
     // Restore scroll position
-    window.scrollTo(0, parseInt(scrollPos, 10));
+    setPageScrollTop(parseInt(scrollPos, 10));
 
     // Immediately clean URL (remove scroll parameter)
     const url = new URL(window.location.href);

--- a/backend/src/js/lib/page-scroller.js
+++ b/backend/src/js/lib/page-scroller.js
@@ -1,0 +1,33 @@
+// ABOUTME: Resolves which element the scroll-preservation helpers should measure
+// ABOUTME: The window by default, or the takeover dialog's body when one is on the page
+
+/**
+ * A page takeover modal (e.g. the registration editor) locks the window scroll
+ * and scrolls its own .dialog-body instead, so the ?scroll= round-trip must
+ * read and restore that element's position rather than the window's.
+ */
+var TAKEOVER_SCROLLER_SELECTOR = ".dialog-panel--takeover .dialog-body";
+
+/**
+ * The current scroll offset of the page's main scroll container.
+ *
+ * @returns {number} scroll offset in pixels
+ */
+export function getPageScrollTop() {
+  var takeoverBody = document.querySelector(TAKEOVER_SCROLLER_SELECTOR);
+  return takeoverBody ? takeoverBody.scrollTop : window.scrollY;
+}
+
+/**
+ * Scroll the page's main scroll container to the given offset.
+ *
+ * @param {number} position - scroll offset in pixels
+ */
+export function setPageScrollTop(position) {
+  var takeoverBody = document.querySelector(TAKEOVER_SCROLLER_SELECTOR);
+  if (takeoverBody) {
+    takeoverBody.scrollTop = position;
+  } else {
+    window.scrollTo(0, position);
+  }
+}

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -188,6 +188,27 @@ def _document_to_dict(document: RegistrationDocument, url_slug: str) -> dict[str
     }
 
 
+def _page_rows(pages: list[RegistrationPage], assembly_id: uuid.UUID) -> list[dict[str, Any]]:
+    """Rows for the registration pages list — also rendered behind the editor's modal."""
+    return [
+        {
+            "page": page,
+            # A page created outside the backoffice can lack a slug; it cannot be
+            # opened here until one is set, so it renders without links.
+            "editor_url": _editor_url(assembly_id, page.url_slug) if page.url_slug else "",
+            "close_url": url_for(
+                "backoffice_registration.save_assembly_registration",
+                assembly_id=assembly_id,
+                url_slug=page.url_slug,
+            )
+            if page.url_slug and page.status == RegistrationPageStatus.PUBLISHED
+            else "",
+            "published_at": page.last_published_at(),
+        }
+        for page in pages
+    ]
+
+
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration")
 @login_required
 def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
@@ -204,23 +225,7 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
                 request.args.get("source", ""),
             )
             pages = list_registration_pages(uow, current_user.id, assembly_id)
-        page_rows = [
-            {
-                "page": page,
-                # A page created outside the backoffice can lack a slug; it cannot be
-                # opened here until one is set, so it renders without links.
-                "editor_url": _editor_url(assembly_id, page.url_slug) if page.url_slug else "",
-                "close_url": url_for(
-                    "backoffice_registration.save_assembly_registration",
-                    assembly_id=assembly_id,
-                    url_slug=page.url_slug,
-                )
-                if page.url_slug and page.status == RegistrationPageStatus.PUBLISHED
-                else "",
-                "published_at": page.last_published_at(),
-            }
-            for page in pages
-        ]
+        page_rows = _page_rows(pages, assembly_id)
 
         return render_template(
             "backoffice/assembly_registration_list.html",
@@ -298,6 +303,11 @@ def view_registration_page(assembly_id: uuid.UUID, url_slug: str) -> ResponseRet
             # Auto-reply email data — the template (if assigned) plus readiness problems.
             email_template, email_readiness_problems = _load_auto_reply_context(uow, registration_page, assembly_id)
 
+            # The editor renders as a modal over the pages list, so the list rows are
+            # needed here too — they form the (inert) backdrop behind the dialog.
+            all_pages = list_registration_pages(uow, current_user.id, assembly_id)
+        page_rows = _page_rows(all_pages, assembly_id)
+
         # The HTML editor is read-only by default; ?edit=1 unlocks it. CLOSED pages
         # have no save path so we always keep them read-only regardless of the param.
         edit_mode = request.args.get("edit") == "1" and registration_status != "CLOSED"
@@ -334,6 +344,8 @@ def view_registration_page(assembly_id: uuid.UUID, url_slug: str) -> ResponseRet
             email_readiness_problems=email_readiness_problems,
             registration_url_prefix=registration_url_prefix(),
             short_url_prefix=short_url_prefix(),
+            page_rows=page_rows,
+            page_takeover=True,
         ), 200
     except RegistrationPageNotFoundError:
         # An edited or removed slug: land the user on the list to pick a page.
@@ -397,9 +409,10 @@ _LIFECYCLE_ACTIONS = frozenset({"publish", "unpublish", "close", "reopen"})
 
 
 def _post_action_section(action: str) -> str:
-    """Where to land after a successful action: save_and_next advances to the email
-    step, lifecycle actions return to the preview step (where their buttons live),
-    and plain save returns to the form step."""
+    """Where to land after a successful action that stays in the editor:
+    save_and_next advances to the email step, unpublish/reopen return to the
+    preview step (where their buttons live), and plain save returns to the form
+    step. Publish and close never reach this — they leave the editor entirely."""
     if action == "save_and_next":
         return "email"
     if action in _LIFECYCLE_ACTIONS:
@@ -433,9 +446,12 @@ def _apply_page_settings(uow: AbstractUnitOfWork, page: RegistrationPage) -> Reg
 
 
 def _post_save_redirect(assembly_id: uuid.UUID, url_slug: str, action: str) -> str:
-    """Where a successful save lands: back on the list when the list's row menu
-    posted the action (return_to=list), else the editor section for the action."""
-    if request.form.get("return_to") == "list":
+    """Where a successful save lands. The editor is a modal over the pages list,
+    so the actions that finish the flow — publish and close — dismiss it by
+    landing on the list. Unpublish stays in the editor (the user unpublished in
+    order to edit), as do the save actions. ``return_to=list`` (posted by the
+    list's row menu) also lands on the list."""
+    if action in ("publish", "close") or request.form.get("return_to") == "list":
         return _list_url(assembly_id)
     return _editor_url(assembly_id, url_slug, section=_post_action_section(action))
 
@@ -448,11 +464,14 @@ def save_assembly_registration(assembly_id: uuid.UUID, url_slug: str) -> Respons
     Actions:
       - save            → update HTML; land back in read-only on the form step.
       - save_and_next   → update HTML; advance to the auto-reply email step.
-      - publish         → transition TEST → PUBLISHED. No HTML update.
-      - unpublish       → transition PUBLISHED → TEST (back to test mode).
-      - close           → transition to CLOSED. Terminal from the UI's point of
-                          view: reopen exists only for backwards compatibility
-                          with older POSTs and is not offered anywhere.
+      - publish         → transition TEST → PUBLISHED. No HTML update. Lands on
+                          the pages list — the editor modal is done.
+      - unpublish       → transition PUBLISHED → TEST (back to test mode); stays
+                          in the editor on the preview step.
+      - close           → transition to CLOSED; lands on the pages list. Terminal
+                          from the UI's point of view: reopen exists only for
+                          backwards compatibility with older POSTs and is not
+                          offered anywhere.
 
     A ``return_to=list`` form field sends the user back to the page list after a
     successful lifecycle action — the list's row menu posts it.

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -920,6 +920,7 @@
          modal backdrop (.dialog-backdrop) .... 40
          floating flash alerts (#floating-alerts) 45  (above header/backdrop, below dialog)
          modal dialog (.dialog-positioner) .... 50
+         flash alerts over a takeover panel ... 55  (see .dialog-panel--takeover below)
        ======================================== */
     #floating-alerts {
         z-index: 45;
@@ -1034,6 +1035,49 @@
         padding: 0.75rem 1.5rem;
         border-top: 1px solid var(--color-borders-dividers);
         background-color: var(--color-tables-cards);
+    }
+
+    /* ========================================
+       TAKEOVER PANEL — a page rendered as a near-full-screen modal over its
+       parent page (the registration editor over the pages list). The page
+       behind is inert (see base_page.html's page_takeover); the panel's body
+       becomes the page's scroll container (see lib/page-scroller.js).
+       ======================================== */
+    .dialog-panel--takeover {
+        /* Matches the content column (max-w-screen-2xl) so the editor keeps
+           its working width; the margin leaves the dimmed list visible. */
+        max-width: 96rem;
+        height: calc(100vh - 3rem);
+        margin: 1.5rem;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .dialog-panel--takeover .dialog-body {
+        flex: 1;
+        max-height: none;
+        padding: 1.5rem;
+    }
+
+    /* Inside the panel the wizard footer still sticks, but the full-viewport
+       breakout (see .wizard-footer-box's stuck styles) would overflow a panel
+       narrower than the viewport — pin the box styling instead. */
+    .dialog-panel--takeover .wizard-footer-box {
+        margin-inline: 0;
+        padding-inline: 1.5rem;
+        border-radius: 0.5rem;
+        border: 1px solid var(--color-borders-dividers);
+    }
+
+    /* While a takeover panel is up: the window must not scroll (the panel body
+       scrolls instead), and flash alerts lift above the dialog layer (z-50)
+       so server-side messages stay readable — see the z-index stack above. */
+    body:has(.dialog-panel--takeover) {
+        overflow: hidden;
+    }
+
+    body:has(.dialog-panel--takeover) #floating-alerts {
+        z-index: 55;
     }
 
     /* Alert-dialog text block — title + description stack (Figma: gap 8) */

--- a/backend/templates/backoffice/assembly_registration.html
+++ b/backend/templates/backoffice/assembly_registration.html
@@ -7,16 +7,18 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
 {% from "backoffice/components/button.html" import button %}
 {% from "backoffice/components/input.html" import checkbox, input, textarea %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
+{% from "backoffice/components/modal.html" import dialog_close_icon %}
 {% from "backoffice/components/url_display.html" import readonly_url_display %}
 {% from "backoffice/components/stepper.html" import stepper %}
 {% from "backoffice/components/prefixed_url_input.html" import prefixed_url_input %}
 {% from "backoffice/components/alert.html" import alert %}
+{% from "backoffice/components/registration_page_list.html" import registration_page_list %}
 {% block title %}{{ assembly.title }} - {{ _("Registration") }}{% endblock %}
 {% block page_header %}
     <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
         {{ page_header(title=assembly.title,
-        back_href=url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id),
-        back_label=_("Back to registration pages")) }}
+        back_href=url_for('backoffice.dashboard'),
+        back_label=_("Back to dashboard")) }}
         <div class="mt-4">
             {{ assembly_tabs(assembly=assembly,
             active_tab="registration",
@@ -29,218 +31,249 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
     </div>
 {% endblock %}
 {% block page_content %}
-    <div x-data="registrationPageController()">
-        {% if not has_registration_page %}
+    {# The editor renders as a takeover modal (see the page_overlay block); this block
+       only paints the registration pages list behind it. The view passes page_takeover,
+       so base_page marks this content inert — a dimmed, non-interactive backdrop. #}
+    {% if has_registration_page %}
+        {{ registration_page_list(assembly, page_rows) }}
+    {% else %}
             {# Warning panel when no registration page exists #}
-            <div class="rounded-lg p-6 mb-6"
-                 style="background-color: var(--color-warning-100);
-                        border: 1px solid var(--color-warning-400)">
-                <div class="flex items-start gap-3">
-                    <svg xmlns="http://www.w3.org/2000/svg"
-                         class="h-6 w-6 flex-shrink-0"
-                         style="color: var(--color-warning-600)"
-                         fill="none"
-                         viewBox="0 0 24 24"
-                         stroke="currentColor"
-                         stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                    </svg>
-                    <div>
-                        <h2 class="text-heading-md mb-2" style="color: var(--color-warning-600);">{{ _("Registration page not created") }}</h2>
-                        <p class="text-body-md mb-4" style="color: var(--color-warning-600);">
-                            {{ _("Before you can configure the registration form, you need to create a registration page from the Details tab.") }}
-                        </p>
-                        {{ button(_("Go to Details tab"),
-                        href=url_for('backoffice.view_assembly', assembly_id=assembly.id),
-                        variant="secondary") }}
-                    </div>
+        <div class="rounded-lg p-6 mb-6"
+             style="background-color: var(--color-warning-100);
+                    border: 1px solid var(--color-warning-400)">
+            <div class="flex items-start gap-3">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     class="h-6 w-6 flex-shrink-0"
+                     style="color: var(--color-warning-600)"
+                     fill="none"
+                     viewBox="0 0 24 24"
+                     stroke="currentColor"
+                     stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                <div>
+                    <h2 class="text-heading-md mb-2" style="color: var(--color-warning-600);">{{ _("Registration page not created") }}</h2>
+                    <p class="text-body-md mb-4" style="color: var(--color-warning-600);">
+                        {{ _("Before you can configure the registration form, you need to create a registration page from the Details tab.") }}
+                    </p>
+                    {{ button(_("Go to Details tab"),
+                    href=url_for('backoffice.view_assembly', assembly_id=assembly.id),
+                    variant="secondary") }}
                 </div>
             </div>
-        {% else %}
+        </div>
+    {% endif %}
+{% endblock %}
+{% block page_overlay %}
+    {% if has_registration_page %}
+        {% set list_url = url_for('backoffice_registration.view_assembly_registration', assembly_id=assembly.id) %}
+        <div x-data="registrationPageController()"
+             @keydown.escape.window="closePageGuarded()">
+            {# Dimmed backdrop over the inert pages list. Deliberately not click-to-close:
+               a stray click during a long editing session must not risk losing work.
+               Closing goes through the X or Esc, both routed through the dirty guard. #}
+            <div class="dialog-backdrop"></div>
+            <div class="dialog-positioner"
+                 role="dialog"
+                 aria-modal="true"
+                 aria-labelledby="registration-editor-title">
+                <div class="dialog-panel dialog-panel--takeover">
+                    <div class="dialog-header">
+                        <h2 class="dialog-title" id="registration-editor-title">{{ registration_page.name }}</h2>
+                        {# Closing the editor is "back to the pages list". A real link — middle-click
+                           and copy-link keep working — but guarded like Cancel while edits are unsaved. #}
+                        <a href="{{ list_url }}"
+                           class="dialog-close-btn"
+                           @click="guardLeave($event)"
+                           aria-label="{{ _('Close and return to the registration pages') }}">
+                            {{ dialog_close_icon() }}
+                        </a>
+                    </div>
+                    <div class="dialog-body">
             {# Sub-navigation within the Registration tab: registration page → auto-reply email → preview & publish.
            URL contract: ?section=form|email|preview. Panels are peers (any step reachable at any time),
            so the stepper is rendered in tabs mode. While editing, the whole stepper is disabled —
            navigation is locked to the card's Save/Cancel, matching the disabled footer buttons. #}
-            {% set section_base = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug) %}
-            {{ stepper(id="reg-steps",
-            items=[
-            {"key": "form", "label": _("Registration page"), "href": section_base ~ "?section=form", "active": active_section == "form"},
-            {"key": "email", "label": _("Auto-reply email"), "href": section_base ~ "?section=email", "active": active_section == "email"},
-            {"key": "preview", "label": _("Preview and publish"), "href": section_base ~ "?section=preview", "active": active_section == "preview"}
-            ],
-            aria_label=_("Registration setup steps"),
-            mode="tabs",
-            preserve_scroll=true,
-            disabled=edit_mode) }}
+                        {% set section_base = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug) %}
+                        {{ stepper(id="reg-steps",
+                        items=[
+                        {"key": "form", "label": _("Registration page"), "href": section_base ~ "?section=form", "active": active_section == "form"},
+                        {"key": "email", "label": _("Auto-reply email"), "href": section_base ~ "?section=email", "active": active_section == "email"},
+                        {"key": "preview", "label": _("Preview and publish"), "href": section_base ~ "?section=preview", "active": active_section == "preview"}
+                        ],
+                        aria_label=_("Registration setup steps"),
+                        mode="tabs",
+                        preserve_scroll=true,
+                        disabled=edit_mode) }}
             {# Whole-artifact status. Sits below the stepper so it applies to all three steps —
                the form HTML, the auto-reply email, and the preview all share this state. #}
-            {% if registration_status == "TEST" %}
-                <div class="rounded-lg p-4 mb-6"
-                     role="alert"
-                     style="background-color: var(--color-warning-100);
-                            border: 1px solid var(--color-warning-400)">
-                    <p class="text-body-md" style="color: var(--color-warning-600);">
-                        <span class="font-semibold">⚠️ {{ _("Test mode") }}:</span>
-                        {{ _("Submissions are recorded as test entries and don't enter the selection pool. Publish the registration when you're ready to go live.") }}
-                    </p>
-                </div>
-            {% elif registration_status == "CLOSED" %}
-                <div class="rounded-lg p-4 mb-6"
-                     role="alert"
-                     style="background-color: var(--color-error-100);
-                            border: 1px solid var(--color-error-400)">
-                    <p class="text-body-md" style="color: var(--color-error-600);">
-                        <span class="font-semibold">⛔ {{ _("Registration closed") }}:</span>
-                        {{ _("Visitors who follow the form URL are redirected to the closed page.") }}
-                    </p>
-                </div>
-            {% elif registration_status == "PUBLISHED" %}
-                <div class="mb-6">
-                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-label-md"
-                          style="background-color: var(--color-success-100);
-                                 color: var(--color-success-600)">
-                        <span class="w-2 h-2 rounded-full"
-                              style="background-color: var(--color-success-400)"></span>
-                        {{ _("Published") }}
-                    </span>
-                </div>
-            {% endif %}
-            {% if active_section == "form" %}
-                <div id="reg-steps-panel-form"
-                     role="tabpanel"
-                     aria-labelledby="reg-steps-tab-form"
-                     tabindex="0">
+                        {% if registration_status == "TEST" %}
+                            <div class="rounded-lg p-4 mb-6"
+                                 role="alert"
+                                 style="background-color: var(--color-warning-100);
+                                        border: 1px solid var(--color-warning-400)">
+                                <p class="text-body-md" style="color: var(--color-warning-600);">
+                                    <span class="font-semibold">⚠️ {{ _("Test mode") }}:</span>
+                                    {{ _("Submissions are recorded as test entries and don't enter the selection pool. Publish the registration when you're ready to go live.") }}
+                                </p>
+                            </div>
+                        {% elif registration_status == "CLOSED" %}
+                            <div class="rounded-lg p-4 mb-6"
+                                 role="alert"
+                                 style="background-color: var(--color-error-100);
+                                        border: 1px solid var(--color-error-400)">
+                                <p class="text-body-md" style="color: var(--color-error-600);">
+                                    <span class="font-semibold">⛔ {{ _("Registration closed") }}:</span>
+                                    {{ _("Visitors who follow the form URL are redirected to the closed page.") }}
+                                </p>
+                            </div>
+                        {% elif registration_status == "PUBLISHED" %}
+                            <div class="mb-6">
+                                <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-label-md"
+                                      style="background-color: var(--color-success-100);
+                                             color: var(--color-success-600)">
+                                    <span class="w-2 h-2 rounded-full"
+                                          style="background-color: var(--color-success-400)"></span>
+                                    {{ _("Published") }}
+                                </span>
+                            </div>
+                        {% endif %}
+                        {% if active_section == "form" %}
+                            <div id="reg-steps-panel-form"
+                                 role="tabpanel"
+                                 aria-labelledby="reg-steps-tab-form"
+                                 tabindex="0">
                     {# Editor takes the remaining width on the left, Assets panel is a fixed-width column on the right.
            The whole two-column layout + CTA row sit inside a single form so the CTAs align to the far
            right edge of the whole layout (not just the left column's edge) and the sticky assets panel
            unsticks at the flex-row's bottom rather than trailing past the CTAs. The assets buttons all
            use type="button" so they never accidentally submit the editor form. #}
-                    {% set edit_url = url_for("backoffice_registration.view_registration_page", assembly_id=assembly.id, url_slug=registration_page.url_slug, section="form", edit="1") %}
-                    {% set view_url = url_for("backoffice_registration.view_registration_page", assembly_id=assembly.id, url_slug=registration_page.url_slug, section="form") %}
-                    {% set next_url = url_for("backoffice_registration.view_registration_page", assembly_id=assembly.id, url_slug=registration_page.url_slug, section="email") %}
-                    {% set save_label = _("Save and Republish") if registration_status == "PUBLISHED" else _("Save") %}
-                    <form method="post"
-                          action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id, url_slug=registration_page.url_slug) }}"
-                          x-data
-                          x-preserve-scroll-on-submit
-                          {% if edit_mode %}@input="markEditDirty()" @change="markEditDirty()" @submit="allowLeave()"{% endif %}>
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                        <div class="flex flex-col lg:flex-row gap-6">
-                            <div class="flex-1 min-w-0">
+                                {% set edit_url = url_for("backoffice_registration.view_registration_page", assembly_id=assembly.id, url_slug=registration_page.url_slug, section="form", edit="1") %}
+                                {% set view_url = url_for("backoffice_registration.view_registration_page", assembly_id=assembly.id, url_slug=registration_page.url_slug, section="form") %}
+                                {% set next_url = url_for("backoffice_registration.view_registration_page", assembly_id=assembly.id, url_slug=registration_page.url_slug, section="email") %}
+                                {% set save_label = _("Save and Republish") if registration_status == "PUBLISHED" else _("Save") %}
+                                <form method="post"
+                                      action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id, url_slug=registration_page.url_slug) }}"
+                                      x-data
+                                      x-preserve-scroll-on-submit
+                                      {% if edit_mode %}@input="markEditDirty()" @change="markEditDirty()" @submit="allowLeave()"{% endif %}>
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                    <div class="flex flex-col lg:flex-row gap-6">
+                                        <div class="flex-1 min-w-0">
                                 {# Registration Form HTML Section #}
-                                <section class="rounded-lg p-6"
-                                         style="background-color: var(--color-tables-cards);
-                                                border: 1px solid var(--color-borders-dividers)">
-                                    <div class="flex items-center justify-between mb-4">
+                                            <section class="rounded-lg p-6"
+                                                     style="background-color: var(--color-tables-cards);
+                                                            border: 1px solid var(--color-borders-dividers)">
+                                                <div class="flex items-center justify-between mb-4">
                                         {# The heading is the page's name; in edit mode it becomes an input so the
                                            variant can be renamed right where it is labelled. #}
-                                        {% if edit_mode %}
-                                            <div class="flex-1 min-w-0 mr-4">
-                                                <label for="page_name" class="sr-only">{{ _("Registration page name") }}</label>
-                                                <input type="text"
-                                                       name="page_name"
-                                                       id="page_name"
-                                                       value="{{ registration_page.name }}"
-                                                       required
-                                                       class="text-heading-lg w-full px-3 py-1.5 rounded-lg"
-                                                       style="color: var(--color-headings); background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers);" />
-                                            </div>
-                                        {% else %}
-                                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ registration_page.name }}</h2>
-                                        {% endif %}
+                                                    {% if edit_mode %}
+                                                        <div class="flex-1 min-w-0 mr-4">
+                                                            <label for="page_name" class="sr-only">{{ _("Registration page name") }}</label>
+                                                            <input type="text"
+                                                                   name="page_name"
+                                                                   id="page_name"
+                                                                   value="{{ registration_page.name }}"
+                                                                   required
+                                                                   class="text-heading-lg w-full px-3 py-1.5 rounded-lg"
+                                                                   style="color: var(--color-headings); background-color: var(--color-page-background); border: 1px solid var(--color-borders-dividers);" />
+                                                        </div>
+                                                    {% else %}
+                                                        <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ registration_page.name }}</h2>
+                                                    {% endif %}
                                         {# Header right: the editorial controls live here, next to the content they act on —
                         Edit swaps in place to Cancel/Save so the eye never travels to the footer for
                         editing concerns. The footer below is navigation only.
                         x-scroll-preserve-links keeps the scroll position across the Edit/Cancel page
                         reloads, so the editor stays in view when switching modes (the directive rewrites
                         the href in capture phase, so the Cancel dirty-guard picks up the amended URL). #}
-                                        <div class="flex items-center gap-2" x-scroll-preserve-links>
-                                            {% set code_icon %}
-                                                <svg xmlns="http://www.w3.org/2000/svg"
-                                                     class="h-4 w-4"
-                                                     fill="none"
-                                                     viewBox="0 0 24 24"
-                                                     stroke="currentColor"
-                                                     stroke-width="2">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-                                                </svg>
-                                            {% endset %}
-                                            {{ button(_("Show Form Skeleton"),
-                                            variant="tertiary",
-                                            leading_icon=code_icon,
-                                            attrs='@click="fetchSkeleton()" :disabled="skeletonLoading"') }}
-                                            {% if edit_mode %}
-                                                {{ button(_("Cancel"), variant="secondary", href=view_url, attrs='@click="guardLeave($event)"') }}
-                                                {{ button(save_label, type="submit", variant="primary", attrs='name="action" value="save"') }}
-                                            {% elif registration_status != "CLOSED" %}
-                                                {{ button(_("Edit"), variant="secondary", href=edit_url) }}
-                                            {% endif %}
-                                        </div>
-                                    </div>
+                                                    <div class="flex items-center gap-2" x-scroll-preserve-links>
+                                                        {% set code_icon %}
+                                                            <svg xmlns="http://www.w3.org/2000/svg"
+                                                                 class="h-4 w-4"
+                                                                 fill="none"
+                                                                 viewBox="0 0 24 24"
+                                                                 stroke="currentColor"
+                                                                 stroke-width="2">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                                                            </svg>
+                                                        {% endset %}
+                                                        {{ button(_("Show Form Skeleton"),
+                                                        variant="tertiary",
+                                                        leading_icon=code_icon,
+                                                        attrs='@click="fetchSkeleton()" :disabled="skeletonLoading"') }}
+                                                        {% if edit_mode %}
+                                                            {{ button(_("Cancel"), variant="secondary", href=view_url, attrs='@click="guardLeave($event)"') }}
+                                                            {{ button(save_label, type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                                        {% elif registration_status != "CLOSED" %}
+                                                            {{ button(_("Edit"), variant="secondary", href=edit_url) }}
+                                                        {% endif %}
+                                                    </div>
+                                                </div>
                                     {# Page URLs are page-scoped settings, edited here rather than on Edit Assembly.
                                        Frozen once the page has been published so shared links keep working. #}
-                                    {% if edit_mode %}
-                                        {% set slugs_locked = registration_page.slugs_frozen %}
-                                        <div class="mb-6 space-y-4">
-                                            {% if slugs_locked %}
-                                                {{ alert(
-                                                message=_("These URLs are locked while the registration page is published or closed, so links shared in invites, QR codes, and elsewhere keep working. Switch the form back to test mode to edit them."),
-                                                variant="info"
-                                                ) }}
-                                            {% endif %}
-                                            {{ prefixed_url_input(
-                                            name="url_slug",
-                                            label=_("Registration URL"),
-                                            hint=_("The URL path for this registration form"),
-                                            prefix=registration_url_prefix,
-                                            placeholder="my-assembly-2026",
-                                            value=registration_page.url_slug,
-                                            disabled=slugs_locked
-                                            ) }}
-                                            {{ prefixed_url_input(
-                                            name="short_url_slug",
-                                            label=_("Short URL (optional)"),
-                                            hint=_("A shorter URL for QR codes and paper invitations"),
-                                            prefix=short_url_prefix,
-                                            placeholder="ma26",
-                                            value=registration_page.short_url_slug,
-                                            disabled=slugs_locked
-                                            ) }}
-                                        </div>
-                                    {% endif %}
-                                    <div class="space-y-4">
-                                        <p class="text-body-sm" style="color: var(--color-secondary-text);">
-                                            {{ _("Paste your HTML form code below. The only required placeholders are {{ form_action }} for the form's action attribute and {{ csrf_form_element }} for CSRF protection.") }}
-                                        </p>
+                                                {% if edit_mode %}
+                                                    {% set slugs_locked = registration_page.slugs_frozen %}
+                                                    <div class="mb-6 space-y-4">
+                                                        {% if slugs_locked %}
+                                                            {{ alert(
+                                                            message=_("These URLs are locked while the registration page is published or closed, so links shared in invites, QR codes, and elsewhere keep working. Switch the form back to test mode to edit them."),
+                                                            variant="info"
+                                                            ) }}
+                                                        {% endif %}
+                                                        {{ prefixed_url_input(
+                                                        name="url_slug",
+                                                        label=_("Registration URL"),
+                                                        hint=_("The URL path for this registration form"),
+                                                        prefix=registration_url_prefix,
+                                                        placeholder="my-assembly-2026",
+                                                        value=registration_page.url_slug,
+                                                        disabled=slugs_locked
+                                                        ) }}
+                                                        {{ prefixed_url_input(
+                                                        name="short_url_slug",
+                                                        label=_("Short URL (optional)"),
+                                                        hint=_("A shorter URL for QR codes and paper invitations"),
+                                                        prefix=short_url_prefix,
+                                                        placeholder="ma26",
+                                                        value=registration_page.short_url_slug,
+                                                        disabled=slugs_locked
+                                                        ) }}
+                                                    </div>
+                                                {% endif %}
+                                                <div class="space-y-4">
+                                                    <p class="text-body-sm" style="color: var(--color-secondary-text);">
+                                                        {{ _("Paste your HTML form code below. The only required placeholders are {{ form_action }} for the form's action attribute and {{ csrf_form_element }} for CSRF protection.") }}
+                                                    </p>
                                         {# HTML Textarea with monospace font. `readonly` is the default;
                        ?edit=1 unlocks it via the Edit CTA below. #}
-                                        {% set textarea_attrs %}
-                                            {% if not edit_mode %}readonly aria-readonly="true"{% endif %} style="font-family: var(--font-mono); font-size: 0.875rem; line-height: 1.5; resize: vertical;{% if not edit_mode %} background-color: var(--color-subtle-background-panels); cursor: default;{% endif %}"
-                                        {% endset %}
-                                        {{ textarea(name="html_content",
-                                        label="",
-                                        value=html_content,
-                                        placeholder="
-                                        <form action=\"{{ form_action }}\" method=\"POST\">
-                                            \n  {{ csrf_form_element }}\n
-                                            <div>
-                                                \n
-                                                <label for=\"first_name\">First Name</label>
-                                                \n
-                                                <input type=\"text\" id=\"first_name\" name=\"first_name\" required />
-                                                \n
-                                            </div>
-                                            \n  <!-- Add more fields here -->\n
-                                            <button type=\"submit\">Register</button>
-                                            \n
-                                        </form>
-                                        ",
-                                        rows=25,
-                                        code_editor=true,
-                                        attrs=textarea_attrs|trim) }}
-                                    </div>
-                                </section>
-                            </div>
+                                                    {% set textarea_attrs %}
+                                                        {% if not edit_mode %}readonly aria-readonly="true"{% endif %} style="font-family: var(--font-mono); font-size: 0.875rem; line-height: 1.5; resize: vertical;{% if not edit_mode %} background-color: var(--color-subtle-background-panels); cursor: default;{% endif %}"
+                                                    {% endset %}
+                                                    {{ textarea(name="html_content",
+                                                    label="",
+                                                    value=html_content,
+                                                    placeholder="
+                                                    <form action=\"{{ form_action }}\" method=\"POST\">
+                                                        \n  {{ csrf_form_element }}\n
+                                                        <div>
+                                                            \n
+                                                            <label for=\"first_name\">First Name</label>
+                                                            \n
+                                                            <input type=\"text\" id=\"first_name\" name=\"first_name\" required />
+                                                            \n
+                                                        </div>
+                                                        \n  <!-- Add more fields here -->\n
+                                                        <button type=\"submit\">Register</button>
+                                                        \n
+                                                    </form>
+                                                    ",
+                                                    rows=25,
+                                                    code_editor=true,
+                                                    attrs=textarea_attrs|trim) }}
+                                                </div>
+                                            </section>
+                                        </div>
                             {# Assets panel (image library). Rendered only in edit mode — uploading and referencing
                images are editing concerns, and hiding the panel keeps the read-only view a clean,
                full-width review of the form. The aside carries the visual box (border/bg) so it
@@ -248,292 +281,292 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                and only the inner content sticks to the top on scroll. That way the box's bottom lines
                up with the editor's bottom instead of leaving the CTAs disconnected. Buttons all use
                type="button" so they never submit the parent editor form. #}
-                            {% if edit_mode %}
-                                <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
-                                       style="background-color: var(--color-tables-cards);
-                                              border: 1px solid var(--color-borders-dividers)">
-                                    <div class="p-6 sticky top-4 w-full">
-                                        <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
-                                        {% set upload_icon %}
-                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                 class="h-4 w-4"
-                                                 fill="none"
-                                                 viewBox="0 0 24 24"
-                                                 stroke="currentColor"
-                                                 stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
-                                            </svg>
-                                        {% endset %}
+                                        {% if edit_mode %}
+                                            <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
+                                                   style="background-color: var(--color-tables-cards);
+                                                          border: 1px solid var(--color-borders-dividers)">
+                                                <div class="p-6 sticky top-4 w-full">
+                                                    <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">{{ _("Assets") }}</h2>
+                                                    {% set upload_icon %}
+                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                             class="h-4 w-4"
+                                                             fill="none"
+                                                             viewBox="0 0 24 24"
+                                                             stroke="currentColor"
+                                                             stroke-width="2">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
+                                                        </svg>
+                                                    {% endset %}
                                         {# Images subsection #}
-                                        <div class="flex items-center justify-between mb-4">
-                                            <h3 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Images") }}</h3>
-                                            {{ button(_("Upload"),
-                                            variant="tertiary",
-                                            leading_icon=upload_icon,
-                                            attrs='type="button" @click="openImageUploadModal()"'
-                                            ) }}
-                                        </div>
+                                                    <div class="flex items-center justify-between mb-4">
+                                                        <h3 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Images") }}</h3>
+                                                        {{ button(_("Upload"),
+                                                        variant="tertiary",
+                                                        leading_icon=upload_icon,
+                                                        attrs='type="button" @click="openImageUploadModal()"'
+                                                        ) }}
+                                                    </div>
                                         {# Format / size hint #}
-                                        <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
-                                             style="background-color: var(--color-info-100);
-                                                    border: 1px solid var(--color-info-400)">
-                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                 class="h-4 w-4 mt-0.5 flex-shrink-0"
-                                                 style="color: var(--color-info-600)"
-                                                 fill="none"
-                                                 viewBox="0 0 24 24"
-                                                 stroke="currentColor"
-                                                 stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                            </svg>
-                                            <p class="text-body-sm" style="color: var(--color-info-600);">
-                                                {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
-                                            </p>
-                                        </div>
+                                                    <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
+                                                         style="background-color: var(--color-info-100);
+                                                                border: 1px solid var(--color-info-400)">
+                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                             class="h-4 w-4 mt-0.5 flex-shrink-0"
+                                                             style="color: var(--color-info-600)"
+                                                             fill="none"
+                                                             viewBox="0 0 24 24"
+                                                             stroke="currentColor"
+                                                             stroke-width="2">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                        </svg>
+                                                        <p class="text-body-sm" style="color: var(--color-info-600);">
+                                                            {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
+                                                        </p>
+                                                    </div>
                                         {# Empty state #}
-                                        <template x-if="!images.length">
-                                            <p class="text-body-sm text-center py-4"
-                                               style="color: var(--color-secondary-text)">
-                                                {{ _("No images uploaded yet.") }}
-                                            </p>
-                                        </template>
+                                                    <template x-if="!images.length">
+                                                        <p class="text-body-sm text-center py-4"
+                                                           style="color: var(--color-secondary-text)">
+                                                            {{ _("No images uploaded yet.") }}
+                                                        </p>
+                                                    </template>
                                         {# Image list #}
-                                        <ul class="space-y-2" x-show="images.length" x-cloak>
-                                            <template x-for="image in images" :key="image.id">
-                                                <li class="rounded-md px-3 py-2 flex items-center justify-between"
-                                                    style="background-color: var(--color-subtle-background-panels)">
-                                                    <a :href="image.public_url"
-                                                       :title="image.alt || image.file_name"
-                                                       target="_blank"
-                                                       rel="noopener"
-                                                       class="text-body-sm truncate flex-1 mr-2"
-                                                       style="color: var(--color-body-text)"
-                                                       x-text="image.display_name"></a>
-                                                    <div class="flex items-center gap-1 flex-shrink-0">
+                                                    <ul class="space-y-2" x-show="images.length" x-cloak>
+                                                        <template x-for="image in images" :key="image.id">
+                                                            <li class="rounded-md px-3 py-2 flex items-center justify-between"
+                                                                style="background-color: var(--color-subtle-background-panels)">
+                                                                <a :href="image.public_url"
+                                                                   :title="image.alt || image.file_name"
+                                                                   target="_blank"
+                                                                   rel="noopener"
+                                                                   class="text-body-sm truncate flex-1 mr-2"
+                                                                   style="color: var(--color-body-text)"
+                                                                   x-text="image.display_name"></a>
+                                                                <div class="flex items-center gap-1 flex-shrink-0">
                                                         {# Image details / edit alt text #}
-                                                        <button type="button"
-                                                                @click="openImageDetailsModal(image)"
-                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                                style="color: var(--color-secondary-text)"
-                                                                :aria-label="image.aria_label_details">
-                                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                                 class="h-4 w-4"
-                                                                 fill="none"
-                                                                 viewBox="0 0 24 24"
-                                                                 stroke="currentColor"
-                                                                 stroke-width="2">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                                            </svg>
-                                                        </button>
+                                                                    <button type="button"
+                                                                            @click="openImageDetailsModal(image)"
+                                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                            style="color: var(--color-secondary-text)"
+                                                                            :aria-label="image.aria_label_details">
+                                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                                             class="h-4 w-4"
+                                                                             fill="none"
+                                                                             viewBox="0 0 24 24"
+                                                                             stroke="currentColor"
+                                                                             stroke-width="2">
+                                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                                        </svg>
+                                                                    </button>
                                                         {# Copy <img> snippet to clipboard #}
-                                                        <button type="button"
-                                                                @click="copyImageSnippet(image)"
-                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                                style="color: var(--color-secondary-text)"
-                                                                :aria-label="image.aria_label_copy_snippet">
-                                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                                 class="h-4 w-4"
-                                                                 fill="none"
-                                                                 viewBox="0 0 24 24"
-                                                                 stroke="currentColor"
-                                                                 stroke-width="2">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                            </svg>
-                                                        </button>
+                                                                    <button type="button"
+                                                                            @click="copyImageSnippet(image)"
+                                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                            style="color: var(--color-secondary-text)"
+                                                                            :aria-label="image.aria_label_copy_snippet">
+                                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                                             class="h-4 w-4"
+                                                                             fill="none"
+                                                                             viewBox="0 0 24 24"
+                                                                             stroke="currentColor"
+                                                                             stroke-width="2">
+                                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                                        </svg>
+                                                                    </button>
                                                         {# Delete #}
-                                                        <button type="button"
-                                                                @click="deleteImage(image)"
-                                                                :disabled="imageBeingDeletedId === image.id"
-                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                                style="color: var(--color-secondary-text)"
-                                                                :aria-label="image.aria_label_delete">
-                                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                                 class="h-4 w-4"
-                                                                 fill="none"
-                                                                 viewBox="0 0 24 24"
-                                                                 stroke="currentColor"
-                                                                 stroke-width="2">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
-                                                            </svg>
-                                                        </button>
-                                                    </div>
-                                                </li>
-                                            </template>
-                                        </ul>
+                                                                    <button type="button"
+                                                                            @click="deleteImage(image)"
+                                                                            :disabled="imageBeingDeletedId === image.id"
+                                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                            style="color: var(--color-secondary-text)"
+                                                                            :aria-label="image.aria_label_delete">
+                                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                                             class="h-4 w-4"
+                                                                             fill="none"
+                                                                             viewBox="0 0 24 24"
+                                                                             stroke="currentColor"
+                                                                             stroke-width="2">
+                                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                                                                        </svg>
+                                                                    </button>
+                                                                </div>
+                                                            </li>
+                                                        </template>
+                                                    </ul>
                                         {# Documents subsection #}
-                                        <div class="flex items-center justify-between mt-6 mb-4 pt-4"
-                                             style="border-top: 1px solid var(--color-borders-dividers)">
-                                            <h3 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Documents") }}</h3>
-                                            {{ button(_("Upload"),
-                                            variant="tertiary",
-                                            leading_icon=upload_icon,
-                                            attrs='type="button" @click="openDocumentUploadModal()"'
-                                            ) }}
-                                        </div>
-                                        {# Format / size hint #}
-                                        <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
-                                             style="background-color: var(--color-info-100);
-                                                    border: 1px solid var(--color-info-400)">
-                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                 class="h-4 w-4 mt-0.5 flex-shrink-0"
-                                                 style="color: var(--color-info-600)"
-                                                 fill="none"
-                                                 viewBox="0 0 24 24"
-                                                 stroke="currentColor"
-                                                 stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                            </svg>
-                                            <p class="text-body-sm" style="color: var(--color-info-600);">
-                                                {{ _("PDF files only. Maximum file size: %(max)s MB per document.", max=max_pdf_upload_mb) }}
-                                            </p>
-                                        </div>
-                                        {# Empty state #}
-                                        <template x-if="!documents.length">
-                                            <p class="text-body-sm text-center py-4"
-                                               style="color: var(--color-secondary-text)">
-                                                {{ _("No documents uploaded yet.") }}
-                                            </p>
-                                        </template>
-                                        {# Document list #}
-                                        <ul class="space-y-2" x-show="documents.length" x-cloak>
-                                            <template x-for="doc in documents" :key="doc.id">
-                                                <li class="rounded-md px-3 py-2 flex items-center justify-between"
-                                                    style="background-color: var(--color-subtle-background-panels)">
-                                                    <a :href="doc.public_url"
-                                                       :title="doc.label || doc.file_name"
-                                                       target="_blank"
-                                                       rel="noopener"
-                                                       class="text-body-sm truncate flex-1 mr-2"
-                                                       style="color: var(--color-body-text)"
-                                                       x-text="doc.display_name"></a>
-                                                    <div class="flex items-center gap-1 flex-shrink-0">
-                                                        {# Document details / edit label #}
-                                                        <button type="button"
-                                                                @click="openDocumentDetailsModal(doc)"
-                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                                style="color: var(--color-secondary-text)"
-                                                                :aria-label="doc.aria_label_details">
-                                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                                 class="h-4 w-4"
-                                                                 fill="none"
-                                                                 viewBox="0 0 24 24"
-                                                                 stroke="currentColor"
-                                                                 stroke-width="2">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                                            </svg>
-                                                        </button>
-                                                        {# Copy <a> snippet to clipboard #}
-                                                        <button type="button"
-                                                                @click="copyDocumentSnippet(doc)"
-                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                                style="color: var(--color-secondary-text)"
-                                                                :aria-label="doc.aria_label_copy_snippet">
-                                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                                 class="h-4 w-4"
-                                                                 fill="none"
-                                                                 viewBox="0 0 24 24"
-                                                                 stroke="currentColor"
-                                                                 stroke-width="2">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                            </svg>
-                                                        </button>
-                                                        {# Delete #}
-                                                        <button type="button"
-                                                                @click="deleteDocument(doc)"
-                                                                :disabled="documentBeingDeletedId === doc.id"
-                                                                class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
-                                                                style="color: var(--color-secondary-text)"
-                                                                :aria-label="doc.aria_label_delete">
-                                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                                 class="h-4 w-4"
-                                                                 fill="none"
-                                                                 viewBox="0 0 24 24"
-                                                                 stroke="currentColor"
-                                                                 stroke-width="2">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
-                                                            </svg>
-                                                        </button>
+                                                    <div class="flex items-center justify-between mt-6 mb-4 pt-4"
+                                                         style="border-top: 1px solid var(--color-borders-dividers)">
+                                                        <h3 class="text-heading-sm" style="color: var(--color-headings);">{{ _("Documents") }}</h3>
+                                                        {{ button(_("Upload"),
+                                                        variant="tertiary",
+                                                        leading_icon=upload_icon,
+                                                        attrs='type="button" @click="openDocumentUploadModal()"'
+                                                        ) }}
                                                     </div>
-                                                </li>
-                                            </template>
-                                        </ul>
+                                        {# Format / size hint #}
+                                                    <div class="rounded-md p-3 mb-4 flex gap-2 items-start"
+                                                         style="background-color: var(--color-info-100);
+                                                                border: 1px solid var(--color-info-400)">
+                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                             class="h-4 w-4 mt-0.5 flex-shrink-0"
+                                                             style="color: var(--color-info-600)"
+                                                             fill="none"
+                                                             viewBox="0 0 24 24"
+                                                             stroke="currentColor"
+                                                             stroke-width="2">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                        </svg>
+                                                        <p class="text-body-sm" style="color: var(--color-info-600);">
+                                                            {{ _("PDF files only. Maximum file size: %(max)s MB per document.", max=max_pdf_upload_mb) }}
+                                                        </p>
+                                                    </div>
+                                        {# Empty state #}
+                                                    <template x-if="!documents.length">
+                                                        <p class="text-body-sm text-center py-4"
+                                                           style="color: var(--color-secondary-text)">
+                                                            {{ _("No documents uploaded yet.") }}
+                                                        </p>
+                                                    </template>
+                                        {# Document list #}
+                                                    <ul class="space-y-2" x-show="documents.length" x-cloak>
+                                                        <template x-for="doc in documents" :key="doc.id">
+                                                            <li class="rounded-md px-3 py-2 flex items-center justify-between"
+                                                                style="background-color: var(--color-subtle-background-panels)">
+                                                                <a :href="doc.public_url"
+                                                                   :title="doc.label || doc.file_name"
+                                                                   target="_blank"
+                                                                   rel="noopener"
+                                                                   class="text-body-sm truncate flex-1 mr-2"
+                                                                   style="color: var(--color-body-text)"
+                                                                   x-text="doc.display_name"></a>
+                                                                <div class="flex items-center gap-1 flex-shrink-0">
+                                                        {# Document details / edit label #}
+                                                                    <button type="button"
+                                                                            @click="openDocumentDetailsModal(doc)"
+                                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                            style="color: var(--color-secondary-text)"
+                                                                            :aria-label="doc.aria_label_details">
+                                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                                             class="h-4 w-4"
+                                                                             fill="none"
+                                                                             viewBox="0 0 24 24"
+                                                                             stroke="currentColor"
+                                                                             stroke-width="2">
+                                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                                        </svg>
+                                                                    </button>
+                                                        {# Copy <a> snippet to clipboard #}
+                                                                    <button type="button"
+                                                                            @click="copyDocumentSnippet(doc)"
+                                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                            style="color: var(--color-secondary-text)"
+                                                                            :aria-label="doc.aria_label_copy_snippet">
+                                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                                             class="h-4 w-4"
+                                                                             fill="none"
+                                                                             viewBox="0 0 24 24"
+                                                                             stroke="currentColor"
+                                                                             stroke-width="2">
+                                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                                        </svg>
+                                                                    </button>
+                                                        {# Delete #}
+                                                                    <button type="button"
+                                                                            @click="deleteDocument(doc)"
+                                                                            :disabled="documentBeingDeletedId === doc.id"
+                                                                            class="p-1.5 rounded-md transition-colors hover:bg-gray-100"
+                                                                            style="color: var(--color-secondary-text)"
+                                                                            :aria-label="doc.aria_label_delete">
+                                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                                             class="h-4 w-4"
+                                                                             fill="none"
+                                                                             viewBox="0 0 24 24"
+                                                                             stroke="currentColor"
+                                                                             stroke-width="2">
+                                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                                                                        </svg>
+                                                                    </button>
+                                                                </div>
+                                                            </li>
+                                                        </template>
+                                                    </ul>
+                                                </div>
+                                            </aside>
+                                        {% endif %}
                                     </div>
-                                </aside>
-                            {% endif %}
-                        </div>
-                    </form>
+                                </form>
                     {# Sticky wizard footer — navigation only (Edit/Cancel/Save live in the card header).
                        Sticky so clicking through the steps never requires scrolling; z-30 keeps it under
                        the modal layer (backdrops are z-40, panels z-50). While editing, navigation is
                        locked so the preview step can never silently lag unsaved changes. #}
-                    <div class="wizard-footer" x-scroll-preserve-links>
-                        <div class="wizard-footer-box">
-                            {% if edit_mode %}
-                                <span id="editing-nav-hint"
-                                      class="mr-auto text-body-sm"
-                                      style="color: var(--color-secondary-text)">
-                                    {{ _("Editing in progress — save or cancel to continue") }}
-                                </span>
-                                {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
-                            {% else %}
-                                {{ button(_("Next →"), variant="primary", href=next_url) }}
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
-            {% endif %}
-            {% if active_section == "email" %}
-                <div id="reg-steps-panel-email"
-                     role="tabpanel"
-                     aria-labelledby="reg-steps-tab-email"
-                     tabindex="0"
-                     class="space-y-4">
-                    {% set email_save_url = url_for('backoffice_registration.save_assembly_registration_email', assembly_id=assembly.id, url_slug=registration_page.url_slug) %}
-                    {% set email_edit_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='email', edit='1') %}
-                    {% set email_view_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='email') %}
-                    {% set preview_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='preview') %}
-                    {% set back_to_form_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='form') %}
+                                <div class="wizard-footer" x-scroll-preserve-links>
+                                    <div class="wizard-footer-box">
+                                        {% if edit_mode %}
+                                            <span id="editing-nav-hint"
+                                                  class="mr-auto text-body-sm"
+                                                  style="color: var(--color-secondary-text)">
+                                                {{ _("Editing in progress — save or cancel to continue") }}
+                                            </span>
+                                            {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
+                                        {% else %}
+                                            {{ button(_("Next →"), variant="primary", href=next_url) }}
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                        {% endif %}
+                        {% if active_section == "email" %}
+                            <div id="reg-steps-panel-email"
+                                 role="tabpanel"
+                                 aria-labelledby="reg-steps-tab-email"
+                                 tabindex="0"
+                                 class="space-y-4">
+                                {% set email_save_url = url_for('backoffice_registration.save_assembly_registration_email', assembly_id=assembly.id, url_slug=registration_page.url_slug) %}
+                                {% set email_edit_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='email', edit='1') %}
+                                {% set email_view_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='email') %}
+                                {% set preview_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='preview') %}
+                                {% set back_to_form_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='form') %}
                     {# Readiness banner — surfaces problems that would stop the auto-reply from actually being delivered #}
-                    {% for problem in email_readiness_problems %}
-                        {% set is_error = problem.severity == "error" %}
-                        <div class="rounded-lg p-4"
-                             role="alert"
-                             style="background-color: var({{ '--color-error-100' if is_error else '--color-warning-100' }});
-                                    border: 1px solid var({{ '--color-error-400' if is_error else '--color-warning-400' }});
-                                    color: var({{ '--color-error-600' if is_error else '--color-warning-600' }})">
-                            <p class="text-body-md">
-                                <span class="font-semibold">{% if is_error %}⛔ {{ _("Auto-reply cannot be sent") }}:{% else %}⚠️ {{ _("Heads up") }}:{% endif %}</span>
-                                {{ problem.message }}
-                            </p>
-                        </div>
-                    {% endfor %}
-                    {% if not email_template %}
+                                {% for problem in email_readiness_problems %}
+                                    {% set is_error = problem.severity == "error" %}
+                                    <div class="rounded-lg p-4"
+                                         role="alert"
+                                         style="background-color: var({{ '--color-error-100' if is_error else '--color-warning-100' }});
+                                                border: 1px solid var({{ '--color-error-400' if is_error else '--color-warning-400' }});
+                                                color: var({{ '--color-error-600' if is_error else '--color-warning-600' }})">
+                                        <p class="text-body-md">
+                                            <span class="font-semibold">{% if is_error %}⛔ {{ _("Auto-reply cannot be sent") }}:{% else %}⚠️ {{ _("Heads up") }}:{% endif %}</span>
+                                            {{ problem.message }}
+                                        </p>
+                                    </div>
+                                {% endfor %}
+                                {% if not email_template %}
                         {# Empty state — no template exists yet. One button to create + assign + enter edit mode. #}
-                        <section class="rounded-lg p-6"
-                                 style="background-color: var(--color-tables-cards);
-                                        border: 1px solid var(--color-borders-dividers)">
-                            <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">{{ _("Auto-reply email") }}</h2>
-                            <p class="text-body-md mb-4" style="color: var(--color-body-text);">
-                                {{ _("Automatically send a confirmation email to people after they register. Templates support variables like the respondent's first name and the assembly title.") }}
-                            </p>
-                            <form method="post"
-                                  action="{{ email_save_url }}"
-                                  x-data
-                                  x-preserve-scroll-on-submit>
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                                <input type="hidden" name="action" value="create" />
-                                {{ button(_("Set up auto-reply email"), type="submit", variant="primary") }}
-                            </form>
-                        </section>
+                                    <section class="rounded-lg p-6"
+                                             style="background-color: var(--color-tables-cards);
+                                                    border: 1px solid var(--color-borders-dividers)">
+                                        <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">{{ _("Auto-reply email") }}</h2>
+                                        <p class="text-body-md mb-4" style="color: var(--color-body-text);">
+                                            {{ _("Automatically send a confirmation email to people after they register. Templates support variables like the respondent's first name and the assembly title.") }}
+                                        </p>
+                                        <form method="post"
+                                              action="{{ email_save_url }}"
+                                              x-data
+                                              x-preserve-scroll-on-submit>
+                                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                            <input type="hidden" name="action" value="create" />
+                                            {{ button(_("Set up auto-reply email"), type="submit", variant="primary") }}
+                                        </form>
+                                    </section>
                         {# Sticky wizard footer — the auto-reply email is optional, so Back/Next stay
                            available even before a template exists. #}
-                        <div class="wizard-footer" x-scroll-preserve-links>
-                            <div class="wizard-footer-box">
-                                <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
-                                {{ button(_("Next →"), variant="primary", href=preview_url) }}
-                            </div>
-                        </div>
-                    {% else %}
+                                    <div class="wizard-footer" x-scroll-preserve-links>
+                                        <div class="wizard-footer-box">
+                                            <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
+                                            {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                                        </div>
+                                    </div>
+                                {% else %}
                         {# Two-box layout mirroring the form section: editor on the left (2/3), variables reference
                            on the right (1/3, sticky). The form wraps both columns and the CTA row so the CTAs
                            align to the far right of the whole layout and the sticky aside unsticks at the
@@ -541,19 +574,19 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                         {# The action name comes from the clicked submit button (Save / Save and next).
                            A hidden <input name="action"> here would be sent as a duplicate and would win
                            over the button value because request.form.get() returns the first entry. #}
-                        <form method="post"
-                              action="{{ email_save_url }}"
-                              x-data
-                              x-preserve-scroll-on-submit
-                              {% if edit_mode %}@input="markEditDirty()" @change="markEditDirty()" @submit="allowLeave()"{% endif %}>
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                            <div class="flex flex-col lg:flex-row gap-6">
-                                <div class="flex-1 min-w-0">
-                                    <section class="rounded-lg p-6"
-                                             style="background-color: var(--color-tables-cards);
-                                                    border: 1px solid var(--color-borders-dividers)">
-                                        <div class="flex items-center justify-between mb-4 gap-4">
-                                            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Auto-reply email template") }}</h2>
+                                    <form method="post"
+                                          action="{{ email_save_url }}"
+                                          x-data
+                                          x-preserve-scroll-on-submit
+                                          {% if edit_mode %}@input="markEditDirty()" @change="markEditDirty()" @submit="allowLeave()"{% endif %}>
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                        <div class="flex flex-col lg:flex-row gap-6">
+                                            <div class="flex-1 min-w-0">
+                                                <section class="rounded-lg p-6"
+                                                         style="background-color: var(--color-tables-cards);
+                                                                border: 1px solid var(--color-borders-dividers)">
+                                                    <div class="flex items-center justify-between mb-4 gap-4">
+                                                        <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Auto-reply email template") }}</h2>
                                             {# Header right: the always-on indicator plus the editorial controls — Edit
                                                swaps in place to Cancel/Save, mirroring the form step. The checkbox is
                                                deliberately checked and disabled: the auto-reply is always sent in the
@@ -561,331 +594,333 @@ ABOUTME: Allows assembly managers to configure RSVP/registration forms with cust
                                                emerges, a proper service-layer enable/disable gets built and this
                                                checkbox gets wired to it. x-scroll-preserve-links keeps the scroll
                                                position across the Edit/Cancel page reloads, matching the form step. #}
-                                            <div class="flex items-center gap-4" x-scroll-preserve-links>
-                                                {{ checkbox(name="auto_reply_enabled",
-                                                label=_("Send auto-reply email"),
-                                                checked=true,
-                                                disabled=true) }}
-                                                {% if edit_mode %}
-                                                    {{ button(_("Cancel"), variant="secondary", href=email_view_url, attrs='@click="guardLeave($event)"') }}
-                                                    {{ button(_("Save") , type="submit", variant="primary", attrs='name="action" value="save"') }}
-                                                {% elif registration_status != "CLOSED" %}
-                                                    {{ button(_("Edit"), variant="secondary", href=email_edit_url) }}
-                                                {% endif %}
-                                            </div>
-                                        </div>
-                                        <div class="space-y-4">
-                                            {% set common_input_attrs %}{% if not edit_mode %}readonly aria-readonly="true" style="background-color: var(--color-subtle-background-panels); cursor: default;"{% endif %}{% endset %}
+                                                        <div class="flex items-center gap-4" x-scroll-preserve-links>
+                                                            {{ checkbox(name="auto_reply_enabled",
+                                                            label=_("Send auto-reply email"),
+                                                            checked=true,
+                                                            disabled=true) }}
+                                                            {% if edit_mode %}
+                                                                {{ button(_("Cancel"), variant="secondary", href=email_view_url, attrs='@click="guardLeave($event)"') }}
+                                                                {{ button(_("Save") , type="submit", variant="primary", attrs='name="action" value="save"') }}
+                                                            {% elif registration_status != "CLOSED" %}
+                                                                {{ button(_("Edit"), variant="secondary", href=email_edit_url) }}
+                                                            {% endif %}
+                                                        </div>
+                                                    </div>
+                                                    <div class="space-y-4">
+                                                        {% set common_input_attrs %}{% if not edit_mode %}readonly aria-readonly="true" style="background-color: var(--color-subtle-background-panels); cursor: default;"{% endif %}{% endset %}
                                             {# Template name is not exposed yet — one template per page, always called "Registration
 auto-reply". When multi-template support ships this becomes a visible input. #}
-                                            {{ input(name="template_subject",
-                                            label=_("Email subject"),
-                                            value=email_template.subject,
-                                            hint=_("Jinja variables allowed, e.g. {{ assembly.title }}."),
-                                            required=true,
-                                            attrs=common_input_attrs|trim) }}
-                                            {% set body_attrs %}
-                                                {% if not edit_mode %}readonly aria-readonly="true"{% endif %} style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;{% if not edit_mode %} background-color: var(--color-subtle-background-panels); cursor: default;{% endif %}"
-                                            {% endset %}
-                                            {{ textarea(name="template_body_html",
-                                            label=_("HTML body"),
-                                            value=email_template.body_html,
-                                            hint=_("Jinja + HTML. A plain-text version is generated automatically for email clients that need it."),
-                                            required=true,
-                                            rows=18,
-                                            code_editor=true,
-                                            attrs=body_attrs|trim) }}
-                                        </div>
-                                    </section>
-                                </div>
+                                                        {{ input(name="template_subject",
+                                                        label=_("Email subject"),
+                                                        value=email_template.subject,
+                                                        hint=_("Jinja variables allowed, e.g. {{ assembly.title }}."),
+                                                        required=true,
+                                                        attrs=common_input_attrs|trim) }}
+                                                        {% set body_attrs %}
+                                                            {% if not edit_mode %}readonly aria-readonly="true"{% endif %} style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.875rem; line-height: 1.5; resize: vertical;{% if not edit_mode %} background-color: var(--color-subtle-background-panels); cursor: default;{% endif %}"
+                                                        {% endset %}
+                                                        {{ textarea(name="template_body_html",
+                                                        label=_("HTML body"),
+                                                        value=email_template.body_html,
+                                                        hint=_("Jinja + HTML. A plain-text version is generated automatically for email clients that need it."),
+                                                        required=true,
+                                                        rows=18,
+                                                        code_editor=true,
+                                                        attrs=body_attrs|trim) }}
+                                                    </div>
+                                                </section>
+                                            </div>
                                 {# Variables reference sidebar — rendered only in edit mode: it's an authoring
                                    aid, and hiding it keeps the read-only view a clean, full-width review of the
                                    email. The aside carries the visual box so it stretches to match the editor's
                                    height, and only the inner content sticks on scroll (same trick as the S1
                                    Assets panel). #}
-                                {% if edit_mode %}
-                                    <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
-                                           style="background-color: var(--color-tables-cards);
-                                                  border: 1px solid var(--color-borders-dividers)">
-                                        <div class="p-6 sticky top-4 w-full">
-                                            <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">{{ _("Available variables") }}</h2>
-                                            <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                                {{ _("Click a variable to select it, then copy and paste into the subject or body. Missing values render as an empty string.") }}
-                                            </p>
-                                            {% set variables = [
-                                            {"expr": "{{ assembly.title }}", "label": _("Assembly title")},
-                                            {"expr": "{{ assembly.question }}", "label": _("Assembly question")},
-                                            {"expr": "{{ assembly.first_assembly_date }}", "label": _("First assembly date (ISO)")},
-                                            {"expr": "{{ respondent.first_name }}", "label": _("Respondent first name")},
-                                            {"expr": "{{ respondent.first_name_or_friend }}", "label": _("First name, or 'Friend' as a fallback")},
-                                            {"expr": "{{ respondent.full_name }}", "label": _("Respondent full name")},
-                                            {"expr": "{{ respondent.email }}", "label": _("Respondent email address")}
-                                            ] %}
-                                            <ul class="space-y-3">
-                                                {% for variable in variables %}
-                                                    <li>
-                                                        <label for="variable-{{ loop.index0 }}"
-                                                               class="text-body-sm font-medium block mb-1"
-                                                               style="color: var(--color-headings)">
-                                                            {{ variable.label }}
-                                                        </label>
-                                                        <div class="flex gap-2">
+                                            {% if edit_mode %}
+                                                <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
+                                                       style="background-color: var(--color-tables-cards);
+                                                              border: 1px solid var(--color-borders-dividers)">
+                                                    <div class="p-6 sticky top-4 w-full">
+                                                        <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">{{ _("Available variables") }}</h2>
+                                                        <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                                            {{ _("Click a variable to select it, then copy and paste into the subject or body. Missing values render as an empty string.") }}
+                                                        </p>
+                                                        {% set variables = [
+                                                        {"expr": "{{ assembly.title }}", "label": _("Assembly title")},
+                                                        {"expr": "{{ assembly.question }}", "label": _("Assembly question")},
+                                                        {"expr": "{{ assembly.first_assembly_date }}", "label": _("First assembly date (ISO)")},
+                                                        {"expr": "{{ respondent.first_name }}", "label": _("Respondent first name")},
+                                                        {"expr": "{{ respondent.first_name_or_friend }}", "label": _("First name, or 'Friend' as a fallback")},
+                                                        {"expr": "{{ respondent.full_name }}", "label": _("Respondent full name")},
+                                                        {"expr": "{{ respondent.email }}", "label": _("Respondent email address")}
+                                                        ] %}
+                                                        <ul class="space-y-3">
+                                                            {% for variable in variables %}
+                                                                <li>
+                                                                    <label for="variable-{{ loop.index0 }}"
+                                                                           class="text-body-sm font-medium block mb-1"
+                                                                           style="color: var(--color-headings)">
+                                                                        {{ variable.label }}
+                                                                    </label>
+                                                                    <div class="flex gap-2">
                                                             {# readonly + aria-readonly: some screen readers still announce "edit text"
                                                            for a readonly input, so we set aria-readonly explicitly. #}
-                                                            <input type="text"
-                                                                   id="variable-{{ loop.index0 }}"
-                                                                   readonly
-                                                                   aria-readonly="true"
-                                                                   value="{{ variable.expr }}"
-                                                                   @click="$event.target.select()"
-                                                                   class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
-                                                                   style="border: 1px solid var(--color-borders-dividers);
-                                                                          background: var(--color-page-background)" />
-                                                            <button type="button"
-                                                                    data-copy-text="{{ variable.expr }}"
-                                                                    data-copy-msg="{{ _('Variable copied to clipboard') }}"
-                                                                    @click="copyToClipboard($el)"
-                                                                    class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                                    style="border: 1px solid var(--color-borders-dividers);
-                                                                           color: var(--color-secondary-text)"
-                                                                    aria-label="{{ _('Copy %(label)s variable', label=variable.label) }}">
-                                                                <svg xmlns="http://www.w3.org/2000/svg"
-                                                                     class="h-4 w-4"
-                                                                     fill="none"
-                                                                     viewBox="0 0 24 24"
-                                                                     stroke="currentColor"
-                                                                     stroke-width="2">
-                                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                                                </svg>
-                                                            </button>
-                                                        </div>
-                                                    </li>
-                                                {% endfor %}
-                                            </ul>
+                                                                        <input type="text"
+                                                                               id="variable-{{ loop.index0 }}"
+                                                                               readonly
+                                                                               aria-readonly="true"
+                                                                               value="{{ variable.expr }}"
+                                                                               @click="$event.target.select()"
+                                                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-body-sm font-mono"
+                                                                               style="border: 1px solid var(--color-borders-dividers);
+                                                                                      background: var(--color-page-background)" />
+                                                                        <button type="button"
+                                                                                data-copy-text="{{ variable.expr }}"
+                                                                                data-copy-msg="{{ _('Variable copied to clipboard') }}"
+                                                                                @click="copyToClipboard($el)"
+                                                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                                                style="border: 1px solid var(--color-borders-dividers);
+                                                                                       color: var(--color-secondary-text)"
+                                                                                aria-label="{{ _('Copy %(label)s variable', label=variable.label) }}">
+                                                                            <svg xmlns="http://www.w3.org/2000/svg"
+                                                                                 class="h-4 w-4"
+                                                                                 fill="none"
+                                                                                 viewBox="0 0 24 24"
+                                                                                 stroke="currentColor"
+                                                                                 stroke-width="2">
+                                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                                            </svg>
+                                                                        </button>
+                                                                    </div>
+                                                                </li>
+                                                            {% endfor %}
+                                                        </ul>
+                                                    </div>
+                                                </aside>
+                                            {% endif %}
                                         </div>
-                                    </aside>
-                                {% endif %}
-                            </div>
-                        </form>
+                                    </form>
                         {# Sticky wizard footer — navigation only (Edit/Cancel/Save live in the card header).
                            While editing, navigation is locked so unsaved changes can't be silently left behind. #}
-                        <div class="wizard-footer" x-scroll-preserve-links>
-                            <div class="wizard-footer-box">
-                                {% if edit_mode %}
-                                    <span class="mr-auto flex items-center gap-3">
-                                        {{ button(_("← Back"), variant="tertiary", disabled=true, aria_describedby="editing-nav-hint") }}
-                                        <span id="editing-nav-hint"
-                                              class="text-body-sm"
-                                              style="color: var(--color-secondary-text)">
-                                            {{ _("Editing in progress — save or cancel to continue") }}
-                                        </span>
-                                    </span>
-                                    {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
-                                {% else %}
-                                    <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
-                                    {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                                    <div class="wizard-footer" x-scroll-preserve-links>
+                                        <div class="wizard-footer-box">
+                                            {% if edit_mode %}
+                                                <span class="mr-auto flex items-center gap-3">
+                                                    {{ button(_("← Back"), variant="tertiary", disabled=true, aria_describedby="editing-nav-hint") }}
+                                                    <span id="editing-nav-hint"
+                                                          class="text-body-sm"
+                                                          style="color: var(--color-secondary-text)">
+                                                        {{ _("Editing in progress — save or cancel to continue") }}
+                                                    </span>
+                                                </span>
+                                                {{ button(_("Next →"), variant="primary", disabled=true, aria_describedby="editing-nav-hint") }}
+                                            {% else %}
+                                                <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_form_url) }}</span>
+                                                {{ button(_("Next →"), variant="primary", href=preview_url) }}
+                                            {% endif %}
+                                        </div>
+                                    </div>
                                 {% endif %}
                             </div>
-                        </div>
-                    {% endif %}
-                </div>
-            {% endif %}
-            {% if active_section == "preview" %}
-                <div id="reg-steps-panel-preview"
-                     role="tabpanel"
-                     aria-labelledby="reg-steps-tab-preview"
-                     tabindex="0">
+                        {% endif %}
+                        {% if active_section == "preview" %}
+                            <div id="reg-steps-panel-preview"
+                                 role="tabpanel"
+                                 aria-labelledby="reg-steps-tab-preview"
+                                 tabindex="0">
                     {# Two-column layout mirroring the earlier steps: live form preview on the
                        left (2/3), sharing links + QR on the right (1/3, sticky). #}
-                    <div class="flex flex-col lg:flex-row gap-6">
-                        <div class="flex-1 min-w-0">
-                            <section class="rounded-lg p-6"
-                                     style="background-color: var(--color-tables-cards);
-                                            border: 1px solid var(--color-borders-dividers)">
-                                <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">{{ _("Form preview") }}</h2>
-                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                    {{ _("This is the last saved version of your registration form, shown exactly as visitors will see it. You can try the fields and dropdowns, but the form cannot be submitted from here.") }}
-                                </p>
-                                {% if registration_page %}
+                                <div class="flex flex-col lg:flex-row gap-6">
+                                    <div class="flex-1 min-w-0">
+                                        <section class="rounded-lg p-6"
+                                                 style="background-color: var(--color-tables-cards);
+                                                        border: 1px solid var(--color-borders-dividers)">
+                                            <h2 class="text-heading-lg mb-2" style="color: var(--color-headings);">{{ _("Form preview") }}</h2>
+                                            <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                                {{ _("This is the last saved version of your registration form, shown exactly as visitors will see it. You can try the fields and dropdowns, but the form cannot be submitted from here.") }}
+                                            </p>
+                                            {% if registration_page %}
                                     {# The preview is a same-origin iframe of a dedicated backoffice route that
                                        renders the saved form through the public pipeline with submission
                                        disabled. The iframe keeps the author's HTML/CSS fully isolated from the
                                        backoffice page. #}
-                                    <iframe src="{{ url_for('backoffice_registration.preview_registration_form', assembly_id=assembly.id, url_slug=registration_page.url_slug) }}"
-                                            title="{{ _('Registration form preview') }}"
-                                            class="w-full rounded-md"
-                                            style="height: 70vh;
-                                                   min-height: 480px;
-                                                   border: 1px solid var(--color-borders-dividers);
-                                                   background-color: white"></iframe>
-                                {% endif %}
-                            </section>
-                        </div>
+                                                <iframe src="{{ url_for('backoffice_registration.preview_registration_form', assembly_id=assembly.id, url_slug=registration_page.url_slug) }}"
+                                                        title="{{ _('Registration form preview') }}"
+                                                        class="w-full rounded-md"
+                                                        style="height: 70vh;
+                                                               min-height: 480px;
+                                                               border: 1px solid var(--color-borders-dividers);
+                                                               background-color: white"></iframe>
+                                            {% endif %}
+                                        </section>
+                                    </div>
                         {# Sharing sidebar — the aside carries the visual box so it stretches to match
                            the preview's height, and only the inner content sticks on scroll (same
                            trick as the earlier steps' sidebars). #}
-                        <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
-                               style="background-color: var(--color-tables-cards);
-                                      border: 1px solid var(--color-borders-dividers)">
-                            <div class="p-6 sticky top-4 w-full">
-                                <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">{{ _("Share your form") }}</h2>
-                                {% if registration_page %}
-                                    <div class="space-y-6">
+                                    <aside class="lg:flex-shrink-0 w-full lg:w-[400px] rounded-lg"
+                                           style="background-color: var(--color-tables-cards);
+                                                  border: 1px solid var(--color-borders-dividers)">
+                                        <div class="p-6 sticky top-4 w-full">
+                                            <h2 class="text-heading-lg mb-4" style="color: var(--color-headings);">{{ _("Share your form") }}</h2>
+                                            {% if registration_page %}
+                                                <div class="space-y-6">
                                         {# Registration URL #}
-                                        {{ readonly_url_display(label=_("Registration URL"),
-                                        hint=_("The URL for your registration form"),
-                                        url=registration_url) }}
+                                                    {{ readonly_url_display(label=_("Registration URL"),
+                                                    hint=_("The URL for your registration form"),
+                                                    url=registration_url) }}
                                         {# Short URL — only if configured #}
-                                        {% if registration_page.short_url_slug %}
-                                            {{ readonly_url_display(label=_("Short URL"),
-                                            hint=_("A shorter URL for QR codes and paper invitations"),
-                                            url=short_url) }}
-                                        {% endif %}
+                                                    {% if registration_page.short_url_slug %}
+                                                        {{ readonly_url_display(label=_("Short URL"),
+                                                        hint=_("A shorter URL for QR codes and paper invitations"),
+                                                        url=short_url) }}
+                                                    {% endif %}
                                         {# QR Code — only when short URL is configured. Stacked vertically to
                                            fit the 400px column. #}
-                                        {% if qr_code_data_url %}
-                                            <div class="pt-4"
-                                                 style="border-top: 1px solid var(--color-borders-dividers)">
-                                                <h3 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("QR Code") }}</h3>
-                                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                                    {{ _("Use this QR code on paper invitations") }}
-                                                </p>
-                                                <div class="flex flex-col items-start gap-4">
-                                                    <div class="p-4 rounded-lg"
-                                                         style="background-color: white;
-                                                                border: 1px solid var(--color-borders-dividers)">
-                                                        <img src="{{ qr_code_data_url }}"
-                                                             alt="{{ _('QR code for registration page') }}"
-                                                             class="w-40 h-40" />
-                                                    </div>
-                                                    <div class="flex flex-col gap-2">
-                                                        <a href="{{ url_for('backoffice_registration.download_registration_qr_code', assembly_id=assembly.id, url_slug=registration_page.url_slug) }}"
-                                                           class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-button-md transition-colors"
-                                                           style="background-color: var(--color-button-secondary-bg);
-                                                                  color: var(--color-button-secondary-text);
-                                                                  border: 1px solid var(--color-borders-dividers)"
-                                                           download>
-                                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                                 class="h-5 w-5"
-                                                                 fill="none"
-                                                                 viewBox="0 0 24 24"
-                                                                 stroke="currentColor"
-                                                                 stroke-width="1.5">
-                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                                                            </svg>
-                                                            {{ _("Download QR Code") }}
-                                                        </a>
-                                                        <p class="text-body-sm" style="color: var(--color-secondary-text);">{{ _("PNG format, 400x400 pixels") }}</p>
-                                                    </div>
+                                                    {% if qr_code_data_url %}
+                                                        <div class="pt-4"
+                                                             style="border-top: 1px solid var(--color-borders-dividers)">
+                                                            <h3 class="text-heading-sm mb-3" style="color: var(--color-headings);">{{ _("QR Code") }}</h3>
+                                                            <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                                                {{ _("Use this QR code on paper invitations") }}
+                                                            </p>
+                                                            <div class="flex flex-col items-start gap-4">
+                                                                <div class="p-4 rounded-lg"
+                                                                     style="background-color: white;
+                                                                            border: 1px solid var(--color-borders-dividers)">
+                                                                    <img src="{{ qr_code_data_url }}"
+                                                                         alt="{{ _('QR code for registration page') }}"
+                                                                         class="w-40 h-40" />
+                                                                </div>
+                                                                <div class="flex flex-col gap-2">
+                                                                    <a href="{{ url_for('backoffice_registration.download_registration_qr_code', assembly_id=assembly.id, url_slug=registration_page.url_slug) }}"
+                                                                       class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-button-md transition-colors"
+                                                                       style="background-color: var(--color-button-secondary-bg);
+                                                                              color: var(--color-button-secondary-text);
+                                                                              border: 1px solid var(--color-borders-dividers)"
+                                                                       download>
+                                                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                                                             class="h-5 w-5"
+                                                                             fill="none"
+                                                                             viewBox="0 0 24 24"
+                                                                             stroke="currentColor"
+                                                                             stroke-width="1.5">
+                                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                                                        </svg>
+                                                                        {{ _("Download QR Code") }}
+                                                                    </a>
+                                                                    <p class="text-body-sm" style="color: var(--color-secondary-text);">{{ _("PNG format, 400x400 pixels") }}</p>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    {% endif %}
                                                 </div>
-                                            </div>
-                                        {% endif %}
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </aside>
-                    </div>
+                                            {% endif %}
+                                        </div>
+                                    </aside>
+                                </div>
                     {# Bottom CTAs — Back on the left is always available. TEST offers Publish;
                        PUBLISHED offers Unpublish (tertiary, reversible — back to test mode) and
                        Close registration (secondary, terminal — goes through a confirmation
                        dialog because there is no reopen). CLOSED offers nothing. #}
-                    {% set registration_save_url = url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id, url_slug=registration_page.url_slug) %}
-                    {% set back_to_email_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='email') %}
-                    <div class="wizard-footer" x-scroll-preserve-links>
-                        <div class="wizard-footer-box">
-                            <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_email_url) }}</span>
-                            {% if registration_status == "TEST" and registration_page %}
-                                <form method="post"
-                                      action="{{ registration_save_url }}"
-                                      x-data
-                                      x-preserve-scroll-on-submit>
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                                    <input type="hidden" name="action" value="publish" />
-                                    {{ button(_("Publish"), type="submit", variant="primary") }}
-                                </form>
-                            {% elif registration_status == "PUBLISHED" and registration_page %}
-                                <form method="post"
-                                      action="{{ registration_save_url }}"
-                                      x-data
-                                      x-preserve-scroll-on-submit>
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                                    <input type="hidden" name="action" value="unpublish" />
-                                    {{ button(_("Unpublish"), type="submit", variant="tertiary") }}
-                                </form>
-                                {{ button(_("Close registration"), variant="secondary", attrs='type="button" @click="openConfirmClose()"') }}
-                            {% endif %}
-                        </div>
+                                {% set registration_save_url = url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id, url_slug=registration_page.url_slug) %}
+                                {% set back_to_email_url = url_for('backoffice_registration.view_registration_page', assembly_id=assembly.id, url_slug=registration_page.url_slug, section='email') %}
+                                <div class="wizard-footer" x-scroll-preserve-links>
+                                    <div class="wizard-footer-box">
+                                        <span class="mr-auto">{{ button(_("← Back"), variant="tertiary", href=back_to_email_url) }}</span>
+                                        {% if registration_status == "TEST" and registration_page %}
+                                            <form method="post"
+                                                  action="{{ registration_save_url }}"
+                                                  x-data
+                                                  x-preserve-scroll-on-submit>
+                                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                                <input type="hidden" name="action" value="publish" />
+                                                {{ button(_("Publish"), type="submit", variant="primary") }}
+                                            </form>
+                                        {% elif registration_status == "PUBLISHED" and registration_page %}
+                                            <form method="post"
+                                                  action="{{ registration_save_url }}"
+                                                  x-data
+                                                  x-preserve-scroll-on-submit>
+                                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                                <input type="hidden" name="action" value="unpublish" />
+                                                {{ button(_("Unpublish"), type="submit", variant="tertiary") }}
+                                            </form>
+                                            {{ button(_("Close registration"), variant="secondary", attrs='type="button" @click="openConfirmClose()"') }}
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                        {% endif %}
                     </div>
                 </div>
-            {% endif %}
-        {% endif %}
+            </div>
         {# Form Skeleton Modal - only shown when registration page exists #}
-        {% if has_registration_page %}
-            <template x-if="skeletonModalOpen">
-                <div x-cloak>
+            {% if has_registration_page %}
+                <template x-if="skeletonModalOpen">
+                    <div x-cloak>
                     {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeSkeletonModal()"
-                         @keydown.escape.window="closeSkeletonModal()"></div>
+                        <div class="fixed inset-0 z-40"
+                             style="background-color: rgba(0, 0, 0, 0.5)"
+                             @click="closeSkeletonModal()"
+                             @keydown.escape.window="closeSkeletonModal()"></div>
                     {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="skeleton-modal-title">
-                        <div class="pointer-events-auto w-full max-w-4xl mx-4 rounded-lg shadow-xl overflow-hidden"
-                             style="background-color: var(--color-tables-cards);
-                                    border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
+                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                             role="dialog"
+                             aria-modal="true"
+                             aria-labelledby="skeleton-modal-title">
+                            <div class="pointer-events-auto w-full max-w-4xl mx-4 rounded-lg shadow-xl overflow-hidden"
+                                 style="background-color: var(--color-tables-cards);
+                                        border: 1px solid var(--color-borders-dividers)"
+                                 @click.stop>
                             {# Header #}
-                            <div class="px-6 py-4 flex items-center justify-between"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="skeleton-modal-title"
-                                    class="text-heading-lg"
-                                    style="color: var(--color-headings)">{{ _("Form Skeleton") }}</h2>
-                                <button type="button"
-                                        @click="closeSkeletonModal()"
-                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100"
-                                        style="color: var(--color-secondary-text)"
-                                        aria-label="{{ _('Close') }}">
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                         class="h-5 w-5"
-                                         fill="none"
-                                         viewBox="0 0 24 24"
-                                         stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
+                                <div class="px-6 py-4 flex items-center justify-between"
+                                     style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                    <h2 id="skeleton-modal-title"
+                                        class="text-heading-lg"
+                                        style="color: var(--color-headings)">{{ _("Form Skeleton") }}</h2>
+                                    <button type="button"
+                                            @click="closeSkeletonModal()"
+                                            class="p-2 rounded-lg transition-colors hover:bg-gray-100"
+                                            style="color: var(--color-secondary-text)"
+                                            aria-label="{{ _('Close') }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                             class="h-5 w-5"
+                                             fill="none"
+                                             viewBox="0 0 24 24"
+                                             stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                        </svg>
+                                    </button>
+                                </div>
                             {# Content #}
-                            <div class="px-6 py-4">
-                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                    {{ _("This skeleton is generated from your assembly's field definitions. Copy all or select specific parts to paste into your form. Then edit to add extra HTML as required.") }}
-                                </p>
-                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                    {{ _("The Plain HTML version is the minimal version, for you to enhance. The GOV.UK styled version uses the %(link_start)sGOV.UK Design System%(link_end)s - which has high web accessibility.",
-                                    link_start=('<a href="https://design-system.service.gov.uk/"
-                                                    class="text-body-md underline break-all"
-                                                    style="color: var(--color-link-text)">'|safe),
-                                        link_end=("</a>"|safe)) }}
-                                </p>
+                                <div class="px-6 py-4">
+                                    <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                        {{ _("This skeleton is generated from your assembly's field definitions. Copy all or select specific parts to paste into your form. Then edit to add extra HTML as required.") }}
+                                    </p>
+                                    <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                        {{ _("The Plain HTML version is the minimal version, for you to enhance. The GOV.UK styled version uses the %(link_start)sGOV.UK Design System%(link_end)s - which has high web accessibility.",
+                                        link_start=('<a href="https://design-system.service.gov.uk/"
+                                                        class="text-body-md underline break-all"
+                                                        style="color: var(--color-link-text)">'|safe),
+                                            link_end=("</a>"|safe)) }}
+                                    </p>
                                 {# Plain/GOV.UK toggle. Hand-rolled rather than the button() macro: the
                                    macro's variant classes are fixed at Jinja render time, but which
                                    button is "active" here can only be known at runtime. #}
-                                <div class="flex gap-2 mb-4"
-                                     role="group"
-                                     aria-label="{{ _('Form skeleton style') }}">
-                                    <button type="button"
-                                            class="btn"
-                                            :class="skeletonView === 'plain' ? 'btn--primary' : 'btn--tertiary'"
-                                            :aria-pressed="skeletonView === 'plain' ? 'true' : 'false'"
-                                            @click="showPlainSkeleton()">{{ _("Plain HTML") }}</button>
-                                    <button type="button"
-                                            class="btn"
-                                            :class="skeletonView === 'styled' ? 'btn--primary' : 'btn--tertiary'"
-                                            :aria-pressed="skeletonView === 'styled' ? 'true' : 'false'"
-                                            @click="showStyledSkeleton()">{{ _("GOV.UK styled") }}</button>
-                                </div>
+                                    <div class="flex gap-2 mb-4"
+                                         role="group"
+                                         aria-label="{{ _('Form skeleton style') }}">
+                                        <button type="button"
+                                                class="btn"
+                                                :class="skeletonView === 'plain' ? 'btn--primary' : 'btn--tertiary'"
+                                                :aria-pressed="skeletonView === 'plain' ? 'true' : 'false'"
+                                                @click="showPlainSkeleton()">{{ _("Plain HTML") }}</button>
+                                        <button type="button"
+                                                class="btn"
+                                                :class="skeletonView === 'styled' ? 'btn--primary' : 'btn--tertiary'"
+                                                :aria-pressed="skeletonView === 'styled' ? 'true' : 'false'"
+                                                @click="showStyledSkeleton()">{{ _("GOV.UK styled") }}</button>
+                                    </div>
                                 {# Two separate x-if'd textareas, not one x-text-bound textarea switched by
                                    x-show: html-editor.js mounts a CodeMirror view over the textarea once,
                                    reading its value at mount time only, so changing x-text on an
@@ -895,126 +930,317 @@ auto-reply". When multi-template support ships this becomes a visible input. #}
                                    DOM as a sibling of the textarea via plain insertBefore(), outside
                                    Alpine's tracking, so without the wrapper x-if would remove only the
                                    textarea it created and leave the CodeMirror instance orphaned. #}
-                                <template x-if="skeletonView === 'plain'">
-                                    <div>
-                                        <textarea readonly
-                                                  data-code-editor
-                                                  aria-label="{{ _('Form skeleton preview') }}"
-                                                  x-text="skeletonHtmlPlain"
-                                                  class="w-full rounded-lg p-4"
-                                                  rows="18"
-                                                  style="font-family: var(--font-mono);
-                                                         font-size: 0.875rem;
-                                                         line-height: 1.5;
-                                                         background-color: var(--color-subtle-background-panels);
-                                                         border: 1px solid var(--color-borders-dividers);
-                                                         color: var(--color-body-text);
-                                                         resize: none"></textarea>
-                                    </div>
-                                </template>
-                                <template x-if="skeletonView === 'styled'">
-                                    <div>
-                                        <textarea readonly
-                                                  data-code-editor
-                                                  aria-label="{{ _('Form skeleton preview (GOV.UK styled)') }}"
-                                                  x-text="skeletonHtmlStyled"
-                                                  class="w-full rounded-lg p-4"
-                                                  rows="18"
-                                                  style="font-family: var(--font-mono);
-                                                         font-size: 0.875rem;
-                                                         line-height: 1.5;
-                                                         background-color: var(--color-subtle-background-panels);
-                                                         border: 1px solid var(--color-borders-dividers);
-                                                         color: var(--color-body-text);
-                                                         resize: none"></textarea>
-                                    </div>
-                                </template>
-                            </div>
+                                    <template x-if="skeletonView === 'plain'">
+                                        <div>
+                                            <textarea readonly
+                                                      data-code-editor
+                                                      aria-label="{{ _('Form skeleton preview') }}"
+                                                      x-text="skeletonHtmlPlain"
+                                                      class="w-full rounded-lg p-4"
+                                                      rows="18"
+                                                      style="font-family: var(--font-mono);
+                                                             font-size: 0.875rem;
+                                                             line-height: 1.5;
+                                                             background-color: var(--color-subtle-background-panels);
+                                                             border: 1px solid var(--color-borders-dividers);
+                                                             color: var(--color-body-text);
+                                                             resize: none"></textarea>
+                                        </div>
+                                    </template>
+                                    <template x-if="skeletonView === 'styled'">
+                                        <div>
+                                            <textarea readonly
+                                                      data-code-editor
+                                                      aria-label="{{ _('Form skeleton preview (GOV.UK styled)') }}"
+                                                      x-text="skeletonHtmlStyled"
+                                                      class="w-full rounded-lg p-4"
+                                                      rows="18"
+                                                      style="font-family: var(--font-mono);
+                                                             font-size: 0.875rem;
+                                                             line-height: 1.5;
+                                                             background-color: var(--color-subtle-background-panels);
+                                                             border: 1px solid var(--color-borders-dividers);
+                                                             color: var(--color-body-text);
+                                                             resize: none"></textarea>
+                                        </div>
+                                    </template>
+                                </div>
                             {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-end"
-                                 style="border-top: 1px solid var(--color-borders-dividers);
-                                        background-color: var(--color-tables-cards)">
-                                {{ button(_("Copy All"), variant="secondary", attrs='@click="copySkeletonToClipboard()"') }}
+                                <div class="px-6 py-3 flex gap-2 justify-end"
+                                     style="border-top: 1px solid var(--color-borders-dividers);
+                                            background-color: var(--color-tables-cards)">
+                                    {{ button(_("Copy All"), variant="secondary", attrs='@click="copySkeletonToClipboard()"') }}
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-            </template>
+                </template>
             {# Image Upload Modal #}
-            <template x-if="imageUploadModalOpen">
-                <div x-cloak>
+                <template x-if="imageUploadModalOpen">
+                    <div x-cloak>
                     {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeImageUploadModalIfAllowed()"
-                         @keydown.escape.window="closeImageUploadModalIfAllowed()"></div>
+                        <div class="fixed inset-0 z-40"
+                             style="background-color: rgba(0, 0, 0, 0.5)"
+                             @click="closeImageUploadModalIfAllowed()"
+                             @keydown.escape.window="closeImageUploadModalIfAllowed()"></div>
                     {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="image-upload-modal-title">
-                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
-                             style="background-color: var(--color-tables-cards);
-                                    border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
+                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                             role="dialog"
+                             aria-modal="true"
+                             aria-labelledby="image-upload-modal-title">
+                            <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+                                 style="background-color: var(--color-tables-cards);
+                                        border: 1px solid var(--color-borders-dividers)"
+                                 @click.stop>
                             {# Header #}
-                            <div class="px-6 py-4 flex items-center justify-between"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="image-upload-modal-title"
-                                    class="text-heading-lg"
-                                    style="color: var(--color-headings)">{{ _("Upload image") }}</h2>
-                                <button type="button"
-                                        @click="closeImageUploadModalIfAllowed()"
-                                        :disabled="imageUploading"
-                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
-                                        style="color: var(--color-secondary-text)"
-                                        aria-label="{{ _('Close') }}">
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                         class="h-5 w-5"
-                                         fill="none"
-                                         viewBox="0 0 24 24"
-                                         stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
+                                <div class="px-6 py-4 flex items-center justify-between"
+                                     style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                    <h2 id="image-upload-modal-title"
+                                        class="text-heading-lg"
+                                        style="color: var(--color-headings)">{{ _("Upload image") }}</h2>
+                                    <button type="button"
+                                            @click="closeImageUploadModalIfAllowed()"
+                                            :disabled="imageUploading"
+                                            class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
+                                            style="color: var(--color-secondary-text)"
+                                            aria-label="{{ _('Close') }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                             class="h-5 w-5"
+                                             fill="none"
+                                             viewBox="0 0 24 24"
+                                             stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                        </svg>
+                                    </button>
+                                </div>
                             {# Content #}
-                            <div class="px-6 py-4">
-                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                    {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. Files are downscaled and re-encoded to PNG on upload.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
-                                </p>
-                                <div class="space-y-4">
-                                    <div>
-                                        <label for="image-upload-file"
+                                <div class="px-6 py-4">
+                                    <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                        {{ _("Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. Files are downscaled and re-encoded to PNG on upload.", formats=allowed_image_formats|join(", "), max=max_image_upload_mb) }}
+                                    </p>
+                                    <div class="space-y-4">
+                                        <div>
+                                            <label for="image-upload-file"
+                                                   class="text-label-md block mb-1"
+                                                   style="color: var(--color-headings)">{{ _("Image file") }}</label>
+                                            <input type="file"
+                                                   id="image-upload-file"
+                                                   x-ref="imageFileInput"
+                                                   accept="image/png,image/jpeg,image/webp"
+                                                   @change="onImageFileSelected($event)"
+                                                   :disabled="imageUploading"
+                                                   class="w-full px-3 py-2 rounded-md text-body-sm"
+                                                   style="border: 1px solid var(--color-borders-dividers);
+                                                          background: var(--color-page-background)" />
+                                            <p x-show="imageFileName"
+                                               x-cloak
+                                               class="text-body-sm mt-1"
+                                               style="color: var(--color-secondary-text)">
+                                                <span x-text="imageFileName"></span>
+                                            </p>
+                                        </div>
+                                        <div>
+                                            <label for="image-upload-alt"
+                                                   class="text-label-md block mb-1"
+                                                   style="color: var(--color-headings)">
+                                                {{ _("Alt text") }}
+                                                <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
+                                            </label>
+                                            <input type="text"
+                                                   id="image-upload-alt"
+                                                   x-model="imageAlt"
+                                                   :disabled="imageUploading"
+                                                   required
+                                                   aria-required="true"
+                                                   class="w-full px-3 py-2 rounded-md text-body-sm"
+                                                   style="border: 1px solid var(--color-borders-dividers);
+                                                          background: var(--color-page-background)" />
+                                            <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                                {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
+                                            </p>
+                                        </div>
+                                    {# Inline error #}
+                                        <div x-show="imageUploadError"
+                                             x-cloak
+                                             class="rounded-md p-3"
+                                             style="background-color: var(--color-error-100);
+                                                    border: 1px solid var(--color-error-400)">
+                                            <p class="text-body-sm"
+                                               style="color: var(--color-error-600)"
+                                               x-text="imageUploadError"></p>
+                                        </div>
+                                    </div>
+                                </div>
+                            {# Footer #}
+                                <div class="px-6 py-3 flex gap-2 justify-end"
+                                     style="border-top: 1px solid var(--color-borders-dividers);
+                                            background-color: var(--color-tables-cards)">
+                                    {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageUploadModalIfAllowed()"', alpine_disabled="imageUploading") }}
+                                    {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitImageUpload()"', alpine_disabled="!imageFile || !imageAlt.trim() || imageUploading") }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            {# Image Details / Edit Alt Modal #}
+                <template x-if="imageDetailsModalOpen && editingImage">
+                    <div x-cloak>
+                    {# Backdrop overlay #}
+                        <div class="fixed inset-0 z-40"
+                             style="background-color: rgba(0, 0, 0, 0.5)"
+                             @click="closeImageDetailsModalIfAllowed()"
+                             @keydown.escape.window="closeImageDetailsModalIfAllowed()"></div>
+                    {# Modal panel #}
+                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                             role="dialog"
+                             aria-modal="true"
+                             aria-labelledby="image-details-modal-title">
+                            <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+                                 style="background-color: var(--color-tables-cards);
+                                        border: 1px solid var(--color-borders-dividers)"
+                                 @click.stop>
+                            {# Header #}
+                                <div class="px-6 py-4 flex items-center justify-between"
+                                     style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                    <h2 id="image-details-modal-title"
+                                        class="text-heading-lg"
+                                        style="color: var(--color-headings)">{{ _("Image details") }}</h2>
+                                    <button type="button"
+                                            @click="closeImageDetailsModalIfAllowed()"
+                                            :disabled="imageEditing"
+                                            class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
+                                            style="color: var(--color-secondary-text)"
+                                            aria-label="{{ _('Close') }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                             class="h-5 w-5"
+                                             fill="none"
+                                             viewBox="0 0 24 24"
+                                             stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            {# Content #}
+                                <div class="px-6 py-4">
+                                {# Thumbnail + compact metadata #}
+                                    <div class="rounded-md p-3 mb-4 flex gap-3"
+                                         style="background-color: var(--color-subtle-background-panels)">
+                                        <div class="flex-shrink-0 w-16 h-16 rounded-md overflow-hidden flex items-center justify-center"
+                                             style="background-color: var(--color-page-background);
+                                                    border: 1px solid var(--color-borders-dividers)">
+                                            <template x-if="editingImage.public_url">
+                                                <img :src="editingImage.public_url"
+                                                     :alt="editingImage.alt || ''"
+                                                     class="max-w-full max-h-full object-contain" />
+                                            </template>
+                                            <template x-if="!editingImage.public_url">
+                                                <span class="text-body-sm text-center px-1 leading-tight"
+                                                      style="color: var(--color-placeholder-text)">{{ _("No preview") }}</span>
+                                            </template>
+                                        </div>
+                                        <div class="flex-1 min-w-0 grid gap-y-1 gap-x-3 text-body-sm content-center"
+                                             style="grid-template-columns: auto 1fr">
+                                            <template x-if="editingImage.original_filename">
+                                                <span class="contents">
+                                                    <span class="text-label-lg whitespace-nowrap"
+                                                          style="color: var(--color-headings)">{{ _("Original filename") }}</span>
+                                                    <span class="min-w-0 truncate text-code"
+                                                          style="color: var(--color-body-text)"
+                                                          :title="editingImage.original_filename"
+                                                          x-text="editingImage.original_filename"></span>
+                                                </span>
+                                            </template>
+                                            <span class="text-label-lg whitespace-nowrap"
+                                                  style="color: var(--color-headings)">{{ _("Dimensions") }}</span>
+                                            <span class="min-w-0" style="color: var(--color-body-text);">
+                                                <span x-text="editingImage.width"></span>
+                                                ×
+                                                <span x-text="editingImage.height"></span>
+                                                {{ _("px") }}
+                                            </span>
+                                            <span class="text-label-lg whitespace-nowrap"
+                                                  style="color: var(--color-headings)">{{ _("File size") }}</span>
+                                            <span class="min-w-0"
+                                                  style="color: var(--color-body-text)"
+                                                  x-text="formatBytes(editingImage.byte_size)"></span>
+                                        </div>
+                                    </div>
+                                {# File name (read-only + copy) #}
+                                    <div class="mb-3">
+                                        <label for="image-details-filename"
                                                class="text-label-md block mb-1"
-                                               style="color: var(--color-headings)">{{ _("Image file") }}</label>
-                                        <input type="file"
-                                               id="image-upload-file"
-                                               x-ref="imageFileInput"
-                                               accept="image/png,image/jpeg,image/webp"
-                                               @change="onImageFileSelected($event)"
-                                               :disabled="imageUploading"
-                                               class="w-full px-3 py-2 rounded-md text-body-sm"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      background: var(--color-page-background)" />
-                                        <p x-show="imageFileName"
-                                           x-cloak
-                                           class="text-body-sm mt-1"
-                                           style="color: var(--color-secondary-text)">
-                                            <span x-text="imageFileName"></span>
-                                        </p>
+                                               style="color: var(--color-headings)">{{ _("File name") }}</label>
+                                        <div class="flex gap-2">
+                                            <input type="text"
+                                                   id="image-details-filename"
+                                                   readonly
+                                                   :value="editingImage.file_name"
+                                                   @click="$event.target.select()"
+                                                   class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
+                                                   style="border: 1px solid var(--color-borders-dividers);
+                                                          background: var(--color-page-background)" />
+                                        {# :data-copy-text is bound reactively so it tracks editingImage.file_name #}
+                                            <button type="button"
+                                                    :data-copy-text="editingImage.file_name"
+                                                    data-copy-msg="{{ _('File name copied to clipboard') }}"
+                                                    @click="copyToClipboard($el)"
+                                                    class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                    style="border: 1px solid var(--color-borders-dividers);
+                                                           color: var(--color-secondary-text)"
+                                                    aria-label="{{ _('Copy file name') }}">
+                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                     class="h-4 w-4"
+                                                     fill="none"
+                                                     viewBox="0 0 24 24"
+                                                     stroke="currentColor"
+                                                     stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </div>
+                                {# <img> snippet (read-only + copy) — hidden when there's no public URL yet #}
+                                    <div class="mb-3" x-show="editingImage.img_snippet">
+                                        <label for="image-details-snippet"
+                                               class="text-label-md block mb-1"
+                                               style="color: var(--color-headings)">{{ _("Image snippet") }}</label>
+                                        <div class="flex gap-2">
+                                            <input type="text"
+                                                   id="image-details-snippet"
+                                                   readonly
+                                                   :value="editingImage.img_snippet"
+                                                   @click="$event.target.select()"
+                                                   class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
+                                                   style="border: 1px solid var(--color-borders-dividers);
+                                                          background: var(--color-page-background)" />
+                                            <button type="button"
+                                                    @click="copyImageSnippet(editingImage)"
+                                                    class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                    style="border: 1px solid var(--color-borders-dividers);
+                                                           color: var(--color-secondary-text)"
+                                                    aria-label="{{ _('Copy image snippet') }}">
+                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                     class="h-4 w-4"
+                                                     fill="none"
+                                                     viewBox="0 0 24 24"
+                                                     stroke="currentColor"
+                                                     stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                </svg>
+                                            </button>
+                                        </div>
                                     </div>
                                     <div>
-                                        <label for="image-upload-alt"
+                                        <label for="image-edit-alt"
                                                class="text-label-md block mb-1"
                                                style="color: var(--color-headings)">
                                             {{ _("Alt text") }}
                                             <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
                                         </label>
                                         <input type="text"
-                                               id="image-upload-alt"
-                                               x-model="imageAlt"
-                                               :disabled="imageUploading"
+                                               id="image-edit-alt"
+                                               x-model="editingImageAlt"
+                                               :disabled="imageEditing"
                                                required
                                                aria-required="true"
                                                class="w-full px-3 py-2 rounded-md text-body-sm"
@@ -1024,600 +1250,409 @@ auto-reply". When multi-template support ships this becomes a visible input. #}
                                             {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
                                         </p>
                                     </div>
-                                    {# Inline error #}
-                                    <div x-show="imageUploadError"
+                                {# Inline error #}
+                                    <div x-show="imageEditError"
                                          x-cloak
-                                         class="rounded-md p-3"
+                                         class="rounded-md p-3 mt-3"
                                          style="background-color: var(--color-error-100);
                                                 border: 1px solid var(--color-error-400)">
                                         <p class="text-body-sm"
                                            style="color: var(--color-error-600)"
-                                           x-text="imageUploadError"></p>
+                                           x-text="imageEditError"></p>
                                     </div>
                                 </div>
-                            </div>
                             {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-end"
-                                 style="border-top: 1px solid var(--color-borders-dividers);
-                                        background-color: var(--color-tables-cards)">
-                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageUploadModalIfAllowed()"', alpine_disabled="imageUploading") }}
-                                {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitImageUpload()"', alpine_disabled="!imageFile || !imageAlt.trim() || imageUploading") }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
-            {# Image Details / Edit Alt Modal #}
-            <template x-if="imageDetailsModalOpen && editingImage">
-                <div x-cloak>
-                    {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeImageDetailsModalIfAllowed()"
-                         @keydown.escape.window="closeImageDetailsModalIfAllowed()"></div>
-                    {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="image-details-modal-title">
-                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
-                             style="background-color: var(--color-tables-cards);
-                                    border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
-                            {# Header #}
-                            <div class="px-6 py-4 flex items-center justify-between"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="image-details-modal-title"
-                                    class="text-heading-lg"
-                                    style="color: var(--color-headings)">{{ _("Image details") }}</h2>
-                                <button type="button"
-                                        @click="closeImageDetailsModalIfAllowed()"
-                                        :disabled="imageEditing"
-                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
-                                        style="color: var(--color-secondary-text)"
-                                        aria-label="{{ _('Close') }}">
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                         class="h-5 w-5"
-                                         fill="none"
-                                         viewBox="0 0 24 24"
-                                         stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
-                            {# Content #}
-                            <div class="px-6 py-4">
-                                {# Thumbnail + compact metadata #}
-                                <div class="rounded-md p-3 mb-4 flex gap-3"
-                                     style="background-color: var(--color-subtle-background-panels)">
-                                    <div class="flex-shrink-0 w-16 h-16 rounded-md overflow-hidden flex items-center justify-center"
-                                         style="background-color: var(--color-page-background);
-                                                border: 1px solid var(--color-borders-dividers)">
-                                        <template x-if="editingImage.public_url">
-                                            <img :src="editingImage.public_url"
-                                                 :alt="editingImage.alt || ''"
-                                                 class="max-w-full max-h-full object-contain" />
-                                        </template>
-                                        <template x-if="!editingImage.public_url">
-                                            <span class="text-body-sm text-center px-1 leading-tight"
-                                                  style="color: var(--color-placeholder-text)">{{ _("No preview") }}</span>
-                                        </template>
-                                    </div>
-                                    <div class="flex-1 min-w-0 grid gap-y-1 gap-x-3 text-body-sm content-center"
-                                         style="grid-template-columns: auto 1fr">
-                                        <template x-if="editingImage.original_filename">
-                                            <span class="contents">
-                                                <span class="text-label-lg whitespace-nowrap"
-                                                      style="color: var(--color-headings)">{{ _("Original filename") }}</span>
-                                                <span class="min-w-0 truncate text-code"
-                                                      style="color: var(--color-body-text)"
-                                                      :title="editingImage.original_filename"
-                                                      x-text="editingImage.original_filename"></span>
-                                            </span>
-                                        </template>
-                                        <span class="text-label-lg whitespace-nowrap"
-                                              style="color: var(--color-headings)">{{ _("Dimensions") }}</span>
-                                        <span class="min-w-0" style="color: var(--color-body-text);">
-                                            <span x-text="editingImage.width"></span>
-                                            ×
-                                            <span x-text="editingImage.height"></span>
-                                            {{ _("px") }}
-                                        </span>
-                                        <span class="text-label-lg whitespace-nowrap"
-                                              style="color: var(--color-headings)">{{ _("File size") }}</span>
-                                        <span class="min-w-0"
-                                              style="color: var(--color-body-text)"
-                                              x-text="formatBytes(editingImage.byte_size)"></span>
-                                    </div>
-                                </div>
-                                {# File name (read-only + copy) #}
-                                <div class="mb-3">
-                                    <label for="image-details-filename"
-                                           class="text-label-md block mb-1"
-                                           style="color: var(--color-headings)">{{ _("File name") }}</label>
+                                <div class="px-6 py-3 flex gap-2 justify-between items-center"
+                                     style="border-top: 1px solid var(--color-borders-dividers);
+                                            background-color: var(--color-tables-cards)">
+                                    {{ button(_("Delete image"), variant="danger", attrs='type="button" @click="deleteEditingImage()"', alpine_disabled="imageEditing || imageBeingDeletedId === editingImage.id") }}
                                     <div class="flex gap-2">
-                                        <input type="text"
-                                               id="image-details-filename"
-                                               readonly
-                                               :value="editingImage.file_name"
-                                               @click="$event.target.select()"
-                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      background: var(--color-page-background)" />
-                                        {# :data-copy-text is bound reactively so it tracks editingImage.file_name #}
-                                        <button type="button"
-                                                :data-copy-text="editingImage.file_name"
-                                                data-copy-msg="{{ _('File name copied to clipboard') }}"
-                                                @click="copyToClipboard($el)"
-                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                style="border: 1px solid var(--color-borders-dividers);
-                                                       color: var(--color-secondary-text)"
-                                                aria-label="{{ _('Copy file name') }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                 class="h-4 w-4"
-                                                 fill="none"
-                                                 viewBox="0 0 24 24"
-                                                 stroke="currentColor"
-                                                 stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
+                                        {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageDetailsModalIfAllowed()"', alpine_disabled="imageEditing") }}
+                                        {{ button(_("Save alt"), variant="primary", attrs='type="button" @click="submitImageEdit()"', alpine_disabled="!editingImageAlt.trim() || imageEditing") }}
                                     </div>
-                                </div>
-                                {# <img> snippet (read-only + copy) — hidden when there's no public URL yet #}
-                                <div class="mb-3" x-show="editingImage.img_snippet">
-                                    <label for="image-details-snippet"
-                                           class="text-label-md block mb-1"
-                                           style="color: var(--color-headings)">{{ _("Image snippet") }}</label>
-                                    <div class="flex gap-2">
-                                        <input type="text"
-                                               id="image-details-snippet"
-                                               readonly
-                                               :value="editingImage.img_snippet"
-                                               @click="$event.target.select()"
-                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      background: var(--color-page-background)" />
-                                        <button type="button"
-                                                @click="copyImageSnippet(editingImage)"
-                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                style="border: 1px solid var(--color-borders-dividers);
-                                                       color: var(--color-secondary-text)"
-                                                aria-label="{{ _('Copy image snippet') }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                 class="h-4 w-4"
-                                                 fill="none"
-                                                 viewBox="0 0 24 24"
-                                                 stroke="currentColor"
-                                                 stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-                                <div>
-                                    <label for="image-edit-alt"
-                                           class="text-label-md block mb-1"
-                                           style="color: var(--color-headings)">
-                                        {{ _("Alt text") }}
-                                        <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
-                                    </label>
-                                    <input type="text"
-                                           id="image-edit-alt"
-                                           x-model="editingImageAlt"
-                                           :disabled="imageEditing"
-                                           required
-                                           aria-required="true"
-                                           class="w-full px-3 py-2 rounded-md text-body-sm"
-                                           style="border: 1px solid var(--color-borders-dividers);
-                                                  background: var(--color-page-background)" />
-                                    <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
-                                        {{ _("Describes the image for screen-reader users and is used as the file's display name in the asset list.") }}
-                                    </p>
-                                </div>
-                                {# Inline error #}
-                                <div x-show="imageEditError"
-                                     x-cloak
-                                     class="rounded-md p-3 mt-3"
-                                     style="background-color: var(--color-error-100);
-                                            border: 1px solid var(--color-error-400)">
-                                    <p class="text-body-sm"
-                                       style="color: var(--color-error-600)"
-                                       x-text="imageEditError"></p>
-                                </div>
-                            </div>
-                            {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-between items-center"
-                                 style="border-top: 1px solid var(--color-borders-dividers);
-                                        background-color: var(--color-tables-cards)">
-                                {{ button(_("Delete image"), variant="danger", attrs='type="button" @click="deleteEditingImage()"', alpine_disabled="imageEditing || imageBeingDeletedId === editingImage.id") }}
-                                <div class="flex gap-2">
-                                    {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeImageDetailsModalIfAllowed()"', alpine_disabled="imageEditing") }}
-                                    {{ button(_("Save alt"), variant="primary", attrs='type="button" @click="submitImageEdit()"', alpine_disabled="!editingImageAlt.trim() || imageEditing") }}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
-            {# Document Upload Modal #}
-            <template x-if="documentUploadModalOpen">
-                <div x-cloak>
-                    {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeDocumentUploadModalIfAllowed()"
-                         @keydown.escape.window="closeDocumentUploadModalIfAllowed()"></div>
-                    {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="document-upload-modal-title">
-                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
-                             style="background-color: var(--color-tables-cards);
-                                    border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
-                            {# Header #}
-                            <div class="px-6 py-4 flex items-center justify-between"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="document-upload-modal-title"
-                                    class="text-heading-lg"
-                                    style="color: var(--color-headings)">{{ _("Upload document") }}</h2>
-                                <button type="button"
-                                        @click="closeDocumentUploadModalIfAllowed()"
-                                        :disabled="documentUploading"
-                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
-                                        style="color: var(--color-secondary-text)"
-                                        aria-label="{{ _('Close') }}">
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                         class="h-5 w-5"
-                                         fill="none"
-                                         viewBox="0 0 24 24"
-                                         stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
-                            {# Content #}
-                            <div class="px-6 py-4">
-                                <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
-                                    {{ _("PDF files only. Maximum file size: %(max)s MB per document.", max=max_pdf_upload_mb) }}
-                                </p>
-                                <div class="space-y-4">
-                                    <div>
-                                        <label for="document-upload-file"
-                                               class="text-label-md block mb-1"
-                                               style="color: var(--color-headings)">{{ _("PDF file") }}</label>
-                                        <input type="file"
-                                               id="document-upload-file"
-                                               x-ref="documentFileInput"
-                                               accept="application/pdf"
-                                               @change="onDocumentFileSelected($event)"
-                                               :disabled="documentUploading"
-                                               class="w-full px-3 py-2 rounded-md text-body-sm"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      background: var(--color-page-background)" />
-                                        <p x-show="documentFileName"
-                                           x-cloak
-                                           class="text-body-sm mt-1"
-                                           style="color: var(--color-secondary-text)">
-                                            <span x-text="documentFileName"></span>
-                                        </p>
-                                    </div>
-                                    <div>
-                                        <label for="document-upload-label"
-                                               class="text-label-md block mb-1"
-                                               style="color: var(--color-headings)">{{ _("Label") }}</label>
-                                        <input type="text"
-                                               id="document-upload-label"
-                                               x-model="documentLabel"
-                                               :disabled="documentUploading"
-                                               class="w-full px-3 py-2 rounded-md text-body-sm"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      background: var(--color-page-background)" />
-                                        <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
-                                            {{ _("Shown to registrants as the download link text and used as the file's display name in the asset list. Defaults to the file name.") }}
-                                        </p>
-                                    </div>
-                                    {# Inline error #}
-                                    <div x-show="documentUploadError"
-                                         x-cloak
-                                         class="rounded-md p-3"
-                                         style="background-color: var(--color-error-100);
-                                                border: 1px solid var(--color-error-400)">
-                                        <p class="text-body-sm"
-                                           style="color: var(--color-error-600)"
-                                           x-text="documentUploadError"></p>
-                                    </div>
-                                </div>
-                            </div>
-                            {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-end"
-                                 style="border-top: 1px solid var(--color-borders-dividers);
-                                        background-color: var(--color-tables-cards)">
-                                {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeDocumentUploadModalIfAllowed()"', alpine_disabled="documentUploading") }}
-                                {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitDocumentUpload()"', alpine_disabled="!documentFile || documentUploading") }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
-            {# Document Details / Edit Label Modal #}
-            <template x-if="documentDetailsModalOpen && editingDocument">
-                <div x-cloak>
-                    {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeDocumentDetailsModalIfAllowed()"
-                         @keydown.escape.window="closeDocumentDetailsModalIfAllowed()"></div>
-                    {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="document-details-modal-title">
-                        <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
-                             style="background-color: var(--color-tables-cards);
-                                    border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
-                            {# Header #}
-                            <div class="px-6 py-4 flex items-center justify-between"
-                                 style="border-bottom: 1px solid var(--color-borders-dividers)">
-                                <h2 id="document-details-modal-title"
-                                    class="text-heading-lg"
-                                    style="color: var(--color-headings)">{{ _("Document details") }}</h2>
-                                <button type="button"
-                                        @click="closeDocumentDetailsModalIfAllowed()"
-                                        :disabled="documentEditing"
-                                        class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
-                                        style="color: var(--color-secondary-text)"
-                                        aria-label="{{ _('Close') }}">
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                         class="h-5 w-5"
-                                         fill="none"
-                                         viewBox="0 0 24 24"
-                                         stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
-                            {# Content #}
-                            <div class="px-6 py-4">
-                                {# Compact metadata #}
-                                <div class="rounded-md p-3 mb-4 grid gap-y-1 gap-x-3 text-body-sm content-center"
-                                     style="background-color: var(--color-subtle-background-panels);
-                                            grid-template-columns: auto 1fr">
-                                    <template x-if="editingDocument.original_filename">
-                                        <span class="contents">
-                                            <span class="text-label-lg whitespace-nowrap"
-                                                  style="color: var(--color-headings)">{{ _("Original filename") }}</span>
-                                            <span class="min-w-0 truncate text-code"
-                                                  style="color: var(--color-body-text)"
-                                                  :title="editingDocument.original_filename"
-                                                  x-text="editingDocument.original_filename"></span>
-                                        </span>
-                                    </template>
-                                    <span class="text-label-lg whitespace-nowrap"
-                                          style="color: var(--color-headings)">{{ _("File size") }}</span>
-                                    <span class="min-w-0"
-                                          style="color: var(--color-body-text)"
-                                          x-text="formatBytes(editingDocument.byte_size)"></span>
-                                </div>
-                                {# File name (read-only + copy) #}
-                                <div class="mb-3">
-                                    <label for="document-details-filename"
-                                           class="text-label-md block mb-1"
-                                           style="color: var(--color-headings)">{{ _("File name") }}</label>
-                                    <div class="flex gap-2">
-                                        <input type="text"
-                                               id="document-details-filename"
-                                               readonly
-                                               :value="editingDocument.file_name"
-                                               @click="$event.target.select()"
-                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      background: var(--color-page-background)" />
-                                        {# :data-copy-text is bound reactively so it tracks editingDocument.file_name #}
-                                        <button type="button"
-                                                :data-copy-text="editingDocument.file_name"
-                                                data-copy-msg="{{ _('File name copied to clipboard') }}"
-                                                @click="copyToClipboard($el)"
-                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                style="border: 1px solid var(--color-borders-dividers);
-                                                       color: var(--color-secondary-text)"
-                                                aria-label="{{ _('Copy file name') }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                 class="h-4 w-4"
-                                                 fill="none"
-                                                 viewBox="0 0 24 24"
-                                                 stroke="currentColor"
-                                                 stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-                                {# <a> snippet (read-only + copy) — hidden when there's no public URL yet #}
-                                <div class="mb-3" x-show="editingDocument.a_snippet">
-                                    <label for="document-details-snippet"
-                                           class="text-label-md block mb-1"
-                                           style="color: var(--color-headings)">
-                                        {{ _("Download link snippet") }}
-                                    </label>
-                                    <div class="flex gap-2">
-                                        <input type="text"
-                                               id="document-details-snippet"
-                                               readonly
-                                               :value="editingDocument.a_snippet"
-                                               @click="$event.target.select()"
-                                               class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
-                                               style="border: 1px solid var(--color-borders-dividers);
-                                                      background: var(--color-page-background)" />
-                                        <button type="button"
-                                                @click="copyDocumentSnippet(editingDocument)"
-                                                class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
-                                                style="border: 1px solid var(--color-borders-dividers);
-                                                       color: var(--color-secondary-text)"
-                                                aria-label="{{ _('Copy download link snippet') }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg"
-                                                 class="h-4 w-4"
-                                                 fill="none"
-                                                 viewBox="0 0 24 24"
-                                                 stroke="currentColor"
-                                                 stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-                                <div>
-                                    <label for="document-edit-label"
-                                           class="text-label-md block mb-1"
-                                           style="color: var(--color-headings)">
-                                        {{ _("Label") }}
-                                        <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
-                                    </label>
-                                    <input type="text"
-                                           id="document-edit-label"
-                                           x-model="editingDocumentLabel"
-                                           :disabled="documentEditing"
-                                           required
-                                           aria-required="true"
-                                           class="w-full px-3 py-2 rounded-md text-body-sm"
-                                           style="border: 1px solid var(--color-borders-dividers);
-                                                  background: var(--color-page-background)" />
-                                    <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
-                                        {{ _("Shown to registrants as the download link text and used as the file's display name in the asset list.") }}
-                                    </p>
-                                </div>
-                                {# Inline error #}
-                                <div x-show="documentEditError"
-                                     x-cloak
-                                     class="rounded-md p-3 mt-3"
-                                     style="background-color: var(--color-error-100);
-                                            border: 1px solid var(--color-error-400)">
-                                    <p class="text-body-sm"
-                                       style="color: var(--color-error-600)"
-                                       x-text="documentEditError"></p>
-                                </div>
-                            </div>
-                            {# Footer #}
-                            <div class="px-6 py-3 flex gap-2 justify-between items-center"
-                                 style="border-top: 1px solid var(--color-borders-dividers);
-                                        background-color: var(--color-tables-cards)">
-                                {{ button(_("Delete document"), variant="danger", attrs='type="button" @click="deleteEditingDocument()"', alpine_disabled="documentEditing || documentBeingDeletedId === editingDocument.id") }}
-                                <div class="flex gap-2">
-                                    {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeDocumentDetailsModalIfAllowed()"', alpine_disabled="documentEditing") }}
-                                    {{ button(_("Save label"), variant="primary", attrs='type="button" @click="submitDocumentEdit()"', alpine_disabled="!editingDocumentLabel.trim() || documentEditing") }}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
-            {# Close-registration confirmation — closing is terminal (there is no reopen), so the
-           destructive action must be explicit. Same single-surface dialog style as the
-           discard confirmation: the safe action is the primary on the right and receives
-           initial focus; the destructive action is a plain red text button. Rendered only
-           where its opener exists (preview step of a published page). #}
-            {% if active_section == "preview" and registration_status == "PUBLISHED" and registration_page %}
-                <template x-if="confirmCloseOpen">
-                    <div x-cloak>
-                        {# Backdrop overlay #}
-                        <div class="fixed inset-0 z-40"
-                             style="background-color: rgba(0, 0, 0, 0.5)"
-                             @click="cancelConfirmClose()"
-                             @keydown.escape.window="cancelConfirmClose()"></div>
-                        {# Modal panel #}
-                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                             role="dialog"
-                             aria-modal="true"
-                             aria-labelledby="close-registration-modal-title">
-                            <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden px-6 py-5"
-                                 style="background-color: var(--color-tables-cards);
-                                        border: 1px solid var(--color-borders-dividers)"
-                                 @click.stop>
-                                <h2 id="close-registration-modal-title"
-                                    class="text-heading-lg mb-2"
-                                    style="color: var(--color-headings)">{{ _("Close registration?") }}</h2>
-                                <p class="text-body-md mb-5" style="color: var(--color-body-text);">
-                                    {{ _("This permanently stops new registrations. Visitors who follow the form link will see the 'registration closed' page, and the form cannot be reopened.") }}
-                                </p>
-                                <div class="flex gap-2 justify-end items-center">
-                                    <form method="post"
-                                          action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id, url_slug=registration_page.url_slug) }}"
-                                          x-data
-                                          x-preserve-scroll-on-submit>
-                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                                        <input type="hidden" name="action" value="close" />
-                                        {{ button(_("Close registration"), type="submit", variant="danger") }}
-                                    </form>
-                                    {{ button(_("Keep it open"), variant="primary", attrs='type="button" x-ref="keepOpenBtn" @click="cancelConfirmClose()"') }}
                                 </div>
                             </div>
                         </div>
                     </div>
                 </template>
-            {% endif %}
+            {# Document Upload Modal #}
+                <template x-if="documentUploadModalOpen">
+                    <div x-cloak>
+                    {# Backdrop overlay #}
+                        <div class="fixed inset-0 z-40"
+                             style="background-color: rgba(0, 0, 0, 0.5)"
+                             @click="closeDocumentUploadModalIfAllowed()"
+                             @keydown.escape.window="closeDocumentUploadModalIfAllowed()"></div>
+                    {# Modal panel #}
+                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                             role="dialog"
+                             aria-modal="true"
+                             aria-labelledby="document-upload-modal-title">
+                            <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+                                 style="background-color: var(--color-tables-cards);
+                                        border: 1px solid var(--color-borders-dividers)"
+                                 @click.stop>
+                            {# Header #}
+                                <div class="px-6 py-4 flex items-center justify-between"
+                                     style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                    <h2 id="document-upload-modal-title"
+                                        class="text-heading-lg"
+                                        style="color: var(--color-headings)">{{ _("Upload document") }}</h2>
+                                    <button type="button"
+                                            @click="closeDocumentUploadModalIfAllowed()"
+                                            :disabled="documentUploading"
+                                            class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
+                                            style="color: var(--color-secondary-text)"
+                                            aria-label="{{ _('Close') }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                             class="h-5 w-5"
+                                             fill="none"
+                                             viewBox="0 0 24 24"
+                                             stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            {# Content #}
+                                <div class="px-6 py-4">
+                                    <p class="text-body-sm mb-4" style="color: var(--color-secondary-text);">
+                                        {{ _("PDF files only. Maximum file size: %(max)s MB per document.", max=max_pdf_upload_mb) }}
+                                    </p>
+                                    <div class="space-y-4">
+                                        <div>
+                                            <label for="document-upload-file"
+                                                   class="text-label-md block mb-1"
+                                                   style="color: var(--color-headings)">{{ _("PDF file") }}</label>
+                                            <input type="file"
+                                                   id="document-upload-file"
+                                                   x-ref="documentFileInput"
+                                                   accept="application/pdf"
+                                                   @change="onDocumentFileSelected($event)"
+                                                   :disabled="documentUploading"
+                                                   class="w-full px-3 py-2 rounded-md text-body-sm"
+                                                   style="border: 1px solid var(--color-borders-dividers);
+                                                          background: var(--color-page-background)" />
+                                            <p x-show="documentFileName"
+                                               x-cloak
+                                               class="text-body-sm mt-1"
+                                               style="color: var(--color-secondary-text)">
+                                                <span x-text="documentFileName"></span>
+                                            </p>
+                                        </div>
+                                        <div>
+                                            <label for="document-upload-label"
+                                                   class="text-label-md block mb-1"
+                                                   style="color: var(--color-headings)">{{ _("Label") }}</label>
+                                            <input type="text"
+                                                   id="document-upload-label"
+                                                   x-model="documentLabel"
+                                                   :disabled="documentUploading"
+                                                   class="w-full px-3 py-2 rounded-md text-body-sm"
+                                                   style="border: 1px solid var(--color-borders-dividers);
+                                                          background: var(--color-page-background)" />
+                                            <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                                {{ _("Shown to registrants as the download link text and used as the file's display name in the asset list. Defaults to the file name.") }}
+                                            </p>
+                                        </div>
+                                    {# Inline error #}
+                                        <div x-show="documentUploadError"
+                                             x-cloak
+                                             class="rounded-md p-3"
+                                             style="background-color: var(--color-error-100);
+                                                    border: 1px solid var(--color-error-400)">
+                                            <p class="text-body-sm"
+                                               style="color: var(--color-error-600)"
+                                               x-text="documentUploadError"></p>
+                                        </div>
+                                    </div>
+                                </div>
+                            {# Footer #}
+                                <div class="px-6 py-3 flex gap-2 justify-end"
+                                     style="border-top: 1px solid var(--color-borders-dividers);
+                                            background-color: var(--color-tables-cards)">
+                                    {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeDocumentUploadModalIfAllowed()"', alpine_disabled="documentUploading") }}
+                                    {{ button(_("Upload"), variant="primary", attrs='type="button" @click="submitDocumentUpload()"', alpine_disabled="!documentFile || documentUploading") }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            {# Document Details / Edit Label Modal #}
+                <template x-if="documentDetailsModalOpen && editingDocument">
+                    <div x-cloak>
+                    {# Backdrop overlay #}
+                        <div class="fixed inset-0 z-40"
+                             style="background-color: rgba(0, 0, 0, 0.5)"
+                             @click="closeDocumentDetailsModalIfAllowed()"
+                             @keydown.escape.window="closeDocumentDetailsModalIfAllowed()"></div>
+                    {# Modal panel #}
+                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                             role="dialog"
+                             aria-modal="true"
+                             aria-labelledby="document-details-modal-title">
+                            <div class="pointer-events-auto w-full max-w-lg mx-4 rounded-lg shadow-xl overflow-hidden"
+                                 style="background-color: var(--color-tables-cards);
+                                        border: 1px solid var(--color-borders-dividers)"
+                                 @click.stop>
+                            {# Header #}
+                                <div class="px-6 py-4 flex items-center justify-between"
+                                     style="border-bottom: 1px solid var(--color-borders-dividers)">
+                                    <h2 id="document-details-modal-title"
+                                        class="text-heading-lg"
+                                        style="color: var(--color-headings)">{{ _("Document details") }}</h2>
+                                    <button type="button"
+                                            @click="closeDocumentDetailsModalIfAllowed()"
+                                            :disabled="documentEditing"
+                                            class="p-2 rounded-lg transition-colors hover:bg-gray-100 disabled:opacity-50"
+                                            style="color: var(--color-secondary-text)"
+                                            aria-label="{{ _('Close') }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                             class="h-5 w-5"
+                                             fill="none"
+                                             viewBox="0 0 24 24"
+                                             stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            {# Content #}
+                                <div class="px-6 py-4">
+                                {# Compact metadata #}
+                                    <div class="rounded-md p-3 mb-4 grid gap-y-1 gap-x-3 text-body-sm content-center"
+                                         style="background-color: var(--color-subtle-background-panels);
+                                                grid-template-columns: auto 1fr">
+                                        <template x-if="editingDocument.original_filename">
+                                            <span class="contents">
+                                                <span class="text-label-lg whitespace-nowrap"
+                                                      style="color: var(--color-headings)">{{ _("Original filename") }}</span>
+                                                <span class="min-w-0 truncate text-code"
+                                                      style="color: var(--color-body-text)"
+                                                      :title="editingDocument.original_filename"
+                                                      x-text="editingDocument.original_filename"></span>
+                                            </span>
+                                        </template>
+                                        <span class="text-label-lg whitespace-nowrap"
+                                              style="color: var(--color-headings)">{{ _("File size") }}</span>
+                                        <span class="min-w-0"
+                                              style="color: var(--color-body-text)"
+                                              x-text="formatBytes(editingDocument.byte_size)"></span>
+                                    </div>
+                                {# File name (read-only + copy) #}
+                                    <div class="mb-3">
+                                        <label for="document-details-filename"
+                                               class="text-label-md block mb-1"
+                                               style="color: var(--color-headings)">{{ _("File name") }}</label>
+                                        <div class="flex gap-2">
+                                            <input type="text"
+                                                   id="document-details-filename"
+                                                   readonly
+                                                   :value="editingDocument.file_name"
+                                                   @click="$event.target.select()"
+                                                   class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
+                                                   style="border: 1px solid var(--color-borders-dividers);
+                                                          background: var(--color-page-background)" />
+                                        {# :data-copy-text is bound reactively so it tracks editingDocument.file_name #}
+                                            <button type="button"
+                                                    :data-copy-text="editingDocument.file_name"
+                                                    data-copy-msg="{{ _('File name copied to clipboard') }}"
+                                                    @click="copyToClipboard($el)"
+                                                    class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                    style="border: 1px solid var(--color-borders-dividers);
+                                                           color: var(--color-secondary-text)"
+                                                    aria-label="{{ _('Copy file name') }}">
+                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                     class="h-4 w-4"
+                                                     fill="none"
+                                                     viewBox="0 0 24 24"
+                                                     stroke="currentColor"
+                                                     stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </div>
+                                {# <a> snippet (read-only + copy) — hidden when there's no public URL yet #}
+                                    <div class="mb-3" x-show="editingDocument.a_snippet">
+                                        <label for="document-details-snippet"
+                                               class="text-label-md block mb-1"
+                                               style="color: var(--color-headings)">
+                                            {{ _("Download link snippet") }}
+                                        </label>
+                                        <div class="flex gap-2">
+                                            <input type="text"
+                                                   id="document-details-snippet"
+                                                   readonly
+                                                   :value="editingDocument.a_snippet"
+                                                   @click="$event.target.select()"
+                                                   class="flex-1 min-w-0 px-3 py-2 rounded-md text-code"
+                                                   style="border: 1px solid var(--color-borders-dividers);
+                                                          background: var(--color-page-background)" />
+                                            <button type="button"
+                                                    @click="copyDocumentSnippet(editingDocument)"
+                                                    class="p-2 rounded-md flex-shrink-0 transition-colors hover:bg-gray-100"
+                                                    style="border: 1px solid var(--color-borders-dividers);
+                                                           color: var(--color-secondary-text)"
+                                                    aria-label="{{ _('Copy download link snippet') }}">
+                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                     class="h-4 w-4"
+                                                     fill="none"
+                                                     viewBox="0 0 24 24"
+                                                     stroke="currentColor"
+                                                     stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <label for="document-edit-label"
+                                               class="text-label-md block mb-1"
+                                               style="color: var(--color-headings)">
+                                            {{ _("Label") }}
+                                            <span aria-hidden="true" style="color: var(--color-error-600);">*</span>
+                                        </label>
+                                        <input type="text"
+                                               id="document-edit-label"
+                                               x-model="editingDocumentLabel"
+                                               :disabled="documentEditing"
+                                               required
+                                               aria-required="true"
+                                               class="w-full px-3 py-2 rounded-md text-body-sm"
+                                               style="border: 1px solid var(--color-borders-dividers);
+                                                      background: var(--color-page-background)" />
+                                        <p class="text-body-sm mt-1" style="color: var(--color-secondary-text);">
+                                            {{ _("Shown to registrants as the download link text and used as the file's display name in the asset list.") }}
+                                        </p>
+                                    </div>
+                                {# Inline error #}
+                                    <div x-show="documentEditError"
+                                         x-cloak
+                                         class="rounded-md p-3 mt-3"
+                                         style="background-color: var(--color-error-100);
+                                                border: 1px solid var(--color-error-400)">
+                                        <p class="text-body-sm"
+                                           style="color: var(--color-error-600)"
+                                           x-text="documentEditError"></p>
+                                    </div>
+                                </div>
+                            {# Footer #}
+                                <div class="px-6 py-3 flex gap-2 justify-between items-center"
+                                     style="border-top: 1px solid var(--color-borders-dividers);
+                                            background-color: var(--color-tables-cards)">
+                                    {{ button(_("Delete document"), variant="danger", attrs='type="button" @click="deleteEditingDocument()"', alpine_disabled="documentEditing || documentBeingDeletedId === editingDocument.id") }}
+                                    <div class="flex gap-2">
+                                        {{ button(_("Cancel"), variant="secondary", attrs='type="button" @click="closeDocumentDetailsModalIfAllowed()"', alpine_disabled="documentEditing") }}
+                                        {{ button(_("Save label"), variant="primary", attrs='type="button" @click="submitDocumentEdit()"', alpine_disabled="!editingDocumentLabel.trim() || documentEditing") }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            {# Close-registration confirmation — closing is terminal (there is no reopen), so the
+           destructive action must be explicit. Same single-surface dialog style as the
+           discard confirmation: the safe action is the primary on the right and receives
+           initial focus; the destructive action is a plain red text button. Rendered only
+           where its opener exists (preview step of a published page). #}
+                {% if active_section == "preview" and registration_status == "PUBLISHED" and registration_page %}
+                    <template x-if="confirmCloseOpen">
+                        <div x-cloak>
+                        {# Backdrop overlay #}
+                            <div class="fixed inset-0 z-40"
+                                 style="background-color: rgba(0, 0, 0, 0.5)"
+                                 @click="cancelConfirmClose()"
+                                 @keydown.escape.window="cancelConfirmClose()"></div>
+                        {# Modal panel #}
+                            <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                                 role="dialog"
+                                 aria-modal="true"
+                                 aria-labelledby="close-registration-modal-title">
+                                <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden px-6 py-5"
+                                     style="background-color: var(--color-tables-cards);
+                                            border: 1px solid var(--color-borders-dividers)"
+                                     @click.stop>
+                                    <h2 id="close-registration-modal-title"
+                                        class="text-heading-lg mb-2"
+                                        style="color: var(--color-headings)">{{ _("Close registration?") }}</h2>
+                                    <p class="text-body-md mb-5" style="color: var(--color-body-text);">
+                                        {{ _("This permanently stops new registrations. Visitors who follow the form link will see the 'registration closed' page, and the form cannot be reopened.") }}
+                                    </p>
+                                    <div class="flex gap-2 justify-end items-center">
+                                        <form method="post"
+                                              action="{{ url_for('backoffice_registration.save_assembly_registration', assembly_id=assembly.id, url_slug=registration_page.url_slug) }}"
+                                              x-data
+                                              x-preserve-scroll-on-submit>
+                                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                            <input type="hidden" name="action" value="close" />
+                                            {{ button(_("Close registration"), type="submit", variant="danger") }}
+                                        </form>
+                                        {{ button(_("Keep it open"), variant="primary", attrs='type="button" x-ref="keepOpenBtn" @click="cancelConfirmClose()"') }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                {% endif %}
             {# Discard-changes confirmation — opened by guardLeave() when the user cancels
            edit mode with unsaved changes. Only edit mode can be dirty, so this is the
            single home of the "was leaving intentional?" decision. #}
-            <template x-if="leaveModalOpen">
-                <div x-cloak>
+                <template x-if="leaveModalOpen">
+                    <div x-cloak>
                     {# Backdrop overlay #}
-                    <div class="fixed inset-0 z-40"
-                         style="background-color: rgba(0, 0, 0, 0.5)"
-                         @click="closeLeaveModal()"
-                         @keydown.escape.window="closeLeaveModal()"></div>
+                        <div class="fixed inset-0 z-40"
+                             style="background-color: rgba(0, 0, 0, 0.5)"
+                             @click="closeLeaveModal()"
+                             @keydown.escape.window="closeLeaveModal()"></div>
                     {# Modal panel #}
-                    <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-                         role="dialog"
-                         aria-modal="true"
-                         aria-labelledby="leave-modal-title">
+                        <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                             role="dialog"
+                             aria-modal="true"
+                             aria-labelledby="leave-modal-title">
                         {# Single-surface dialog (no header/footer dividers, per the Figma design):
                            title, body, and actions share one padded panel. Keep editing is the
                            primary (safe) action on the right and receives initial focus; Discard
                            changes is a plain text button so the destructive path never looks like
                            the default. #}
-                        <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden px-6 py-5"
-                             style="background-color: var(--color-tables-cards);
-                                    border: 1px solid var(--color-borders-dividers)"
-                             @click.stop>
-                            <h2 id="leave-modal-title"
-                                class="text-heading-lg mb-2"
-                                style="color: var(--color-headings)">{{ _("Discard changes?") }}</h2>
-                            <p class="text-body-md mb-5" style="color: var(--color-body-text);">
-                                {{ _("You have unsaved changes. If you leave this page, your changes will be lost.") }}
-                            </p>
-                            <div class="flex gap-2 justify-end items-center">
-                                {{ button(_("Discard changes"), variant="tertiary", attrs='type="button" @click="discardAndLeave()"') }}
-                                {{ button(_("Keep editing") , variant="primary", attrs='type="button" x-ref="keepEditingBtn" @click="closeLeaveModal()"') }}
+                            <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden px-6 py-5"
+                                 style="background-color: var(--color-tables-cards);
+                                        border: 1px solid var(--color-borders-dividers)"
+                                 @click.stop>
+                                <h2 id="leave-modal-title"
+                                    class="text-heading-lg mb-2"
+                                    style="color: var(--color-headings)">{{ _("Discard changes?") }}</h2>
+                                <p class="text-body-md mb-5" style="color: var(--color-body-text);">
+                                    {{ _("You have unsaved changes. If you leave this page, your changes will be lost.") }}
+                                </p>
+                                <div class="flex gap-2 justify-end items-center">
+                                    {{ button(_("Discard changes"), variant="tertiary", attrs='type="button" @click="discardAndLeave()"') }}
+                                    {{ button(_("Keep editing") , variant="primary", attrs='type="button" x-ref="keepEditingBtn" @click="closeLeaveModal()"') }}
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-            </template>
+                </template>
             {# Toast notification #}
-            {# role="status" (polite live region) so screen readers hear
-               copy/upload/delete outcomes - same intent as floating_alerts'
-               aria-live="polite". #}
-            <div x-cloak
-                 x-show="toastVisible"
-                 role="status"
-                 x-transition:enter="transition ease-out duration-200"
-                 x-transition:enter-start="opacity-0 -translate-y-2"
-                 x-transition:enter-end="opacity-100 translate-y-0"
-                 x-transition:leave="transition ease-in duration-150"
-                 x-transition:leave-start="opacity-100 translate-y-0"
-                 x-transition:leave-end="opacity-0 -translate-y-2"
-                 class="fixed top-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg shadow-lg"
-                 :style="toastType === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400); color: var(--color-error-600);'">
-                <span x-text="toastMessage"></span>
-            </div>
-        {% endif %}
-    </div>
-    {% if has_registration_page %}
-        <script nonce="{{ csp_nonce }}"
-                src="{{ url_for('static', filename='backoffice/js/dist/html-editor.js', v=static_hashes('backoffice/js/dist/html-editor.js')) }}"></script>
+                {# role="status" (polite live region) so screen readers hear
+                   copy/upload/delete outcomes - same intent as floating_alerts'
+                   aria-live="polite". #}
+                <div x-cloak
+                     x-show="toastVisible"
+                     role="status"
+                     x-transition:enter="transition ease-out duration-200"
+                     x-transition:enter-start="opacity-0 -translate-y-2"
+                     x-transition:enter-end="opacity-100 translate-y-0"
+                     x-transition:leave="transition ease-in duration-150"
+                     x-transition:leave-start="opacity-100 translate-y-0"
+                     x-transition:leave-end="opacity-0 -translate-y-2"
+                     class="fixed top-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg shadow-lg"
+                     :style="toastType === 'success' ? 'background-color: var(--color-success-100); border: 1px solid var(--color-success-400); color: var(--color-success-600);' : 'background-color: var(--color-error-100); border: 1px solid var(--color-error-400); color: var(--color-error-600);'">
+                    <span x-text="toastMessage"></span>
+                </div>
+            {% endif %}
+        </div>
+        {% if has_registration_page %}
+            <script nonce="{{ csp_nonce }}"
+                    src="{{ url_for('static', filename='backoffice/js/dist/html-editor.js', v=static_hashes('backoffice/js/dist/html-editor.js')) }}"></script>
         {# The controller lives in src/js/backoffice/registration-page.js, so it cannot be
            rendered through Jinja. Everything only the server can supply - url_for routes,
            the CSRF token, the translated strings, the seeded asset lists - is handed over
@@ -1625,50 +1660,52 @@ auto-reply". When multi-template support ships this becomes a visible input. #}
            break the page. The per-item routes are rendered once with a sentinel UUID that
            urlWithId() swaps for the real id, which keeps the route name a Python-side
            dependency rather than a URL shape the JavaScript has to guess. #}
-        {% set registration_page_urls = {
-        "skeleton": url_for("backoffice_registration.get_registration_skeleton", assembly_id=assembly.id),
-        "uploadImage": url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id),
-        "imageItem": url_for("backoffice_registration.update_assembly_registration_image", assembly_id=assembly.id, image_id="00000000-0000-0000-0000-000000000000"),
-        "uploadDocument": url_for("backoffice_registration.upload_registration_document", assembly_id=assembly.id),
-        "documentItem": url_for("backoffice_registration.update_assembly_registration_document", assembly_id=assembly.id, document_id="00000000-0000-0000-0000-000000000000"),
-        } %}
-        {% set registration_page_messages = {
-        "skeletonFetchFailed": _("An error occurred while fetching the form skeleton"),
-        "copied": _("Copied to clipboard"),
-        "copyFailed": _("Failed to copy to clipboard"),
-        "snippetCopied": _("Snippet copied to clipboard"),
-        "noPublicUrl": _("No public URL available yet"),
-        "uploadFailed": _("Upload failed"),
-        "altRequired": _("Alt text is required for accessibility"),
-        "imageUploaded": _("Image uploaded"),
-        "imageUploadNetworkError": _("Network error while uploading the image"),
-        "confirmDeleteImage": _("Delete this image?"),
-        "deleteImageFailed": _("Failed to delete image"),
-        "imageDeleted": _("Image deleted"),
-        "deleteImageNetworkError": _("Network error while deleting the image"),
-        "updateImageFailed": _("Failed to update image"),
-        "imageUpdated": _("Image updated"),
-        "updateImageNetworkError": _("Network error while updating the image"),
-        "labelRequired": _("Label is required"),
-        "documentUploaded": _("Document uploaded"),
-        "documentUploadNetworkError": _("Network error while uploading the document"),
-        "confirmDeleteDocument": _("Delete this document?"),
-        "deleteDocumentFailed": _("Failed to delete document"),
-        "documentDeleted": _("Document deleted"),
-        "deleteDocumentNetworkError": _("Network error while deleting the document"),
-        "updateDocumentFailed": _("Failed to update document"),
-        "documentUpdated": _("Document updated"),
-        "updateDocumentNetworkError": _("Network error while updating the document"),
-        } %}
-        {% set registration_page_data = {
-        "editMode": edit_mode,
-        "csrfToken": csrf_token(),
-        "images": images,
-        "documents": documents,
-        "urls": registration_page_urls,
-        "messages": registration_page_messages,
-        } %}
-        <script type="application/json" id="registration-page-data" nonce="{{ csp_nonce }}">{{ registration_page_data|tojson }}</script>
+            {% set registration_page_urls = {
+            "list": url_for("backoffice_registration.view_assembly_registration", assembly_id=assembly.id),
+            "skeleton": url_for("backoffice_registration.get_registration_skeleton", assembly_id=assembly.id),
+            "uploadImage": url_for("backoffice_registration.upload_registration_image", assembly_id=assembly.id),
+            "imageItem": url_for("backoffice_registration.update_assembly_registration_image", assembly_id=assembly.id, image_id="00000000-0000-0000-0000-000000000000"),
+            "uploadDocument": url_for("backoffice_registration.upload_registration_document", assembly_id=assembly.id),
+            "documentItem": url_for("backoffice_registration.update_assembly_registration_document", assembly_id=assembly.id, document_id="00000000-0000-0000-0000-000000000000"),
+            } %}
+            {% set registration_page_messages = {
+            "skeletonFetchFailed": _("An error occurred while fetching the form skeleton"),
+            "copied": _("Copied to clipboard"),
+            "copyFailed": _("Failed to copy to clipboard"),
+            "snippetCopied": _("Snippet copied to clipboard"),
+            "noPublicUrl": _("No public URL available yet"),
+            "uploadFailed": _("Upload failed"),
+            "altRequired": _("Alt text is required for accessibility"),
+            "imageUploaded": _("Image uploaded"),
+            "imageUploadNetworkError": _("Network error while uploading the image"),
+            "confirmDeleteImage": _("Delete this image?"),
+            "deleteImageFailed": _("Failed to delete image"),
+            "imageDeleted": _("Image deleted"),
+            "deleteImageNetworkError": _("Network error while deleting the image"),
+            "updateImageFailed": _("Failed to update image"),
+            "imageUpdated": _("Image updated"),
+            "updateImageNetworkError": _("Network error while updating the image"),
+            "labelRequired": _("Label is required"),
+            "documentUploaded": _("Document uploaded"),
+            "documentUploadNetworkError": _("Network error while uploading the document"),
+            "confirmDeleteDocument": _("Delete this document?"),
+            "deleteDocumentFailed": _("Failed to delete document"),
+            "documentDeleted": _("Document deleted"),
+            "deleteDocumentNetworkError": _("Network error while deleting the document"),
+            "updateDocumentFailed": _("Failed to update document"),
+            "documentUpdated": _("Document updated"),
+            "updateDocumentNetworkError": _("Network error while updating the document"),
+            } %}
+            {% set registration_page_data = {
+            "editMode": edit_mode,
+            "csrfToken": csrf_token(),
+            "images": images,
+            "documents": documents,
+            "urls": registration_page_urls,
+            "messages": registration_page_messages,
+            } %}
+            <script type="application/json" id="registration-page-data" nonce="{{ csp_nonce }}">{{ registration_page_data|tojson }}</script>
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/backend/templates/backoffice/assembly_registration_list.html
+++ b/backend/templates/backoffice/assembly_registration_list.html
@@ -4,9 +4,9 @@ ABOUTME: One row per page with status, publish date and a per-row actions menu
 #}
 {% extends "backoffice/base_page.html" %}
 {% from "backoffice/components/page_header.html" import page_header %}
-{% from "backoffice/components/button.html" import button %}
+{% from "backoffice/components/registration_page_list.html" import registration_page_list %}
 {% from "backoffice/components/assembly_tabs.html" import assembly_tabs %}
-{% block title %}{{ assembly.title }} - {{ _("Registration") }}{% endblock %}
+{% block title %}{{ assembly.title }} - Registration{% endblock %}
 {% block page_header %}
     <div class="max-w-screen-2xl mx-auto px-6 pt-4 w-full">
         {{ page_header(title=assembly.title,
@@ -24,138 +24,5 @@ ABOUTME: One row per page with status, publish date and a per-row actions menu
     </div>
 {% endblock %}
 {% block page_content %}
-    <div>
-        {# Header row: section title + create CTA, per the Figma list view #}
-        <div class="flex items-center justify-between mb-6">
-            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration") }}</h2>
-            <form method="post"
-                  action="{{ url_for('backoffice_registration.create_assembly_registration_page', assembly_id=assembly.id) }}">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                {{ button(_("Create HTML page"), type="submit", variant="primary") }}
-            </form>
-        </div>
-
-        {% if page_rows %}
-            <div class="rounded-lg" style="border: 1px solid var(--color-borders-dividers);">
-                <table class="w-full text-body-sm">
-                    <thead>
-                        <tr style="background-color: var(--color-subtle-background-panels);">
-                            <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Name") }}</th>
-                            <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Status") }}</th>
-                            <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Date of publish") }}</th>
-                            <th scope="col" class="px-3 py-2 text-right">
-                                <span class="sr-only">{{ _("Actions") }}</span>
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for row in page_rows %}
-                            {% set page = row.page %}
-                            <tr style="background-color: var(--color-tables-cards); border-top: 1px solid var(--color-borders-dividers);">
-                                <td class="px-3 py-3">
-                                    {% if row.editor_url %}
-                                        <a href="{{ row.editor_url }}"
-                                           class="text-label-lg hover:underline"
-                                           style="color: var(--color-links);">{{ page.name }}</a>
-                                    {% else %}
-                                        <span class="text-label-lg" style="color: var(--color-body-text);">{{ page.name }}</span>
-                                    {% endif %}
-                                    {% if page.language %}
-                                        <span class="ml-2 px-2 py-0.5 rounded text-body-xs uppercase"
-                                              style="background-color: var(--color-subtle-background-panels); color: var(--color-secondary-text); border: 1px solid var(--color-borders-dividers);">{{ page.language }}</span>
-                                    {% endif %}
-                                </td>
-                                <td class="px-3 py-3">
-                                    {% if page.status.value == "PUBLISHED" %}
-                                        <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-body-sm"
-                                              style="background-color: var(--color-success-100); color: var(--color-success-600); border: 1px solid var(--color-success-400);">
-                                            <span class="w-2 h-2 rounded-full" style="background-color: var(--color-success-400);"></span>
-                                            {{ _("Published") }}
-                                        </span>
-                                    {% elif page.status.value == "CLOSED" %}
-                                        <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-body-sm"
-                                              style="background-color: var(--color-error-100); color: var(--color-error-600); border: 1px solid var(--color-error-400);">
-                                            <span class="w-2 h-2 rounded-full" style="background-color: var(--color-error-400);"></span>
-                                            {{ _("Closed") }}
-                                        </span>
-                                    {% else %}
-                                        <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-body-sm"
-                                              style="background-color: var(--color-warning-100); color: var(--color-warning-600); border: 1px solid var(--color-warning-400);">
-                                            <span class="w-2 h-2 rounded-full" style="background-color: var(--color-warning-400);"></span>
-                                            {{ _("Test") }}
-                                        </span>
-                                    {% endif %}
-                                </td>
-                                <td class="px-3 py-3" style="color: var(--color-body-text);">
-                                    {% if row.published_at %}
-                                        {{ row.published_at | dateformat }}
-                                    {% else %}
-                                        <span style="color: var(--color-secondary-text);">—</span>
-                                    {% endif %}
-                                </td>
-                                <td class="px-3 py-3 text-right">
-                                    {# Per-row actions menu (kebab), mirroring the dropdown_button component's
-                                       open/close and ARIA behaviour but mixing link and submit items #}
-                                    <div class="relative inline-flex"
-                                         x-data="{ open: false }"
-                                         @keydown.escape.window="open = false">
-                                        <button type="button"
-                                                id="page-actions-{{ loop.index }}-toggle"
-                                                class="p-2 rounded hover:bg-black/5"
-                                                @click="open = !open"
-                                                @click.outside="open = false"
-                                                aria-haspopup="menu"
-                                                x-bind:aria-expanded="open ? 'true' : 'false'"
-                                                aria-controls="page-actions-{{ loop.index }}-menu"
-                                                aria-label="{{ _('Actions for %(name)s', name=page.name) }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" style="color: var(--color-secondary-text);">
-                                                <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
-                                            </svg>
-                                        </button>
-                                        <div x-show="open"
-                                             x-cloak
-                                             id="page-actions-{{ loop.index }}-menu"
-                                             role="menu"
-                                             aria-labelledby="page-actions-{{ loop.index }}-toggle"
-                                             class="menu menu--right"
-                                             style="min-width: 14rem;">
-                                            <a role="menuitem"
-                                               class="menu-item"
-                                               href="{{ url_for('backoffice.view_assembly', assembly_id=assembly.id) }}">
-                                                {{ _("See assembly details") }}
-                                            </a>
-                                            {% if row.close_url %}
-                                                {# role="none": a form is not a valid child of role="menu" - the
-                                                   menuitem is the submit button inside it #}
-                                                <form method="post" action="{{ row.close_url }}" role="none">
-                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                                                    <input type="hidden" name="action" value="close" />
-                                                    <input type="hidden" name="return_to" value="list" />
-                                                    <button type="submit" role="menuitem" class="menu-item w-full text-left">
-                                                        {{ _("Close registration") }}
-                                                    </button>
-                                                </form>
-                                            {% endif %}
-                                            {% if row.editor_url %}
-                                                <a role="menuitem" class="menu-item" href="{{ row.editor_url }}">
-                                                    {{ _("Edit registration") }}
-                                                </a>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        {% else %}
-            <div class="rounded-lg p-6"
-                 style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
-                <p class="text-body-md" style="color: var(--color-body-text);">
-                    {{ _("This assembly has no registration pages yet. Create one to start collecting registrations — you can add more pages later, for example for language variants or A/B tests.") }}
-                </p>
-            </div>
-        {% endif %}
-    </div>
+    {{ registration_page_list(assembly, page_rows) }}
 {% endblock %}

--- a/backend/templates/backoffice/base_page.html
+++ b/backend/templates/backoffice/base_page.html
@@ -21,7 +21,12 @@ ABOUTME: Sticky top nav + sticky page-header slot, flash messages, content slot,
         {# Sticky chrome: the top bar and (where present) the page header + tabs
            stay pinned while page content scrolls beneath them. The header uses the
            page background so the sticky page-header slot is opaque. #}
-        <header class="sticky top-0 z-40" style="background-color: var(--color-bg-secondary);">
+        {# page_takeover: set by views whose page_content is only the dimmed, decorative
+           backdrop of a page-level modal (see the page_overlay block below). The header,
+           main and footer are then inert — invisible to keyboard and assistive tech — so
+           the overlay's dialog is the only interactive surface. The floating alerts stay
+           outside the inert regions: flash messages must remain live above the dialog. #}
+        <header class="sticky top-0 z-40" style="background-color: var(--color-bg-secondary);" {% if page_takeover %}inert{% endif %}>
             {# "My account" and "Switch to site admin" are old-design pages; their
                target="new" opens both in one shared tab rather than stacking tabs. #}
             {{ navigation(
@@ -43,15 +48,25 @@ ABOUTME: Sticky top nav + sticky page-header slot, flash messages, content slot,
             {% block page_header %}{% endblock %}
         </header>
 
-        <main class="max-w-screen-2xl mx-auto px-6 py-8 flex-1 w-full">
+        <main class="max-w-screen-2xl mx-auto px-6 py-8 flex-1 w-full" {% if page_takeover %}inert{% endif %}>
             {% block page_content %}{% endblock %}
         </main>
 
         {# Flash messages: fixed top-centre overlay. Its z-index (#floating-alerts,
            45) is defined and documented in main.css — above the sticky header
-           (z-40), below modal dialogs (z-50). #}
+           (z-40), below modal dialogs (z-50), but lifted above a page takeover
+           dialog (55) so flashes stay readable over the full-screen panel. #}
         {{ floating_alerts() }}
 
-        {{ footer() }}
+        {% if page_takeover %}
+            <div inert>{{ footer() }}</div>
+        {% else %}
+            {{ footer() }}
+        {% endif %}
+
+        {# Page-level modal overlay — rendered over the inert page when the view
+           sets page_takeover. Fixed-position content, so placement in the flex
+           column does not affect layout. #}
+        {% block page_overlay %}{% endblock %}
     </div>
 {% endblock %}

--- a/backend/templates/backoffice/components/registration_page_list.html
+++ b/backend/templates/backoffice/components/registration_page_list.html
@@ -1,0 +1,141 @@
+{#
+ABOUTME: The registration pages list — heading + create CTA + one row per page
+ABOUTME: Rendered by the list page, and again behind the editor's takeover modal
+#}
+{% from "backoffice/components/button.html" import button %}
+{% macro registration_page_list(assembly, page_rows) %}
+    <div>
+        {# Header row: section title + create CTA, per the Figma list view #}
+        <div class="flex items-center justify-between mb-6">
+            <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration") }}</h2>
+            <form method="post"
+                  action="{{ url_for('backoffice_registration.create_assembly_registration_page', assembly_id=assembly.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                {{ button(_("Create HTML page"), type="submit", variant="primary") }}
+            </form>
+        </div>
+
+        {% if page_rows %}
+            <div class="rounded-lg" style="border: 1px solid var(--color-borders-dividers);">
+                <table class="w-full text-body-sm">
+                    <thead>
+                        <tr style="background-color: var(--color-subtle-background-panels);">
+                            <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Name") }}</th>
+                            <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Status") }}</th>
+                            <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Date of publish") }}</th>
+                            <th scope="col" class="px-3 py-2 text-right">
+                                <span class="sr-only">{{ _("Actions") }}</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in page_rows %}
+                            {% set page = row.page %}
+                            <tr style="background-color: var(--color-tables-cards); border-top: 1px solid var(--color-borders-dividers);">
+                                <td class="px-3 py-3">
+                                    {% if row.editor_url %}
+                                        <a href="{{ row.editor_url }}"
+                                           class="text-label-lg hover:underline"
+                                           style="color: var(--color-links);">{{ page.name }}</a>
+                                    {% else %}
+                                        <span class="text-label-lg" style="color: var(--color-body-text);">{{ page.name }}</span>
+                                    {% endif %}
+                                    {% if page.language %}
+                                        <span class="ml-2 px-2 py-0.5 rounded text-body-xs uppercase"
+                                              style="background-color: var(--color-subtle-background-panels); color: var(--color-secondary-text); border: 1px solid var(--color-borders-dividers);">{{ page.language }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-3 py-3">
+                                    {% if page.status.value == "PUBLISHED" %}
+                                        <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-body-sm"
+                                              style="background-color: var(--color-success-100); color: var(--color-success-600); border: 1px solid var(--color-success-400);">
+                                            <span class="w-2 h-2 rounded-full" style="background-color: var(--color-success-400);"></span>
+                                            {{ _("Published") }}
+                                        </span>
+                                    {% elif page.status.value == "CLOSED" %}
+                                        <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-body-sm"
+                                              style="background-color: var(--color-error-100); color: var(--color-error-600); border: 1px solid var(--color-error-400);">
+                                            <span class="w-2 h-2 rounded-full" style="background-color: var(--color-error-400);"></span>
+                                            {{ _("Closed") }}
+                                        </span>
+                                    {% else %}
+                                        <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-body-sm"
+                                              style="background-color: var(--color-warning-100); color: var(--color-warning-600); border: 1px solid var(--color-warning-400);">
+                                            <span class="w-2 h-2 rounded-full" style="background-color: var(--color-warning-400);"></span>
+                                            {{ _("Test") }}
+                                        </span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-3 py-3" style="color: var(--color-body-text);">
+                                    {% if row.published_at %}
+                                        {{ row.published_at | dateformat }}
+                                    {% else %}
+                                        <span style="color: var(--color-secondary-text);">—</span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-3 py-3 text-right">
+                                    {# Per-row actions menu (kebab), mirroring the dropdown_button component's
+                                       open/close and ARIA behaviour but mixing link and submit items #}
+                                    <div class="relative inline-flex"
+                                         x-data="{ open: false }"
+                                         @keydown.escape.window="open = false">
+                                        <button type="button"
+                                                id="page-actions-{{ loop.index }}-toggle"
+                                                class="p-2 rounded hover:bg-black/5"
+                                                @click="open = !open"
+                                                @click.outside="open = false"
+                                                aria-haspopup="menu"
+                                                x-bind:aria-expanded="open ? 'true' : 'false'"
+                                                aria-controls="page-actions-{{ loop.index }}-menu"
+                                                aria-label="{{ _('Actions for %(name)s', name=page.name) }}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" style="color: var(--color-secondary-text);">
+                                                <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+                                            </svg>
+                                        </button>
+                                        <div x-show="open"
+                                             x-cloak
+                                             id="page-actions-{{ loop.index }}-menu"
+                                             role="menu"
+                                             aria-labelledby="page-actions-{{ loop.index }}-toggle"
+                                             class="menu menu--right"
+                                             style="min-width: 14rem;">
+                                            <a role="menuitem"
+                                               class="menu-item"
+                                               href="{{ url_for('backoffice.view_assembly', assembly_id=assembly.id) }}">
+                                                {{ _("See assembly details") }}
+                                            </a>
+                                            {% if row.close_url %}
+                                                {# role="none": a form is not a valid child of role="menu" - the
+                                                   menuitem is the submit button inside it #}
+                                                <form method="post" action="{{ row.close_url }}" role="none">
+                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                                    <input type="hidden" name="action" value="close" />
+                                                    <input type="hidden" name="return_to" value="list" />
+                                                    <button type="submit" role="menuitem" class="menu-item w-full text-left">
+                                                        {{ _("Close registration") }}
+                                                    </button>
+                                                </form>
+                                            {% endif %}
+                                            {% if row.editor_url %}
+                                                <a role="menuitem" class="menu-item" href="{{ row.editor_url }}">
+                                                    {{ _("Edit registration") }}
+                                                </a>
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="rounded-lg p-6"
+                 style="background-color: var(--color-subtle-background-panels); border: 1px solid var(--color-borders-dividers);">
+                <p class="text-body-md" style="color: var(--color-body-text);">
+                    {{ _("This assembly has no registration pages yet. Create one to start collecting registrations — you can add more pages later, for example for language variants or A/B tests.") }}
+                </p>
+            </div>
+        {% endif %}
+    </div>
+{% endmacro %}

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -552,7 +552,10 @@ def confirm_close_registration(page: Page):
 
 @then("the registration should be shown as closed")
 def registration_shown_as_closed(page: Page):
-    expect(page.get_by_role("alert").filter(has_text="Registration closed")).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+    """Closing finishes the editor flow: it dismisses the editor modal and lands
+    on the pages list, where the page's row carries the Closed status badge."""
+    page.wait_for_url(lambda url: url.rstrip("/").endswith("/registration"), timeout=PLAYWRIGHT_TIMEOUT)
+    expect(page.get_by_role("cell", name="Closed", exact=True)).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
 
 
 @then("the registration should be shown as in test mode")
@@ -591,16 +594,22 @@ def submitting_preview_form_does_nothing(page: Page):
 def _wait_until_scrolled(page: Page, timeout_ms: int = 5000) -> None:
     """Poll window.scrollY (via CDP evaluate) until it is greater than 0.
 
+    The registration editor is a takeover modal whose .dialog-body is the page's
+    scroll container (the window itself is scroll-locked), so that element's
+    scrollTop is what the restore leg writes to; window.scrollY stays the
+    fallback for ordinary pages.
+
     We deliberately avoid page.wait_for_function here: its string predicate is
     compiled with eval in the page's own context, which our strict-dynamic CSP
     (no 'unsafe-eval') rejects. page.evaluate runs in Playwright's utility world,
     so it is not subject to the page CSP.
     """
+    scroller = "document.querySelector('.dialog-panel--takeover .dialog-body')?.scrollTop ?? window.scrollY"
     for _ in range(max(1, timeout_ms // 100)):
-        if page.evaluate("window.scrollY") > 0:
+        if page.evaluate(scroller) > 0:
             return
         page.wait_for_timeout(100)
-    raise AssertionError("window did not scroll (scrollY stayed 0)")
+    raise AssertionError("the page's scroll container did not scroll (stayed at 0)")
 
 
 @when(parsers.parse('I open the read-only registration form view for "{title}" with a saved scroll of {pos:d}'))

--- a/backend/tests/component/test_backoffice_registration_page_script.py
+++ b/backend/tests/component/test_backoffice_registration_page_script.py
@@ -232,6 +232,7 @@ class TestTheDataBlock:
         urls = _page_data(page_html)["urls"]
 
         assert set(urls) == {
+            "list",
             "skeleton",
             "uploadImage",
             "imageItem",

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -391,6 +391,27 @@ class TestLifecycleFooterControls:
         assert 'value="unpublish"' not in body
         assert "Close registration/my-slug" not in body
 
+    def test_publish_publishes_the_page_and_lands_on_the_list(self, logged_in_admin, fake_store, assembly_id):
+        # Publishing finishes the editor flow, so it dismisses the editor modal:
+        # the redirect goes to the pages list, not back into the editor.
+        page = _seed_page(
+            fake_store,
+            assembly_id,
+            RegistrationPageStatus.TEST,
+            form_html="<form>{{ csrf_form_element }}{{ form_action }}</form>",
+        )
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly_id}/registration/my-slug/save",
+            data={"action": "publish"},
+        )
+
+        assert response.status_code == 302
+        assert response.location == f"/backoffice/assembly/{assembly_id}/registration"
+        with FakeUnitOfWork(store=fake_store) as uow:
+            stored = uow.registration_pages.get(page.id)
+        assert stored.status == RegistrationPageStatus.PUBLISHED
+
     def test_unpublish_returns_page_to_test_and_lands_on_preview(self, logged_in_admin, fake_store, assembly_id):
         page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.PUBLISHED)
 
@@ -405,7 +426,9 @@ class TestLifecycleFooterControls:
             stored = uow.registration_pages.get(page.id)
         assert stored.status == RegistrationPageStatus.TEST
 
-    def test_close_closes_the_page_and_lands_on_preview(self, logged_in_admin, fake_store, assembly_id):
+    def test_close_closes_the_page_and_lands_on_the_list(self, logged_in_admin, fake_store, assembly_id):
+        # Closing finishes the editor flow, so it dismisses the editor modal:
+        # the redirect goes to the pages list, not back into the editor.
         page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.PUBLISHED)
 
         response = logged_in_admin.post(
@@ -414,7 +437,7 @@ class TestLifecycleFooterControls:
         )
 
         assert response.status_code == 302
-        assert "section=preview" in response.location
+        assert response.location == f"/backoffice/assembly/{assembly_id}/registration"
         with FakeUnitOfWork(store=fake_store) as uow:
             stored = uow.registration_pages.get(page.id)
         assert stored.status == RegistrationPageStatus.CLOSED

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 14:57+0200\n"
+"POT-Creation-Date: 2026-08-18 11:10+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -133,27 +133,6 @@ msgstr ""
 #, fuzzy
 msgid "Name deleted"
 msgstr "Kiválasztás"
-
-#: src/opendlp/domain/validators.py:54
-#, fuzzy
-msgid "URL slug cannot be empty"
-msgstr "Utoljára módosítva"
-
-#: src/opendlp/domain/validators.py:56
-#, python-format
-msgid "URL slug cannot be longer than %(max)s characters"
-msgstr ""
-
-#: src/opendlp/domain/validators.py:60
-msgid ""
-"URL slug must be lowercase letters, numbers and hyphens, with no leading "
-"or trailing hyphen"
-msgstr ""
-
-#: src/opendlp/domain/validators.py:63
-#, python-format
-msgid "URL slug '%(value)s' is reserved and cannot be used"
-msgstr ""
 
 #: src/opendlp/domain/value_objects.py:18
 msgid "User - Basic access to assigned assemblies"
@@ -1068,8 +1047,8 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:161
 #: src/opendlp/entrypoints/blueprints/backoffice.py:392
 #: src/opendlp/entrypoints/blueprints/backoffice.py:449
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:242
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:349
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:247
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:360
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:82
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:94
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:129
@@ -1108,19 +1087,19 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:284
 #: src/opendlp/entrypoints/blueprints/backoffice.py:383
 #: src/opendlp/entrypoints/blueprints/backoffice.py:440
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:248
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:355
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:517
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:729
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:795
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:819
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:917
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:980
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1008
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1033
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1081
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1111
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1138
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:253
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:366
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:535
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:747
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:813
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:837
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:935
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:998
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1026
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1051
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1099
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1129
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1156
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:408
@@ -1274,104 +1253,104 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:150
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:185
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:149
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:184
 #, fuzzy, python-format
 msgid "Details for %(name)s"
 msgstr "Hiba részletei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:151
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:150
 #, python-format
 msgid "Copy <img> snippet for %(name)s"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:152
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:187
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:151
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:186
 #, fuzzy, python-format
 msgid "Delete %(name)s"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:186
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:185
 #, python-format
 msgid "Copy download link snippet for %(name)s"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:254
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:365
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:259
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:376
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:340
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:502
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:723
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:351
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:520
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:741
 #, fuzzy
 msgid "That registration page could not be found."
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:377
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:388
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:378
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:389
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:381
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:392
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:384
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:395
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:387
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:398
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:389
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:400
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:390
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:401
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:511
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:726
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:792
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:978
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1006
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1031
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1079
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1109
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1136
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:529
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:744
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:810
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:996
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1024
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1049
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1097
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1127
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1154
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:527
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:545
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:598
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:616
 #, fuzzy
 msgid "Registration auto-reply"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:599
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:617
 msgid "Thanks for registering for {{ assembly.title }}"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:601
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:619
 msgid ""
 "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
 "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
@@ -1380,139 +1359,139 @@ msgid ""
 "<p>Best wishes,<br>The team</p>"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:639
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:657
 msgid "Auto-reply email created. Edit it below and click Save."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:651
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:669
 msgid "There is no auto-reply email to save yet — set one up first."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:665
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:683
 msgid "Auto-reply email saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:684
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:702
 msgid "Unknown action — nothing was changed."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:720
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:738
 msgid "The auto-reply email could not be found."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:738
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:756
 #, fuzzy
 msgid "An error occurred while saving the auto-reply email"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:763
-#: templates/backoffice/assembly_registration.html:67
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:781
+#: templates/backoffice/assembly_registration.html:100
 #: templates/backoffice/patterns/_stepper.html:28
 #: templates/backoffice/patterns/_stepper.html:102
 #, fuzzy
 msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:787
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:805
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:803
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:821
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:817
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:911
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:835
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:929
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:822
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:840
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:921
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:939
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:948
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1051
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:966
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1069
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:954
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1057
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:972
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1075
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:958
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:995
-#: templates/backoffice/assembly_registration.html:1641
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:976
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1013
+#: templates/backoffice/assembly_registration.html:1674
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:976
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1077
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:994
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1095
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:983
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1001
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1002
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1027
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1020
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1045
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1004
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1029
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1107
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1134
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1022
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1047
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1125
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1152
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1011
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1029
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1036
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1054
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1084
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1102
 #, fuzzy
 msgid "An error occurred while uploading the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1098
-#: templates/backoffice/assembly_registration.html:1651
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1116
+#: templates/backoffice/assembly_registration.html:1684
 msgid "Label is required"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1105
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1132
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1123
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1150
 #, fuzzy
 msgid "Document not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1116
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1134
 #, fuzzy
 msgid "An error occurred while updating the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1141
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1159
 #, fuzzy
 msgid "An error occurred while deleting the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -3024,52 +3003,6 @@ msgstr "Bejelentkezés"
 msgid "registration"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/service_layer/registration_page_service.py:71
-#, python-format
-msgid "The %(label)s must be at most %(max_bytes)s bytes; got %(size)s"
-msgstr ""
-
-#: src/opendlp/service_layer/registration_page_service.py:164
-msgid "Failed to generate unique short URL slug after multiple attempts"
-msgstr ""
-
-#: src/opendlp/service_layer/registration_page_service.py:219
-#: src/opendlp/service_layer/registration_page_service.py:546
-#, fuzzy
-msgid "The registration page name is required"
-msgstr "Vissza a regisztrációhoz"
-
-#: src/opendlp/service_layer/registration_page_service.py:222
-#: src/opendlp/service_layer/registration_page_service.py:549
-#, python-format
-msgid "This assembly already has a registration page named '%(name)s'"
-msgstr ""
-
-#: src/opendlp/service_layer/registration_page_service.py:393
-msgid ""
-"A registration page that has been published cannot be deleted; close it "
-"instead"
-msgstr ""
-
-#: src/opendlp/service_layer/registration_page_service.py:395
-msgid "This registration page has registrations, so it cannot be deleted"
-msgstr ""
-
-#: src/opendlp/service_layer/registration_page_service.py:475
-#: src/opendlp/service_layer/registration_page_service.py:483
-#, python-format
-msgid "The slug '%(slug)s' is already in use by another registration page"
-msgstr ""
-
-#: src/opendlp/service_layer/registration_page_service.py:581
-msgid "thank-you HTML"
-msgstr ""
-
-#: src/opendlp/service_layer/registration_page_service.py:597
-#, fuzzy
-msgid "form HTML"
-msgstr "Keresztnév"
-
 #: src/opendlp/service_layer/respondent_export_service.py:48
 #, python-format
 msgid "Invalid respondent status filter: %(value)s"
@@ -3330,7 +3263,7 @@ msgstr ""
 msgid "My Account"
 msgstr "Hozzon létre fiókot"
 
-#: templates/backoffice/base_page.html:39 templates/base.html:79
+#: templates/backoffice/base_page.html:44 templates/base.html:79
 msgid "Sign out"
 msgstr "Kilépés"
 
@@ -3371,7 +3304,7 @@ msgstr "Sikerült"
 msgid "Important"
 msgstr "Fontos"
 
-#: templates/backoffice/base_page.html:37 templates/base.html:176
+#: templates/backoffice/base_page.html:42 templates/base.html:176
 #: templates/base_public.html:40
 msgid "User Data Agreement"
 msgstr "Felhasználói Adatkezelési Megállapodás"
@@ -3467,12 +3400,12 @@ msgstr "Add meg a meghívókódodat a regisztrációhoz"
 #: templates/backoffice/assembly_data.html:503
 #: templates/backoffice/assembly_edit_respondent.html:134
 #: templates/backoffice/assembly_form.html:96
-#: templates/backoffice/assembly_registration.html:173
-#: templates/backoffice/assembly_registration.html:570
-#: templates/backoffice/assembly_registration.html:1043
-#: templates/backoffice/assembly_registration.html:1235
-#: templates/backoffice/assembly_registration.html:1338
-#: templates/backoffice/assembly_registration.html:1509
+#: templates/backoffice/assembly_registration.html:206
+#: templates/backoffice/assembly_registration.html:603
+#: templates/backoffice/assembly_registration.html:1078
+#: templates/backoffice/assembly_registration.html:1270
+#: templates/backoffice/assembly_registration.html:1373
+#: templates/backoffice/assembly_registration.html:1544
 #: templates/backoffice/assembly_view_respondent.html:302
 #: templates/backoffice/components/edit_number_to_select_modal.html:40
 #: templates/backoffice/components/respondent_status_form.html:87
@@ -3515,8 +3448,8 @@ msgstr ""
 
 #: templates/admin/invite_view.html:34
 #: templates/backoffice/assembly_details.html:118
-#: templates/backoffice/assembly_registration.html:193
-#: templates/backoffice/assembly_registration.html:735
+#: templates/backoffice/assembly_registration.html:226
+#: templates/backoffice/assembly_registration.html:768
 #, fuzzy
 msgid "Registration URL"
 msgstr "Vissza a regisztrációhoz"
@@ -3558,10 +3491,10 @@ msgstr ""
 
 #: templates/admin/invite_view.html:64 templates/admin/invites.html:68
 #: templates/admin/users.html:115 templates/backoffice/assembly_details.html:53
-#: templates/backoffice/assembly_registration_list.html:44
 #: templates/backoffice/assembly_respondents.html:126
 #: templates/backoffice/assembly_selection.html:171
 #: templates/backoffice/assembly_selection.html:351
+#: templates/backoffice/components/registration_page_list.html:24
 #: templates/backoffice/respondents/export_modal.html:38
 #: templates/main/view_assembly_data.html:54
 #: templates/main/view_assembly_details.html:13
@@ -3722,10 +3655,10 @@ msgstr ""
 
 #: templates/admin/invites.html:71 templates/admin/users.html:118
 #: templates/backoffice/assembly_members.html:51
-#: templates/backoffice/assembly_registration_list.html:47
 #: templates/backoffice/assembly_respondents.html:130
 #: templates/backoffice/assembly_selection.html:183
 #: templates/backoffice/assembly_selection.html:363
+#: templates/backoffice/components/registration_page_list.html:27
 #: templates/backoffice/respondent_field_schema/view.html:138
 #: templates/backoffice/targets/category_block.html:111
 #: templates/main/view_assembly_data.html:60
@@ -3853,8 +3786,8 @@ msgid "Edit User"
 msgstr "Módosítsa a számot."
 
 #: templates/admin/user_edit.html:20 templates/admin/users.html:163
-#: templates/backoffice/assembly_registration.html:176
-#: templates/backoffice/assembly_registration.html:573
+#: templates/backoffice/assembly_registration.html:209
+#: templates/backoffice/assembly_registration.html:606
 #: templates/backoffice/assembly_respondents.html:143
 #: templates/backoffice/assembly_selection.html:78
 #: templates/backoffice/assembly_selection.html:291
@@ -4049,8 +3982,8 @@ msgid "Showing %(start)s to %(end)s of %(total)s users"
 msgstr ""
 
 #: templates/admin/users.html:112
-#: templates/backoffice/assembly_registration_list.html:43
 #: templates/backoffice/assembly_respondents.html:127
+#: templates/backoffice/components/registration_page_list.html:23
 #: templates/backoffice/service_docs/_emails.html:70
 #, fuzzy
 msgid "Name"
@@ -4334,6 +4267,7 @@ msgstr ""
 #: templates/backoffice/assembly_data.html:17
 #: templates/backoffice/assembly_details.html:19
 #: templates/backoffice/assembly_members.html:20
+#: templates/backoffice/assembly_registration.html:21
 #: templates/backoffice/assembly_registration_list.html:14
 #: templates/backoffice/assembly_respondents.html:21
 #: templates/backoffice/assembly_selection.html:18
@@ -4623,10 +4557,10 @@ msgstr ""
 
 #: templates/backoffice/assembly_data.html:339
 #: templates/backoffice/assembly_data.html:397
-#: templates/backoffice/assembly_registration.html:270
-#: templates/backoffice/assembly_registration.html:367
-#: templates/backoffice/assembly_registration.html:1044
-#: templates/backoffice/assembly_registration.html:1339
+#: templates/backoffice/assembly_registration.html:303
+#: templates/backoffice/assembly_registration.html:400
+#: templates/backoffice/assembly_registration.html:1079
+#: templates/backoffice/assembly_registration.html:1374
 msgid "Upload"
 msgstr ""
 
@@ -4739,13 +4673,13 @@ msgid "The URL for this registration form"
 msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:125
-#: templates/backoffice/assembly_registration.html:740
+#: templates/backoffice/assembly_registration.html:773
 msgid "Short URL"
 msgstr ""
 
 #: templates/backoffice/assembly_details.html:126
-#: templates/backoffice/assembly_registration.html:203
-#: templates/backoffice/assembly_registration.html:741
+#: templates/backoffice/assembly_registration.html:236
+#: templates/backoffice/assembly_registration.html:774
 msgid "A shorter URL for QR codes and paper invitations"
 msgstr ""
 
@@ -4755,14 +4689,17 @@ msgid "No registration page has been created for this assembly."
 msgstr "Vissza a közösségi gyűléshez"
 
 #: templates/backoffice/assembly_details.html:142
-#, python-format
 msgid ""
 "To create your first registration page, edit an existing one, or add "
-"another (for example a language variant), go to the "
-"%(link_start)sRegistration tab%(link_end)s."
+"another (for example a language variant), go to the"
 msgstr ""
 
-#: templates/backoffice/assembly_details.html:151
+#: templates/backoffice/assembly_details.html:145
+#, fuzzy
+msgid "Registration tab"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/assembly_details.html:152
 #: templates/backoffice/edit_assembly.html:8
 #: templates/backoffice/edit_assembly.html:12
 #: templates/main/edit_assembly.html:2 templates/main/edit_assembly.html:23
@@ -4849,88 +4786,79 @@ msgstr "Vissza a közösségi gyűléshez"
 msgid "Type to search by email or name..."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:14
-#: templates/backoffice/assembly_registration_list.html:9
-#: templates/backoffice/assembly_registration_list.html:30
-#: templates/backoffice/components/assembly_tabs.html:55
-#: templates/backoffice/service_docs.html:32
-#, fuzzy
-msgid "Registration"
-msgstr "Vissza a regisztrációhoz"
-
-#: templates/backoffice/assembly_registration.html:19
-#, fuzzy
-msgid "Back to registration pages"
-msgstr "Vissza a regisztrációhoz"
-
-#: templates/backoffice/assembly_registration.html:49
+#: templates/backoffice/assembly_registration.html:55
 #, fuzzy
 msgid "Registration page not created"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:51
+#: templates/backoffice/assembly_registration.html:57
 msgid ""
 "Before you can configure the registration form, you need to create a "
 "registration page from the Details tab."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:53
+#: templates/backoffice/assembly_registration.html:59
 #, fuzzy
 msgid "Go to Details tab"
 msgstr "További beállítások"
 
-#: templates/backoffice/assembly_registration.html:68
-#: templates/backoffice/assembly_registration.html:515
+#: templates/backoffice/assembly_registration.html:88
+#, fuzzy
+msgid "Close and return to the registration pages"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/assembly_registration.html:101
+#: templates/backoffice/assembly_registration.html:548
 #: templates/backoffice/patterns/_stepper.html:29
 #: templates/backoffice/patterns/_stepper.html:103
 #, fuzzy
 msgid "Auto-reply email"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/assembly_registration.html:69
+#: templates/backoffice/assembly_registration.html:102
 #: templates/backoffice/patterns/_stepper.html:30
 #: templates/backoffice/patterns/_stepper.html:104
 #, fuzzy
 msgid "Preview and publish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:71
+#: templates/backoffice/assembly_registration.html:104
 #, fuzzy
 msgid "Registration setup steps"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:83
+#: templates/backoffice/assembly_registration.html:116
 #, fuzzy
 msgid "Test mode"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:84
+#: templates/backoffice/assembly_registration.html:117
 msgid ""
 "Submissions are recorded as test entries and don't enter the selection "
 "pool. Publish the registration when you're ready to go live."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:93
+#: templates/backoffice/assembly_registration.html:126
 #, fuzzy
 msgid "Registration closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:94
+#: templates/backoffice/assembly_registration.html:127
 msgid "Visitors who follow the form URL are redirected to the closed page."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:104
-#: templates/backoffice/assembly_registration_list.html:73
+#: templates/backoffice/assembly_registration.html:137
+#: templates/backoffice/components/registration_page_list.html:53
 msgid "Published"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:121
+#: templates/backoffice/assembly_registration.html:154
 #, fuzzy
 msgid "Save and Republish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:121
-#: templates/backoffice/assembly_registration.html:571
+#: templates/backoffice/assembly_registration.html:154
+#: templates/backoffice/assembly_registration.html:604
 #: templates/backoffice/components/edit_number_to_select_modal.html:41
 #: templates/backoffice/respondent_field_schema/view.html:228
 #: templates/backoffice/respondent_field_schema/view.html:269
@@ -4943,270 +4871,270 @@ msgstr "Módosítások mentése"
 msgid "Save"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:139
+#: templates/backoffice/assembly_registration.html:172
 #, fuzzy
 msgid "Registration page name"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:168
+#: templates/backoffice/assembly_registration.html:201
 msgid "Show Form Skeleton"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:187
+#: templates/backoffice/assembly_registration.html:220
 msgid ""
 "These URLs are locked while the registration page is published or closed,"
 " so links shared in invites, QR codes, and elsewhere keep working. Switch"
 " the form back to test mode to edit them."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:194
+#: templates/backoffice/assembly_registration.html:227
 #, fuzzy
 msgid "The URL path for this registration form"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:202
+#: templates/backoffice/assembly_registration.html:235
 #, fuzzy
 msgid "Short URL (optional)"
 msgstr "Email cím"
 
-#: templates/backoffice/assembly_registration.html:213
+#: templates/backoffice/assembly_registration.html:246
 msgid ""
 "Paste your HTML form code below. The only required placeholders are {{ "
 "form_action }} for the form's action attribute and {{ csrf_form_element "
 "}} for CSRF protection."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:256
+#: templates/backoffice/assembly_registration.html:289
 #, fuzzy
 msgid "Assets"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:269
+#: templates/backoffice/assembly_registration.html:302
 #: templates/backoffice/service_docs.html:38
 #, fuzzy
 msgid "Images"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:290
+#: templates/backoffice/assembly_registration.html:323
 #, python-format
 msgid "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:297
+#: templates/backoffice/assembly_registration.html:330
 #, fuzzy
 msgid "No images uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:366
+#: templates/backoffice/assembly_registration.html:399
 #: templates/backoffice/service_docs.html:39
 #, fuzzy
 msgid "Documents"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:387
-#: templates/backoffice/assembly_registration.html:1284
+#: templates/backoffice/assembly_registration.html:420
+#: templates/backoffice/assembly_registration.html:1319
 #, python-format
 msgid "PDF files only. Maximum file size: %(max)s MB per document."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:394
+#: templates/backoffice/assembly_registration.html:427
 #, fuzzy
 msgid "No documents uploaded yet."
 msgstr "Feladat állapota"
 
-#: templates/backoffice/assembly_registration.html:475
-#: templates/backoffice/assembly_registration.html:680
+#: templates/backoffice/assembly_registration.html:508
+#: templates/backoffice/assembly_registration.html:713
 msgid "Editing in progress — save or cancel to continue"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:477
-#: templates/backoffice/assembly_registration.html:479
-#: templates/backoffice/assembly_registration.html:533
-#: templates/backoffice/assembly_registration.html:683
-#: templates/backoffice/assembly_registration.html:686
+#: templates/backoffice/assembly_registration.html:510
+#: templates/backoffice/assembly_registration.html:512
+#: templates/backoffice/assembly_registration.html:566
+#: templates/backoffice/assembly_registration.html:716
+#: templates/backoffice/assembly_registration.html:719
 #, fuzzy
 msgid "Next →"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:505
+#: templates/backoffice/assembly_registration.html:538
 #, fuzzy
 msgid "Auto-reply cannot be sent"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:505
+#: templates/backoffice/assembly_registration.html:538
 msgid "Heads up"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:517
+#: templates/backoffice/assembly_registration.html:550
 msgid ""
 "Automatically send a confirmation email to people after they register. "
 "Templates support variables like the respondent's first name and the "
 "assembly title."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:525
+#: templates/backoffice/assembly_registration.html:558
 msgid "Set up auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:532
-#: templates/backoffice/assembly_registration.html:676
-#: templates/backoffice/assembly_registration.html:685
-#: templates/backoffice/assembly_registration.html:796
+#: templates/backoffice/assembly_registration.html:565
+#: templates/backoffice/assembly_registration.html:709
+#: templates/backoffice/assembly_registration.html:718
+#: templates/backoffice/assembly_registration.html:829
 msgid "← Back"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:556
+#: templates/backoffice/assembly_registration.html:589
 msgid "Auto-reply email template"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:566
+#: templates/backoffice/assembly_registration.html:599
 msgid "Send auto-reply email"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:582
+#: templates/backoffice/assembly_registration.html:615
 msgid "Email subject"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:584
+#: templates/backoffice/assembly_registration.html:617
 msgid "Jinja variables allowed, e.g. {{ assembly.title }}."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:591
+#: templates/backoffice/assembly_registration.html:624
 msgid "HTML body"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:593
+#: templates/backoffice/assembly_registration.html:626
 msgid ""
 "Jinja + HTML. A plain-text version is generated automatically for email "
 "clients that need it."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:611
+#: templates/backoffice/assembly_registration.html:644
 #, fuzzy
 msgid "Available variables"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:613
+#: templates/backoffice/assembly_registration.html:646
 msgid ""
 "Click a variable to select it, then copy and paste into the subject or "
 "body. Missing values render as an empty string."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:616
+#: templates/backoffice/assembly_registration.html:649
 #, fuzzy
 msgid "Assembly title"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/assembly_registration.html:617
+#: templates/backoffice/assembly_registration.html:650
 #, fuzzy
 msgid "Assembly question"
 msgstr "A gyűlés fő témája"
 
-#: templates/backoffice/assembly_registration.html:618
+#: templates/backoffice/assembly_registration.html:651
 #, fuzzy
 msgid "First assembly date (ISO)"
 msgstr "Első gyűlés időpontja"
 
-#: templates/backoffice/assembly_registration.html:619
+#: templates/backoffice/assembly_registration.html:652
 #, fuzzy
 msgid "Respondent first name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:620
+#: templates/backoffice/assembly_registration.html:653
 msgid "First name, or 'Friend' as a fallback"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:621
+#: templates/backoffice/assembly_registration.html:654
 #, fuzzy
 msgid "Respondent full name"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/assembly_registration.html:622
+#: templates/backoffice/assembly_registration.html:655
 #, fuzzy
 msgid "Respondent email address"
 msgstr "Email cím hiányzik"
 
-#: templates/backoffice/assembly_registration.html:646
+#: templates/backoffice/assembly_registration.html:679
 msgid "Variable copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:651
+#: templates/backoffice/assembly_registration.html:684
 #, python-format
 msgid "Copy %(label)s variable"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:705
+#: templates/backoffice/assembly_registration.html:738
 msgid "Form preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:707
+#: templates/backoffice/assembly_registration.html:740
 msgid ""
 "This is the last saved version of your registration form, shown exactly "
 "as visitors will see it. You can try the fields and dropdowns, but the "
 "form cannot be submitted from here."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:715
+#: templates/backoffice/assembly_registration.html:748
 #, fuzzy
 msgid "Registration form preview"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:731
+#: templates/backoffice/assembly_registration.html:764
 msgid "Share your form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:736
+#: templates/backoffice/assembly_registration.html:769
 msgid "The URL for your registration form"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:749
+#: templates/backoffice/assembly_registration.html:782
 #, fuzzy
 msgid "QR Code"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:751
+#: templates/backoffice/assembly_registration.html:784
 msgid "Use this QR code on paper invitations"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:758
+#: templates/backoffice/assembly_registration.html:791
 #, fuzzy
 msgid "QR code for registration page"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:776
+#: templates/backoffice/assembly_registration.html:809
 #, fuzzy
 msgid "Download QR Code"
 msgstr "Táblázat lapfülei"
 
-#: templates/backoffice/assembly_registration.html:778
+#: templates/backoffice/assembly_registration.html:811
 msgid "PNG format, 400x400 pixels"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:804
+#: templates/backoffice/assembly_registration.html:837
 msgid "Publish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:813
+#: templates/backoffice/assembly_registration.html:846
 msgid "Unpublish"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:815
-#: templates/backoffice/assembly_registration.html:1552
-#: templates/backoffice/assembly_registration_list.html:135
+#: templates/backoffice/assembly_registration.html:848
+#: templates/backoffice/assembly_registration.html:1587
+#: templates/backoffice/components/registration_page_list.html:113
 #, fuzzy
 msgid "Close registration"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:845
+#: templates/backoffice/assembly_registration.html:880
 #, fuzzy
 msgid "Form Skeleton"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:850
-#: templates/backoffice/assembly_registration.html:971
-#: templates/backoffice/assembly_registration.html:1078
-#: templates/backoffice/assembly_registration.html:1271
-#: templates/backoffice/assembly_registration.html:1373
+#: templates/backoffice/assembly_registration.html:885
+#: templates/backoffice/assembly_registration.html:1006
+#: templates/backoffice/assembly_registration.html:1113
+#: templates/backoffice/assembly_registration.html:1306
+#: templates/backoffice/assembly_registration.html:1408
 #: templates/backoffice/components/db_selection_progress_modal.html:117
 #: templates/backoffice/components/manage_tabs_progress_modal.html:111
 #: templates/backoffice/components/modal.html:106
@@ -5217,14 +5145,14 @@ msgstr "Rétegzett kiválasztás"
 msgid "Close"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/assembly_registration.html:863
+#: templates/backoffice/assembly_registration.html:898
 msgid ""
 "This skeleton is generated from your assembly's field definitions. Copy "
 "all or select specific parts to paste into your form. Then edit to add "
 "extra HTML as required."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:866
+#: templates/backoffice/assembly_registration.html:901
 #, python-format
 msgid ""
 "The Plain HTML version is the minimal version, for you to enhance. The "
@@ -5232,373 +5160,331 @@ msgid ""
 "System%(link_end)s - which has high web accessibility."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:877
+#: templates/backoffice/assembly_registration.html:912
 #, fuzzy
 msgid "Form skeleton style"
 msgstr "Rétegzett kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:882
+#: templates/backoffice/assembly_registration.html:917
 msgid "Plain HTML"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:887
+#: templates/backoffice/assembly_registration.html:922
 msgid "GOV.UK styled"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:902
+#: templates/backoffice/assembly_registration.html:937
 msgid "Form skeleton preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:919
+#: templates/backoffice/assembly_registration.html:954
 msgid "Form skeleton preview (GOV.UK styled)"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:937
+#: templates/backoffice/assembly_registration.html:972
 msgid "Copy All"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:965
+#: templates/backoffice/assembly_registration.html:1000
 #, fuzzy
 msgid "Upload image"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:984
+#: templates/backoffice/assembly_registration.html:1019
 #, python-format
 msgid ""
 "Supported formats: %(formats)s. Maximum file size: %(max)s MB per image. "
 "Files are downscaled and re-encoded to PNG on upload."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:990
+#: templates/backoffice/assembly_registration.html:1025
 msgid "Image file"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1011
-#: templates/backoffice/assembly_registration.html:1202
+#: templates/backoffice/assembly_registration.html:1046
+#: templates/backoffice/assembly_registration.html:1237
 #, fuzzy
 msgid "Alt text"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1024
-#: templates/backoffice/assembly_registration.html:1215
+#: templates/backoffice/assembly_registration.html:1059
+#: templates/backoffice/assembly_registration.html:1250
 msgid ""
 "Describes the image for screen-reader users and is used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1072
+#: templates/backoffice/assembly_registration.html:1107
 #, fuzzy
 msgid "Image details"
 msgstr "Meghívó kód"
 
-#: templates/backoffice/assembly_registration.html:1103
+#: templates/backoffice/assembly_registration.html:1138
 msgid "No preview"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1111
-#: templates/backoffice/assembly_registration.html:1392
+#: templates/backoffice/assembly_registration.html:1146
+#: templates/backoffice/assembly_registration.html:1427
 msgid "Original filename"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1119
+#: templates/backoffice/assembly_registration.html:1154
 #, fuzzy
 msgid "Dimensions"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1124
+#: templates/backoffice/assembly_registration.html:1159
 msgid "px"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1127
-#: templates/backoffice/assembly_registration.html:1400
+#: templates/backoffice/assembly_registration.html:1162
+#: templates/backoffice/assembly_registration.html:1435
 msgid "File size"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1137
-#: templates/backoffice/assembly_registration.html:1409
+#: templates/backoffice/assembly_registration.html:1172
+#: templates/backoffice/assembly_registration.html:1444
 #, fuzzy
 msgid "File name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:1150
-#: templates/backoffice/assembly_registration.html:1422
+#: templates/backoffice/assembly_registration.html:1185
+#: templates/backoffice/assembly_registration.html:1457
 msgid "File name copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1155
-#: templates/backoffice/assembly_registration.html:1427
+#: templates/backoffice/assembly_registration.html:1190
+#: templates/backoffice/assembly_registration.html:1462
 #, fuzzy
 msgid "Copy file name"
 msgstr "Keresztnév"
 
-#: templates/backoffice/assembly_registration.html:1171
+#: templates/backoffice/assembly_registration.html:1206
 #, fuzzy
 msgid "Image snippet"
 msgstr "Jelentések a folyamatról"
 
-#: templates/backoffice/assembly_registration.html:1186
+#: templates/backoffice/assembly_registration.html:1221
 msgid "Copy image snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1233
+#: templates/backoffice/assembly_registration.html:1268
 #, fuzzy
 msgid "Delete image"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1236
+#: templates/backoffice/assembly_registration.html:1271
 #, fuzzy
 msgid "Save alt"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:1265
+#: templates/backoffice/assembly_registration.html:1300
 #, fuzzy
 msgid "Upload document"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1290
+#: templates/backoffice/assembly_registration.html:1325
 #, fuzzy
 msgid "PDF file"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1310
-#: templates/backoffice/assembly_registration.html:1476
+#: templates/backoffice/assembly_registration.html:1345
+#: templates/backoffice/assembly_registration.html:1511
 #: templates/backoffice/patterns/_progress.html:125
 #: templates/backoffice/respondent_field_schema/view.html:132
 #: templates/backoffice/respondent_field_schema/view.html:358
 msgid "Label"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1319
+#: templates/backoffice/assembly_registration.html:1354
 msgid ""
 "Shown to registrants as the download link text and used as the file's "
 "display name in the asset list. Defaults to the file name."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1367
+#: templates/backoffice/assembly_registration.html:1402
 #, fuzzy
 msgid "Document details"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1444
+#: templates/backoffice/assembly_registration.html:1479
 #, fuzzy
 msgid "Download link snippet"
 msgstr "Táblázat lapfülei"
 
-#: templates/backoffice/assembly_registration.html:1460
+#: templates/backoffice/assembly_registration.html:1495
 msgid "Copy download link snippet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1489
+#: templates/backoffice/assembly_registration.html:1524
 msgid ""
 "Shown to registrants as the download link text and used as the file's "
 "display name in the asset list."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1507
+#: templates/backoffice/assembly_registration.html:1542
 #, fuzzy
 msgid "Delete document"
 msgstr "Hozzon létre fiókot"
 
-#: templates/backoffice/assembly_registration.html:1510
+#: templates/backoffice/assembly_registration.html:1545
 #, fuzzy
 msgid "Save label"
 msgstr "Elkezdve"
 
-#: templates/backoffice/assembly_registration.html:1541
+#: templates/backoffice/assembly_registration.html:1576
 #, fuzzy
 msgid "Close registration?"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/assembly_registration.html:1543
+#: templates/backoffice/assembly_registration.html:1578
 msgid ""
 "This permanently stops new registrations. Visitors who follow the form "
 "link will see the 'registration closed' page, and the form cannot be "
 "reopened."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1554
+#: templates/backoffice/assembly_registration.html:1589
 #, fuzzy
 msgid "Keep it open"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1587
+#: templates/backoffice/assembly_registration.html:1622
 #, fuzzy
 msgid "Discard changes?"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1589
+#: templates/backoffice/assembly_registration.html:1624
 msgid ""
 "You have unsaved changes. If you leave this page, your changes will be "
 "lost."
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1592
+#: templates/backoffice/assembly_registration.html:1627
 #, fuzzy
 msgid "Discard changes"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/assembly_registration.html:1593
+#: templates/backoffice/assembly_registration.html:1628
 #, fuzzy
 msgid "Keep editing"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1635
+#: templates/backoffice/assembly_registration.html:1668
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:1636
+#: templates/backoffice/assembly_registration.html:1669
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1637
+#: templates/backoffice/assembly_registration.html:1670
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1638
+#: templates/backoffice/assembly_registration.html:1671
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1639
+#: templates/backoffice/assembly_registration.html:1672
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1640
+#: templates/backoffice/assembly_registration.html:1673
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1642
+#: templates/backoffice/assembly_registration.html:1675
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1643
+#: templates/backoffice/assembly_registration.html:1676
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1644
+#: templates/backoffice/assembly_registration.html:1677
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1645
+#: templates/backoffice/assembly_registration.html:1678
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1646
+#: templates/backoffice/assembly_registration.html:1679
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1647
+#: templates/backoffice/assembly_registration.html:1680
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1648
+#: templates/backoffice/assembly_registration.html:1681
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1649
+#: templates/backoffice/assembly_registration.html:1682
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1650
+#: templates/backoffice/assembly_registration.html:1683
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1652
+#: templates/backoffice/assembly_registration.html:1685
 #, fuzzy
 msgid "Document uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1653
+#: templates/backoffice/assembly_registration.html:1686
 #, fuzzy
 msgid "Network error while uploading the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1654
+#: templates/backoffice/assembly_registration.html:1687
 #, fuzzy
 msgid "Delete this document?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1655
+#: templates/backoffice/assembly_registration.html:1688
 #, fuzzy
 msgid "Failed to delete document"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1656
+#: templates/backoffice/assembly_registration.html:1689
 #, fuzzy
 msgid "Document deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1657
+#: templates/backoffice/assembly_registration.html:1690
 #, fuzzy
 msgid "Network error while deleting the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1658
+#: templates/backoffice/assembly_registration.html:1691
 #, fuzzy
 msgid "Failed to update document"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1659
+#: templates/backoffice/assembly_registration.html:1692
 #, fuzzy
 msgid "Document updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1660
+#: templates/backoffice/assembly_registration.html:1693
 #, fuzzy
 msgid "Network error while updating the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
-
-#: templates/backoffice/assembly_registration_list.html:34
-#, fuzzy
-msgid "Create HTML page"
-msgstr "Vissza a regisztrációhoz"
-
-#: templates/backoffice/assembly_registration_list.html:45
-#, fuzzy
-msgid "Date of publish"
-msgstr "Módosítások mentése"
-
-#: templates/backoffice/assembly_registration_list.html:79
-#, fuzzy
-msgid "Closed"
-msgstr "Menü bezárása"
-
-#: templates/backoffice/assembly_registration_list.html:85
-#, fuzzy
-msgid "Test"
-msgstr "Kezdés dátuma"
-
-#: templates/backoffice/assembly_registration_list.html:110
-#, fuzzy, python-format
-msgid "Actions for %(name)s"
-msgstr "Hiba részletei"
-
-#: templates/backoffice/assembly_registration_list.html:125
-#, fuzzy
-msgid "See assembly details"
-msgstr "Közösségi gyűlés"
-
-#: templates/backoffice/assembly_registration_list.html:141
-#, fuzzy
-msgid "Edit registration"
-msgstr "Vissza a regisztrációhoz"
-
-#: templates/backoffice/assembly_registration_list.html:156
-msgid ""
-"This assembly has no registration pages yet. Create one to start "
-"collecting registrations — you can add more pages later, for example for "
-"language variants or A/B tests."
-msgstr ""
 
 #: templates/backoffice/assembly_respondents.html:14
 #: templates/backoffice/assembly_respondents.html:81
@@ -6190,16 +6076,16 @@ msgstr "Új jelszó"
 msgid "Back to Respondents"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: templates/backoffice/base_page.html:30
+#: templates/backoffice/base_page.html:35
 msgid "Help (knowledge hub)"
 msgstr ""
 
-#: templates/backoffice/base_page.html:34
+#: templates/backoffice/base_page.html:39
 #, fuzzy
 msgid "My account"
 msgstr "Hozzon létre fiókot"
 
-#: templates/backoffice/base_page.html:35
+#: templates/backoffice/base_page.html:40
 msgid "Switch to site admin"
 msgstr ""
 
@@ -6428,6 +6314,13 @@ msgstr ""
 #: templates/backoffice/service_docs.html:24
 msgid "This page allows direct database modifications. Use with caution."
 msgstr ""
+
+#: templates/backoffice/components/assembly_tabs.html:55
+#: templates/backoffice/components/registration_page_list.html:10
+#: templates/backoffice/service_docs.html:32
+#, fuzzy
+msgid "Registration"
+msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/components/assembly_tabs.html:42
 #: templates/backoffice/respondent_field_schema/view.html:9
@@ -6671,6 +6564,48 @@ msgstr "Jelentések a folyamatról"
 #: templates/backoffice/components/pagination.html:55
 #, python-format
 msgid "Showing %(start)s-%(end)s of %(total)s %(items)s"
+msgstr ""
+
+#: templates/backoffice/components/registration_page_list.html:14
+#, fuzzy
+msgid "Create HTML page"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/components/registration_page_list.html:25
+#, fuzzy
+msgid "Date of publish"
+msgstr "Módosítások mentése"
+
+#: templates/backoffice/components/registration_page_list.html:59
+#, fuzzy
+msgid "Closed"
+msgstr "Menü bezárása"
+
+#: templates/backoffice/components/registration_page_list.html:65
+#, fuzzy
+msgid "Test"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/components/registration_page_list.html:90
+#, fuzzy, python-format
+msgid "Actions for %(name)s"
+msgstr "Hiba részletei"
+
+#: templates/backoffice/components/registration_page_list.html:105
+#, fuzzy
+msgid "See assembly details"
+msgstr "Közösségi gyűlés"
+
+#: templates/backoffice/components/registration_page_list.html:119
+#, fuzzy
+msgid "Edit registration"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/components/registration_page_list.html:134
+msgid ""
+"This assembly has no registration pages yet. Create one to start "
+"collecting registrations — you can add more pages later, for example for "
+"language variants or A/B tests."
 msgstr ""
 
 #: templates/backoffice/components/replacement_modal.html:39
@@ -14461,13 +14396,3 @@ msgstr ""
 #~ "Each assembly can have only one "
 #~ "registration page."
 #~ msgstr ""
-
-#~ msgid ""
-#~ "To create your first registration page,"
-#~ " edit an existing one, or add "
-#~ "another (for example a language "
-#~ "variant), go to the"
-#~ msgstr ""
-
-#~ msgid "Registration tab"
-#~ msgstr "Vissza a regisztrációhoz"

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-18 11:10+0200\n"
+"POT-Creation-Date: 2026-08-19 16:56+0200\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -133,6 +133,27 @@ msgstr ""
 #, fuzzy
 msgid "Name deleted"
 msgstr "Kiválasztás"
+
+#: src/opendlp/domain/validators.py:54
+#, fuzzy
+msgid "URL slug cannot be empty"
+msgstr "Utoljára módosítva"
+
+#: src/opendlp/domain/validators.py:56
+#, python-format
+msgid "URL slug cannot be longer than %(max)s characters"
+msgstr ""
+
+#: src/opendlp/domain/validators.py:60
+msgid ""
+"URL slug must be lowercase letters, numbers and hyphens, with no leading "
+"or trailing hyphen"
+msgstr ""
+
+#: src/opendlp/domain/validators.py:63
+#, python-format
+msgid "URL slug '%(value)s' is reserved and cannot be used"
+msgstr ""
 
 #: src/opendlp/domain/value_objects.py:18
 msgid "User - Basic access to assigned assemblies"
@@ -1048,7 +1069,7 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:392
 #: src/opendlp/entrypoints/blueprints/backoffice.py:449
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:247
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:360
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:361
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:82
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:94
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:129
@@ -1088,18 +1109,18 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:383
 #: src/opendlp/entrypoints/blueprints/backoffice.py:440
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:253
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:366
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:535
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:747
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:813
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:837
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:935
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:998
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1026
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1051
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1099
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1129
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1156
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:367
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:538
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:750
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:816
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:840
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:938
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1001
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1029
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1054
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1102
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1132
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1159
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
 #: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:408
@@ -1253,104 +1274,104 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:149
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:184
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:150
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:185
 #, fuzzy, python-format
 msgid "Details for %(name)s"
 msgstr "Hiba részletei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:150
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:151
 #, python-format
 msgid "Copy <img> snippet for %(name)s"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:151
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:186
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:152
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:187
 #, fuzzy, python-format
 msgid "Delete %(name)s"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:185
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:186
 #, python-format
 msgid "Copy download link snippet for %(name)s"
 msgstr ""
 
 #: src/opendlp/entrypoints/blueprints/backoffice_registration.py:259
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:376
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:377
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:351
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:520
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:741
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:352
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:523
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:744
 #, fuzzy
 msgid "That registration page could not be found."
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:388
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:391
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:389
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:392
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:392
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:395
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:395
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:398
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:398
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:401
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:400
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:403
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:401
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:404
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:529
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:744
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:810
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:996
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1024
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1049
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1097
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1127
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1154
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:532
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:747
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:813
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:999
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1027
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1052
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1100
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1130
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1157
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:545
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:548
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:616
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:619
 #, fuzzy
 msgid "Registration auto-reply"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:617
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:620
 msgid "Thanks for registering for {{ assembly.title }}"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:619
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:622
 msgid ""
 "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
 "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
@@ -1359,32 +1380,32 @@ msgid ""
 "<p>Best wishes,<br>The team</p>"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:657
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:660
 msgid "Auto-reply email created. Edit it below and click Save."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:669
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:672
 msgid "There is no auto-reply email to save yet — set one up first."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:683
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:686
 msgid "Auto-reply email saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:702
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:705
 msgid "Unknown action — nothing was changed."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:738
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:741
 msgid "The auto-reply email could not be found."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:756
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:759
 #, fuzzy
 msgid "An error occurred while saving the auto-reply email"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:781
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:784
 #: templates/backoffice/assembly_registration.html:100
 #: templates/backoffice/patterns/_stepper.html:28
 #: templates/backoffice/patterns/_stepper.html:102
@@ -1392,106 +1413,106 @@ msgstr "Hiba történt a gyűlés frissítése közben"
 msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:805
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:808
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:821
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:824
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:835
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:929
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:838
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:932
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:840
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:843
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:939
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:942
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:966
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1069
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:969
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1072
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:972
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1075
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:975
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1078
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:976
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1013
-#: templates/backoffice/assembly_registration.html:1674
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:979
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1016
+#: templates/backoffice/assembly_registration.html:1678
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:994
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1095
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:997
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1098
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1001
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1004
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1020
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1045
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1023
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1048
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1022
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1047
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1125
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1152
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1025
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1050
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1128
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1155
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1029
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1032
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1054
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1057
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1102
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1105
 #, fuzzy
 msgid "An error occurred while uploading the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1116
-#: templates/backoffice/assembly_registration.html:1684
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1119
+#: templates/backoffice/assembly_registration.html:1688
 msgid "Label is required"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1123
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1150
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1126
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1153
 #, fuzzy
 msgid "Document not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1134
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1137
 #, fuzzy
 msgid "An error occurred while updating the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1159
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1162
 #, fuzzy
 msgid "An error occurred while deleting the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -3002,6 +3023,52 @@ msgstr "Bejelentkezés"
 #, fuzzy
 msgid "registration"
 msgstr "Vissza a regisztrációhoz"
+
+#: src/opendlp/service_layer/registration_page_service.py:73
+#, python-format
+msgid "The %(label)s must be at most %(max_bytes)s bytes; got %(size)s"
+msgstr ""
+
+#: src/opendlp/service_layer/registration_page_service.py:171
+msgid "Failed to generate unique short URL slug after multiple attempts"
+msgstr ""
+
+#: src/opendlp/service_layer/registration_page_service.py:226
+#: src/opendlp/service_layer/registration_page_service.py:553
+#, fuzzy
+msgid "The registration page name is required"
+msgstr "Vissza a regisztrációhoz"
+
+#: src/opendlp/service_layer/registration_page_service.py:229
+#: src/opendlp/service_layer/registration_page_service.py:556
+#, python-format
+msgid "This assembly already has a registration page named '%(name)s'"
+msgstr ""
+
+#: src/opendlp/service_layer/registration_page_service.py:400
+msgid ""
+"A registration page that has been published cannot be deleted; close it "
+"instead"
+msgstr ""
+
+#: src/opendlp/service_layer/registration_page_service.py:402
+msgid "This registration page has registrations, so it cannot be deleted"
+msgstr ""
+
+#: src/opendlp/service_layer/registration_page_service.py:482
+#: src/opendlp/service_layer/registration_page_service.py:490
+#, python-format
+msgid "The slug '%(slug)s' is already in use by another registration page"
+msgstr ""
+
+#: src/opendlp/service_layer/registration_page_service.py:588
+msgid "thank-you HTML"
+msgstr ""
+
+#: src/opendlp/service_layer/registration_page_service.py:604
+#, fuzzy
+msgid "form HTML"
+msgstr "Keresztnév"
 
 #: src/opendlp/service_layer/respondent_export_service.py:48
 #, python-format
@@ -4689,17 +4756,14 @@ msgid "No registration page has been created for this assembly."
 msgstr "Vissza a közösségi gyűléshez"
 
 #: templates/backoffice/assembly_details.html:142
+#, python-format
 msgid ""
 "To create your first registration page, edit an existing one, or add "
-"another (for example a language variant), go to the"
+"another (for example a language variant), go to the "
+"%(link_start)sRegistration tab%(link_end)s."
 msgstr ""
 
-#: templates/backoffice/assembly_details.html:145
-#, fuzzy
-msgid "Registration tab"
-msgstr "Vissza a regisztrációhoz"
-
-#: templates/backoffice/assembly_details.html:152
+#: templates/backoffice/assembly_details.html:151
 #: templates/backoffice/edit_assembly.html:8
 #: templates/backoffice/edit_assembly.html:12
 #: templates/main/edit_assembly.html:2 templates/main/edit_assembly.html:23
@@ -4785,6 +4849,14 @@ msgstr "Vissza a közösségi gyűléshez"
 #: templates/main/view_assembly_members.html:61
 msgid "Type to search by email or name..."
 msgstr ""
+
+#: templates/backoffice/assembly_registration.html:16
+#: templates/backoffice/components/assembly_tabs.html:55
+#: templates/backoffice/components/registration_page_list.html:10
+#: templates/backoffice/service_docs.html:32
+#, fuzzy
+msgid "Registration"
+msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_registration.html:55
 #, fuzzy
@@ -5120,7 +5192,7 @@ msgstr ""
 
 #: templates/backoffice/assembly_registration.html:848
 #: templates/backoffice/assembly_registration.html:1587
-#: templates/backoffice/components/registration_page_list.html:113
+#: templates/backoffice/components/registration_page_list.html:115
 #, fuzzy
 msgid "Close registration"
 msgstr "Vissza a regisztrációhoz"
@@ -5370,118 +5442,118 @@ msgstr "Módosítások mentése"
 msgid "Keep editing"
 msgstr "Kieső emberek pótlása új kiválasztással"
 
-#: templates/backoffice/assembly_registration.html:1668
+#: templates/backoffice/assembly_registration.html:1672
 #, fuzzy
 msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: templates/backoffice/assembly_registration.html:1669
+#: templates/backoffice/assembly_registration.html:1673
 #: templates/backoffice/components/url_display.html:37
 msgid "Copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1670
+#: templates/backoffice/assembly_registration.html:1674
 msgid "Failed to copy to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1671
+#: templates/backoffice/assembly_registration.html:1675
 msgid "Snippet copied to clipboard"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1672
+#: templates/backoffice/assembly_registration.html:1676
 msgid "No public URL available yet"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1673
+#: templates/backoffice/assembly_registration.html:1677
 #, fuzzy
 msgid "Upload failed"
 msgstr "Kész"
 
-#: templates/backoffice/assembly_registration.html:1675
+#: templates/backoffice/assembly_registration.html:1679
 #, fuzzy
 msgid "Image uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1676
+#: templates/backoffice/assembly_registration.html:1680
 #, fuzzy
 msgid "Network error while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1677
+#: templates/backoffice/assembly_registration.html:1681
 #, fuzzy
 msgid "Delete this image?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1678
+#: templates/backoffice/assembly_registration.html:1682
 msgid "Failed to delete image"
 msgstr ""
 
-#: templates/backoffice/assembly_registration.html:1679
+#: templates/backoffice/assembly_registration.html:1683
 #, fuzzy
 msgid "Image deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1680
+#: templates/backoffice/assembly_registration.html:1684
 #, fuzzy
 msgid "Network error while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1681
+#: templates/backoffice/assembly_registration.html:1685
 #, fuzzy
 msgid "Failed to update image"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1682
+#: templates/backoffice/assembly_registration.html:1686
 #, fuzzy
 msgid "Image updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1683
+#: templates/backoffice/assembly_registration.html:1687
 #, fuzzy
 msgid "Network error while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1685
+#: templates/backoffice/assembly_registration.html:1689
 #, fuzzy
 msgid "Document uploaded"
 msgstr "Új jelszó"
 
-#: templates/backoffice/assembly_registration.html:1686
+#: templates/backoffice/assembly_registration.html:1690
 #, fuzzy
 msgid "Network error while uploading the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1687
+#: templates/backoffice/assembly_registration.html:1691
 #, fuzzy
 msgid "Delete this document?"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/assembly_registration.html:1688
+#: templates/backoffice/assembly_registration.html:1692
 #, fuzzy
 msgid "Failed to delete document"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1689
+#: templates/backoffice/assembly_registration.html:1693
 #, fuzzy
 msgid "Document deleted"
 msgstr "Kiválasztás"
 
-#: templates/backoffice/assembly_registration.html:1690
+#: templates/backoffice/assembly_registration.html:1694
 #, fuzzy
 msgid "Network error while deleting the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: templates/backoffice/assembly_registration.html:1691
+#: templates/backoffice/assembly_registration.html:1695
 #, fuzzy
 msgid "Failed to update document"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1692
+#: templates/backoffice/assembly_registration.html:1696
 #, fuzzy
 msgid "Document updated"
 msgstr "Utoljára módosítva"
 
-#: templates/backoffice/assembly_registration.html:1693
+#: templates/backoffice/assembly_registration.html:1697
 #, fuzzy
 msgid "Network error while updating the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
@@ -6315,13 +6387,6 @@ msgstr ""
 msgid "This page allows direct database modifications. Use with caution."
 msgstr ""
 
-#: templates/backoffice/components/assembly_tabs.html:55
-#: templates/backoffice/components/registration_page_list.html:10
-#: templates/backoffice/service_docs.html:32
-#, fuzzy
-msgid "Registration"
-msgstr "Vissza a regisztrációhoz"
-
 #: templates/backoffice/components/assembly_tabs.html:42
 #: templates/backoffice/respondent_field_schema/view.html:9
 #: templates/backoffice/service_docs.html:33
@@ -6596,12 +6661,12 @@ msgstr "Hiba részletei"
 msgid "See assembly details"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/components/registration_page_list.html:119
+#: templates/backoffice/components/registration_page_list.html:121
 #, fuzzy
 msgid "Edit registration"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/components/registration_page_list.html:134
+#: templates/backoffice/components/registration_page_list.html:136
 msgid ""
 "This assembly has no registration pages yet. Create one to start "
 "collecting registrations — you can add more pages later, for example for "
@@ -14396,3 +14461,13 @@ msgstr ""
 #~ "Each assembly can have only one "
 #~ "registration page."
 #~ msgstr ""
+
+#~ msgid ""
+#~ "To create your first registration page,"
+#~ " edit an existing one, or add "
+#~ "another (for example a language "
+#~ "variant), go to the"
+#~ msgstr ""
+
+#~ msgid "Registration tab"
+#~ msgstr "Vissza a regisztrációhoz"


### PR DESCRIPTION
## What

Follow-up to #239, implementing the UX designer's feedback: opening a registration page from the list now presents the 3-step editor (page HTML → auto-reply email → preview & publish) as a **near-full-screen modal over the pages list**, replacing the old "Back to registration pages" back-button navigation.

## UX behaviour

- **Same URLs as before.** The editor keeps its `/registration/<slug>?section=…` URL; the modal is presentational. Deep links, browser back/refresh and shared URLs all keep working and open in the modal too.
- **Closing the modal is "back to the list".** The dialog header's X (a real link, so middle-click works) and the Esc key both close the editor, routed through the existing unsaved-changes guard so dirty edits get the discard confirmation first. Backdrop clicks deliberately do **not** close — a stray click during a long editing session must not risk losing work.
- **Publish and Close registration dismiss the modal** and land on the list (success flash shown there). **Unpublish stays** on the preview step, since the user typically unpublishes in order to edit.
- The real list is rendered behind the dimmed backdrop, and it is `inert` — invisible to keyboard and assistive tech, so the dialog is the only interactive surface (no JS focus trap needed).

## Implementation notes

- `base_page.html` gains a generic `page_overlay` block plus `page_takeover` support that marks header/main/footer inert — reusable for any future page-level modal. Flash alerts stay live and lift above the dialog layer (z-55).
- The list markup is extracted into a shared `registration_page_list` macro, used by the list page and as the editor's backdrop.
- New `.dialog-panel--takeover` CSS variant: near-full-screen panel whose body is the scroll container; the window scroll is locked while it is up, and the wizard footers' full-viewport sticky breakout is neutralised inside the panel.
- The `?scroll=` preservation machinery (save + restore legs) now targets the takeover dialog body when present, falling back to the window (`src/js/lib/page-scroller.js`).
- Esc handling lives in the edit-guard slice as `closePageGuarded()`: it yields while any nested dialog (skeleton, asset modals, discard, close-confirm) is open, so Esc closes those first.

## Tests

- New/updated vitest coverage for `closePageGuarded` and the `listUrl` wiring (377 JS tests pass).
- Component tests updated: publish/close now redirect to the list; the JSON data block carries the list URL.
- BDD steps updated for the new UX (close lands on the list; scroll restore asserts the dialog body). All 76 registration BDD browser tests pass.
- Full non-BDD suite: 4274 passed. `just check` (mypy, ruff, deptry, UnitOfWork convention) clean. Hungarian catalog regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)