### PR TITLE
fix: keep CSV settings form in edit mode on validation failure

### DIFF
--- a/backend/src/opendlp/entrypoints/blueprints/db_selection_backoffice.py
+++ b/backend/src/opendlp/entrypoints/blueprints/db_selection_backoffice.py
@@ -14,6 +14,7 @@ from opendlp.entrypoints.decorators import require_assembly_management
 from opendlp.entrypoints.forms import DbSelectionSettingsForm
 from opendlp.entrypoints.scroll_utils import redirect_preserving_scroll
 from opendlp.service_layer.assembly_service import (
+    get_assembly_nav_context,
     get_assembly_with_permissions,
     get_csv_upload_status,
     get_or_create_csv_config,
@@ -22,7 +23,7 @@ from opendlp.service_layer.assembly_service import (
 )
 from opendlp.service_layer.exceptions import InsufficientPermissions, InvalidSelection, NotFoundError
 from opendlp.service_layer.report_translation import translate_run_report_to_html
-from opendlp.service_layer.respondent_service import reset_selection_status
+from opendlp.service_layer.respondent_service import get_respondent_attribute_columns, reset_selection_status
 from opendlp.service_layer.selection_report import (
     SelectionReportError,
     build_selection_report,
@@ -321,23 +322,34 @@ def save_db_settings(assembly_id: uuid.UUID) -> ResponseReturnValue:
     try:
         uow = bootstrap.get_flask_uow()
         with uow:
-            # Get available columns for form validation
-            respondents = uow.respondents.get_by_assembly_id(assembly_id)
-            available_columns: list[str] = []
-            if respondents and respondents[0].attributes:
-                available_columns = sorted(respondents[0].attributes.keys())
+            # Get available columns for form validation (same source as the page's hints)
+            available_columns = get_respondent_attribute_columns(uow, assembly_id)
 
         # Create form with request data for validation
         form = DbSelectionSettingsForm(available_columns=available_columns)
 
         if not form.validate_on_submit():
-            # Re-render the page with validation errors
-            for field_name, errors in form.errors.items():
-                for error in errors:
-                    flash(f"{field_name}: {error}", "error")
-            return redirect_preserving_scroll(
-                url_for("backoffice.view_assembly_data", assembly_id=assembly_id, source="csv")
-            )
+            # Re-render the page in edit mode so errors appear under the fields
+            # and the user's input is preserved (mirrors save_gsheet_config).
+            # Reuse the UnitOfWork for the sequential reads below.
+            with uow:
+                nav = get_assembly_nav_context(uow, current_user.id, assembly_id, "csv")
+                csv_config = get_or_create_csv_config(uow, current_user.id, assembly_id)
+            return render_template(
+                "backoffice/assembly_data.html",
+                assembly=nav.assembly,
+                data_source="csv",
+                data_source_locked=nav.data_source_locked,
+                gsheet=nav.gsheet,
+                targets_enabled=nav.targets_enabled,
+                respondents_enabled=nav.respondents_enabled,
+                selection_enabled=nav.selection_enabled,
+                csv_status=nav.csv_status,
+                csv_settings_form=form,
+                csv_available_columns=available_columns,
+                csv_mode="edit",
+                csv_config=csv_config,
+            ), 200
 
         # Parse comma-separated columns
         check_same_address_cols = (

--- a/backend/tests/component/test_db_selection_backoffice.py
+++ b/backend/tests/component/test_db_selection_backoffice.py
@@ -586,6 +586,46 @@ class TestSaveCsvSettings:
         assert response.status_code == 200
         assert b"Selection settings saved successfully" in response.data
 
+    def test_save_csv_settings_invalid_attribute_rerenders_edit_mode(
+        self, logged_in_admin, assembly_with_csv_config_unconfirmed
+    ):
+        """Invalid attribute names re-render the page in edit mode with the error under the field."""
+        assembly = assembly_with_csv_config_unconfirmed
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly.id}/data/csv/settings",
+            data={
+                "check_same_address": "y",
+                "check_same_address_cols_string": "blabla",
+                "columns_to_keep_string": "Gender",
+            },
+        )
+
+        assert response.status_code == 200
+        assert b"Unrecognised attribute names: blabla" in response.data
+        assert b"Save Settings" in response.data
+        assert b'value="blabla"' in response.data
+        assert b"check_same_address_cols_string:" not in response.data
+
+    def test_save_csv_settings_missing_address_attrs_rerenders_edit_mode(
+        self, logged_in_admin, assembly_with_csv_config_unconfirmed
+    ):
+        """Empty address attributes with check_same_address on re-renders in edit mode with the error."""
+        assembly = assembly_with_csv_config_unconfirmed
+
+        response = logged_in_admin.post(
+            f"/backoffice/assembly/{assembly.id}/data/csv/settings",
+            data={
+                "check_same_address": "y",
+                "check_same_address_cols_string": "",
+                "columns_to_keep_string": "",
+            },
+        )
+
+        assert response.status_code == 200
+        assert b"You must specify address attributes" in response.data
+        assert b"Save Settings" in response.data
+
     def test_save_csv_settings_requires_auth(self, client, assembly_with_csv_config_unconfirmed):
         """Save settings endpoint requires authentication."""
         assembly = assembly_with_csv_config_unconfirmed

--- a/backend/tests/component/test_db_selection_backoffice.py
+++ b/backend/tests/component/test_db_selection_backoffice.py
@@ -587,7 +587,7 @@ class TestSaveCsvSettings:
         assert b"Selection settings saved successfully" in response.data
 
     def test_save_csv_settings_invalid_attribute_rerenders_edit_mode(
-        self, logged_in_admin, assembly_with_csv_config_unconfirmed
+        self, logged_in_admin, assembly_with_csv_config_unconfirmed, fake_store
     ):
         """Invalid attribute names re-render the page in edit mode with the error under the field."""
         assembly = assembly_with_csv_config_unconfirmed
@@ -606,6 +606,12 @@ class TestSaveCsvSettings:
         assert b"Save Settings" in response.data
         assert b'value="blabla"' in response.data
         assert b"check_same_address_cols_string:" not in response.data
+        # Nothing was saved: settings unchanged and config still unconfirmed
+        with FakeUnitOfWork(store=fake_store) as uow:
+            stored = uow.assemblies.get(assembly.id)
+            assert stored.csv.settings_confirmed is False
+            assert stored.selection_settings.check_same_address is False
+            assert stored.selection_settings.check_same_address_cols == []
 
     def test_save_csv_settings_missing_address_attrs_rerenders_edit_mode(
         self, logged_in_admin, assembly_with_csv_config_unconfirmed


### PR DESCRIPTION
## Problem

On the backoffice assembly data page (`/backoffice/assembly/<id>/data?source=csv&mode=edit`), submitting the Selection Settings form with an invalid value — e.g. an unrecognised attribute name like `blabla` in **Address Attributes** — flashed a raw `check_same_address_cols_string: <error>` message and redirected back to the page **in read mode**, discarding the user's input and the field-level errors.

## Fix

On validation failure, `save_db_settings` now re-renders `assembly_data.html` directly with the bound form instead of flash + redirect, mirroring the existing pattern in `save_gsheet_config`:

- validation errors appear under the offending fields,
- the submitted values are preserved,
- the form stays in **edit mode**.

The route also now uses `get_respondent_attribute_columns` for validation (the same service the GET view uses for the "Available respondent attributes" hint), instead of reading only the first respondent's attributes — so validation checks against exactly the attribute list the page displays.

## Tests

Two new component tests in `tests/component/test_db_selection_backoffice.py`:

- unrecognised attribute name → 200 re-render with the error under the field, input preserved, still in edit mode;
- empty address attributes with **Check Same Address** enabled → 200 re-render with the cross-field error.

All 45 component + e2e tests for this blueprint pass; mypy and lint are clean. Also verified manually in the browser.

## Note

As with the gsheet form (same pattern), after a validation failure the browser URL is the POST endpoint, so a manual refresh re-submits the form. Switching both forms to a redirect-based error flow would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)