### PR TITLE
feat: show page URLs and add delete to the registration pages list

### DIFF
--- a/backend/docs/agent/830-multiple-reg-pages/frontend-plan.md
+++ b/backend/docs/agent/830-multiple-reg-pages/frontend-plan.md
@@ -70,9 +70,10 @@ Implementation notes:
 
 `GET /assembly/<id>/registration` renders the Figma table:
 
-- **Columns:** Name (+ language chip when set) · Status chip (existing status
-  chip styling: TEST amber / PUBLISHED green / CLOSED red) · Date of publish ·
-  kebab menu.
+- **Columns:** Name (+ language chip when set) · Links (full and short URL, each
+  with a copy button) · QR code (thumbnail of the short URL's code, downloading
+  the full-size PNG) · Status chip (existing status chip styling: TEST amber /
+  PUBLISHED green / CLOSED red) · Date of publish · kebab menu.
 - **Date of publish** = timestamp of the page's most recent PUBLISH activity
   entry (`page.activity`), blank for never-published pages. Format with the
   babel date filter (no `.strftime` in templates).
@@ -82,11 +83,15 @@ Implementation notes:
   - *Close registration* → POST to the page's close action; only shown for
     PUBLISHED pages (lifecycle: TEST ⇄ PUBLISHED ⇄ CLOSED, no CLOSED → TEST).
   - *Edit registration* → the page's editor URL.
+  - *Delete registration page* → arms a confirmation dialog that POSTs to
+    `.../registration/<slug>/delete`; only shown where the delete would be
+    allowed (see §6).
 - Row click (name cell) also opens the editor.
-- **Create HTML page** button → existing `POST .../registration/create`,
+- **Create registration page** button → existing `POST .../registration/create`,
   which must now (a) stop rejecting a second page, and (b) generate a unique
   default name ("Registration page", "Registration page 2", …). It redirects
-  to the new page's editor where the name can be changed.
+  to the new page's editor where the name can be changed. Once the assembly has
+  a page the label reads "Create another registration page".
 - Empty state: the table shows a single explanatory row + the create button
   (replaces the old details-tab create CTA).
 
@@ -123,10 +128,13 @@ Implementation notes:
 
 ## 6. Out of scope / open questions
 
-- **Duplicate / Delete rows:** the services exist
-  (`duplicate_registration_page`, `delete_registration_page`) but the Figma
-  menu doesn't include them. Not built in this pass; they slot naturally into
-  the same kebab menu once designed.
+- **Duplicate rows:** the service exists (`duplicate_registration_page`) but the
+  Figma menu doesn't include it. Not built; it slots naturally into the same
+  kebab menu once designed.
+- **Delete rows:** built after review feedback. The kebab offers *Delete
+  registration page* only for pages `delete_registration_page` would accept —
+  never published, no registrations — behind a confirmation dialog. It is a hard
+  delete: no archive, no soft delete, no undelete.
 - Bulk "close all pages" — service exists, no design; deferred.
 - Navigation redesign visible in Figma — explicitly untouched.
 

--- a/backend/features/backoffice-registration-editor.feature
+++ b/backend/features/backoffice-registration-editor.feature
@@ -108,3 +108,16 @@ Feature: Backoffice registration HTML editor
     Then I should see the registration page list
     When I open the first registration page from the list
     Then I should be on the read-only registration form view
+
+  Scenario: Deleting a registration page from the list asks for confirmation first
+    Given I am logged in as an admin user
+    And there is an assembly called "Delete Page Assembly" with a registration page
+    When I visit the registration tab for "Delete Page Assembly"
+    And I choose to delete the first registration page
+    Then I should see the delete registration page confirmation
+    When I choose to keep the registration page
+    Then the delete registration page confirmation should be closed
+    And the assembly "Delete Page Assembly" should still have a registration page
+    When I choose to delete the first registration page
+    And I confirm deleting the registration page
+    Then the assembly "Delete Page Assembly" should have no registration pages

--- a/backend/src/js/backoffice/alpine-components.js
+++ b/backend/src/js/backoffice/alpine-components.js
@@ -4,6 +4,7 @@
 import { autocomplete } from "../components/autocomplete.js";
 import { autoDismissAlert } from "../components/auto-dismiss-alert.js";
 import { modal } from "../components/modal.js";
+import { registrationPageRow } from "../components/registration-page-row.js";
 import {
   buttonLoadingDemo,
   progressModalDemo,
@@ -26,6 +27,7 @@ document.addEventListener("alpine:init", function () {
   Alpine.data("buttonLoadingDemo", buttonLoadingDemo);
   Alpine.data("modal", modal);
   Alpine.data("progressModalDemo", progressModalDemo);
+  Alpine.data("registrationPageRow", registrationPageRow);
   Alpine.data("showcaseNav", showcaseNav);
   Alpine.data("tabsKeyboard", tabsKeyboard);
   Alpine.data("urlSelect", urlSelect);

--- a/backend/src/js/components/registration-page-row.js
+++ b/backend/src/js/components/registration-page-row.js
@@ -1,0 +1,44 @@
+// ABOUTME: Alpine component for one row of the backoffice registration pages list
+// ABOUTME: Owns the row's actions menu and the delete confirmation that guards it
+
+/**
+ * Build the state for one registration page row.
+ *
+ * Deleting a page is permanent - there is no archive and no undo - so the menu
+ * item only arms a confirmation dialog. Opening it dismisses the menu (the two
+ * surfaces would otherwise overlap) and moves focus to the safe "Keep it"
+ * action; cancelling hands focus back to the kebab the user came from.
+ *
+ * @returns {Object} Alpine component state
+ */
+export function registrationPageRow() {
+  return {
+    open: false,
+    confirmDeleteOpen: false,
+
+    toggleMenu: function () {
+      this.open = !this.open;
+    },
+
+    closeMenu: function () {
+      this.open = false;
+    },
+
+    openConfirmDelete: function () {
+      var self = this;
+      self.open = false;
+      self.confirmDeleteOpen = true;
+      self.$nextTick(function () {
+        if (self.$refs.keepPageBtn) self.$refs.keepPageBtn.focus();
+      });
+    },
+
+    cancelConfirmDelete: function () {
+      var self = this;
+      self.confirmDeleteOpen = false;
+      self.$nextTick(function () {
+        if (self.$refs.menuToggle) self.$refs.menuToggle.focus();
+      });
+    },
+  };
+}

--- a/backend/src/js/components/registration-page-row.test.js
+++ b/backend/src/js/components/registration-page-row.test.js
@@ -1,0 +1,84 @@
+// ABOUTME: Unit tests for the registrationPageRow Alpine component
+// ABOUTME: Covers the actions menu toggle and the delete confirmation's focus handling
+
+import { describe, expect, it, vi } from "vitest";
+
+import { registrationPageRow } from "./registration-page-row.js";
+
+function buildRow() {
+  const state = registrationPageRow();
+  state.$refs = {
+    menuToggle: { focus: vi.fn() },
+    keepPageBtn: { focus: vi.fn() },
+  };
+  state.$nextTick = (fn) => fn();
+  return state;
+}
+
+describe("registrationPageRow menu", () => {
+  it("starts with the menu and the confirmation closed", () => {
+    const state = buildRow();
+
+    expect(state.open).toBe(false);
+    expect(state.confirmDeleteOpen).toBe(false);
+  });
+
+  it("toggles the menu open and shut", () => {
+    const state = buildRow();
+
+    state.toggleMenu();
+    expect(state.open).toBe(true);
+
+    state.toggleMenu();
+    expect(state.open).toBe(false);
+  });
+
+  it("closes the menu on demand", () => {
+    const state = buildRow();
+    state.open = true;
+
+    state.closeMenu();
+
+    expect(state.open).toBe(false);
+  });
+});
+
+describe("registrationPageRow delete confirmation", () => {
+  it("dismisses the menu and opens the dialog", () => {
+    const state = buildRow();
+    state.open = true;
+
+    state.openConfirmDelete();
+
+    expect(state.open).toBe(false);
+    expect(state.confirmDeleteOpen).toBe(true);
+  });
+
+  it("focuses the safe action when the dialog opens", () => {
+    const state = buildRow();
+
+    state.openConfirmDelete();
+
+    expect(state.$refs.keepPageBtn.focus).toHaveBeenCalled();
+  });
+
+  it("closes the dialog and returns focus to the menu button on cancel", () => {
+    const state = buildRow();
+    state.openConfirmDelete();
+
+    state.cancelConfirmDelete();
+
+    expect(state.confirmDeleteOpen).toBe(false);
+    expect(state.$refs.menuToggle.focus).toHaveBeenCalled();
+  });
+
+  it("survives a missing ref rather than throwing", () => {
+    const state = buildRow();
+    state.$refs = {};
+
+    state.openConfirmDelete();
+    state.cancelConfirmDelete();
+
+    expect(state.confirmDeleteOpen).toBe(false);
+  });
+});

--- a/backend/src/opendlp/domain/registration_page.py
+++ b/backend/src/opendlp/domain/registration_page.py
@@ -214,10 +214,13 @@ class RegistrationPage:
 
         Once a page has been published its slug has been in the world - on
         invites, QR codes and printed materials - so the row must survive to keep
-        those URLs resolving. Callers must additionally check that no respondent
-        registered through the page; that needs repository access.
+        those URLs resolving. Status is checked as well as the activity log: a
+        page that arrived at PUBLISHED or CLOSED without an activity entry (an
+        import, say) is just as public as one that got there through publish().
+        Callers must additionally check that no respondent registered through the
+        page; that needs repository access.
         """
-        return not self.has_ever_been_published()
+        return self.status == RegistrationPageStatus.TEST and not self.has_ever_been_published()
 
     def rename(self, name: str) -> None:
         self.name = name.strip()

--- a/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
+++ b/backend/src/opendlp/entrypoints/blueprints/backoffice_registration.py
@@ -75,6 +75,8 @@ from opendlp.service_layer.registration_image_service import (
 from opendlp.service_layer.registration_page_service import (
     close_registration_page,
     create_registration_page_with_slugs,
+    deletable_registration_page_ids,
+    delete_registration_page,
     generate_starter_form_html_variants,
     get_registration_page_by_slug,
     get_registration_page_with_source,
@@ -188,25 +190,51 @@ def _document_to_dict(document: RegistrationDocument, url_slug: str) -> dict[str
     }
 
 
-def _page_rows(pages: list[RegistrationPage], assembly_id: uuid.UUID) -> list[dict[str, Any]]:
+def _page_row(page: RegistrationPage, assembly_id: uuid.UUID, deletable_ids: set[uuid.UUID]) -> dict[str, Any]:
+    """One row of the registration pages list.
+
+    A page created outside the backoffice can lack a slug; it has no public URL
+    and cannot be opened here until one is set, so it renders without links. The
+    QR code encodes the short URL, matching the editor's sharing panel, so it
+    only exists once a short slug does.
+    """
+    page_short_url = short_url(page.short_url_slug) if page.short_url_slug else ""
+    return {
+        "page": page,
+        "editor_url": _editor_url(assembly_id, page.url_slug) if page.url_slug else "",
+        "close_url": url_for(
+            "backoffice_registration.save_assembly_registration",
+            assembly_id=assembly_id,
+            url_slug=page.url_slug,
+        )
+        if page.url_slug and page.status == RegistrationPageStatus.PUBLISHED
+        else "",
+        "delete_url": url_for(
+            "backoffice_registration.delete_assembly_registration_page",
+            assembly_id=assembly_id,
+            url_slug=page.url_slug,
+        )
+        if page.url_slug and page.id in deletable_ids
+        else "",
+        "registration_url": registration_url(page.url_slug) if page.url_slug else "",
+        "short_url": page_short_url,
+        "qr_code_data_url": generate_qr_code_base64(page_short_url) if page_short_url else "",
+        "qr_code_url": url_for(
+            "backoffice_registration.download_registration_qr_code",
+            assembly_id=assembly_id,
+            url_slug=page.url_slug,
+        )
+        if page_short_url and page.url_slug
+        else "",
+        "published_at": page.last_published_at(),
+    }
+
+
+def _page_rows(
+    pages: list[RegistrationPage], assembly_id: uuid.UUID, deletable_ids: set[uuid.UUID]
+) -> list[dict[str, Any]]:
     """Rows for the registration pages list — also rendered behind the editor's modal."""
-    return [
-        {
-            "page": page,
-            # A page created outside the backoffice can lack a slug; it cannot be
-            # opened here until one is set, so it renders without links.
-            "editor_url": _editor_url(assembly_id, page.url_slug) if page.url_slug else "",
-            "close_url": url_for(
-                "backoffice_registration.save_assembly_registration",
-                assembly_id=assembly_id,
-                url_slug=page.url_slug,
-            )
-            if page.url_slug and page.status == RegistrationPageStatus.PUBLISHED
-            else "",
-            "published_at": page.last_published_at(),
-        }
-        for page in pages
-    ]
+    return [_page_row(page, assembly_id, deletable_ids) for page in pages]
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration")
@@ -225,7 +253,8 @@ def view_assembly_registration(assembly_id: uuid.UUID) -> ResponseReturnValue:
                 request.args.get("source", ""),
             )
             pages = list_registration_pages(uow, current_user.id, assembly_id)
-        page_rows = _page_rows(pages, assembly_id)
+            deletable_ids = deletable_registration_page_ids(uow, current_user.id, assembly_id)
+        page_rows = _page_rows(pages, assembly_id, deletable_ids)
 
         return render_template(
             "backoffice/assembly_registration_list.html",
@@ -306,7 +335,8 @@ def view_registration_page(assembly_id: uuid.UUID, url_slug: str) -> ResponseRet
             # The editor renders as a modal over the pages list, so the list rows are
             # needed here too — they form the (inert) backdrop behind the dialog.
             all_pages = list_registration_pages(uow, current_user.id, assembly_id)
-        page_rows = _page_rows(all_pages, assembly_id)
+            deletable_ids = deletable_registration_page_ids(uow, current_user.id, assembly_id)
+        page_rows = _page_rows(all_pages, assembly_id, deletable_ids)
 
         # The HTML editor is read-only by default; ?edit=1 unlocks it. CLOSED pages
         # have no save path so we always keep them read-only regardless of the param.
@@ -823,6 +853,55 @@ def create_assembly_registration_page(assembly_id: uuid.UUID) -> ResponseReturnV
         logger.exception("Error creating registration page for assembly", assembly_id=str(assembly_id), error=str(e))
         flash(_("An error occurred while creating the registration page"), "error")
         return redirect(_list_url(assembly_id))
+
+
+@backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/<url_slug>/delete", methods=["POST"])
+@login_required
+def delete_assembly_registration_page(assembly_id: uuid.UUID, url_slug: str) -> ResponseReturnValue:
+    """Delete a registration page outright — no archive, no undo.
+
+    The service refuses a page that has been published or that has collected
+    registrations, so the list only offers this where it will succeed; a refusal
+    reaching here (a page published in another tab, say) becomes a flash and
+    lands back on the list with the page intact.
+    """
+    try:
+        uow = bootstrap.get_flask_uow()
+        with uow:
+            page = _page_by_slug(uow, assembly_id, url_slug)
+            page_name = page.name
+            delete_registration_page(uow, current_user.id, page.id)
+        flash(_("Registration page '%(name)s' deleted", name=page_name), "success")
+    except RegistrationPageNotFoundError:
+        flash(_("That registration page could not be found."), "warning")
+    except InsufficientPermissions as e:
+        logger.warning(
+            "Insufficient permissions for assembly",
+            assembly_id=str(assembly_id),
+            user_id=str(current_user.id),
+            error=str(e),
+        )
+        flash(_("You don't have permission to modify this assembly"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+    except NotFoundError as e:
+        logger.warning(
+            "Assembly not found for user", assembly_id=str(assembly_id), user_id=str(current_user.id), error=str(e)
+        )
+        flash(_("Assembly not found"), "error")
+        return redirect(url_for("backoffice.dashboard"))
+    except ValueError as e:
+        # The service's refusals are written for an organiser to read.
+        logger.warning("Cannot delete registration page", assembly_id=str(assembly_id), error=str(e))
+        flash(str(e), "error")
+    except Exception as e:
+        logger.exception(
+            "Delete registration page error",
+            assembly_id=str(assembly_id),
+            user_id=str(current_user.id),
+            error=str(e),
+        )
+        flash(_("An error occurred while deleting the registration page"), "error")
+    return redirect(_list_url(assembly_id))
 
 
 @backoffice_registration_bp.route("/assembly/<uuid:assembly_id>/registration/skeleton")

--- a/backend/src/opendlp/service_layer/registration_page_service.py
+++ b/backend/src/opendlp/service_layer/registration_page_service.py
@@ -386,20 +386,55 @@ def _copy_auto_reply_template(uow: AbstractUnitOfWork, source: RegistrationPage,
     return copy.id
 
 
-def delete_registration_page(uow: AbstractUnitOfWork, user_id: uuid.UUID, page_id: uuid.UUID) -> None:
-    """Delete a page that was never published and has no registrations.
+def _delete_blocker(page: RegistrationPage, registration_count: int) -> str:
+    """Why this page may not be deleted, or the empty string when it may.
 
     A published page keeps its row so the slugs on invites and QR codes still
     resolve; close it instead. A page in TEST can still have collected test
     submissions, which are equally worth keeping the row for.
+    """
+    if not page.can_be_deleted():
+        return _("A registration page that has been published cannot be deleted; close it instead")
+    if registration_count:
+        return _("This registration page has registrations, so it cannot be deleted")
+    return ""
+
+
+def deletable_registration_page_ids(
+    uow: AbstractUnitOfWork, user_id: uuid.UUID, assembly_id: uuid.UUID
+) -> set[uuid.UUID]:
+    """The assembly's pages that ``delete_registration_page`` would accept.
+
+    Lets the list view offer delete only where it would succeed. A user who may
+    view the assembly but not manage it gets the empty set rather than an error,
+    so the list still renders for them - without a destructive action they
+    cannot perform.
+
+    The caller is expected to manage the `uow` context (`with uow: ...`).
+    """
+    user, assembly = _load_user_and_assembly(uow, user_id, assembly_id)
+    if not can_manage_assembly(user, assembly):
+        return set()
+    counts = uow.respondents.count_by_registration_page(assembly_id)
+    return {
+        page.id
+        for page in uow.registration_pages.list_by_assembly_id(assembly_id)
+        if not _delete_blocker(page, counts.get(page.id, 0))
+    }
+
+
+def delete_registration_page(uow: AbstractUnitOfWork, user_id: uuid.UUID, page_id: uuid.UUID) -> None:
+    """Delete a page that was never published and has no registrations.
+
+    The page and its HTML source go for good - there is no archive and no undo.
+    See ``_delete_blocker`` for the two cases this refuses.
 
     The caller is expected to manage the `uow` context (`with uow: ...`).
     """
     _user, page = _load_manageable_page(uow, user_id, page_id)
-    if not page.can_be_deleted():
-        raise ValueError(_("A registration page that has been published cannot be deleted; close it instead"))
-    if uow.respondents.count_by_registration_page(page.assembly_id).get(page.id):
-        raise ValueError(_("This registration page has registrations, so it cannot be deleted"))
+    blocker = _delete_blocker(page, uow.respondents.count_by_registration_page(page.assembly_id).get(page.id, 0))
+    if blocker:
+        raise ValueError(blocker)
 
     source = uow.registration_page_html_sources.get_by_page_id(page.id)
     if source is not None:

--- a/backend/static/backoffice/src/main.css
+++ b/backend/static/backoffice/src/main.css
@@ -374,6 +374,11 @@
         background-color: var(--color-button-tertiary-bg-hover);
     }
 
+    /* Destructive menu item — marks an action that cannot be undone. */
+    .menu-item--danger {
+        color: var(--color-error-600);
+    }
+
     /* Icon wrapper inside buttons — used by leading_icon/trailing_icon/icon
        slots on the button macro. Not to be confused with .btn--icon (variant). */
     .btn-icon {

--- a/backend/templates/backoffice/components/registration_page_list.html
+++ b/backend/templates/backoffice/components/registration_page_list.html
@@ -3,15 +3,22 @@ ABOUTME: The registration pages list — heading + create CTA + one row per page
 ABOUTME: Rendered by the list page, and again behind the editor's takeover modal
 #}
 {% from "backoffice/components/button.html" import button %}
+{% from "backoffice/components/url_display.html" import compact_url_display %}
 {% macro registration_page_list(assembly, page_rows) %}
     <div>
-        {# Header row: section title + create CTA, per the Figma list view #}
+        {# Header row: section title + create CTA, per the Figma list view. The CTA
+           names what it makes; once the assembly has a page, "another" says that
+           this adds to them rather than replacing what is there. #}
         <div class="flex items-center justify-between mb-6">
             <h2 class="text-heading-lg" style="color: var(--color-headings);">{{ _("Registration") }}</h2>
             <form method="post"
                   action="{{ url_for('backoffice_registration.create_assembly_registration_page', assembly_id=assembly.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                {{ button(_("Create HTML page"), type="submit", variant="primary") }}
+                {% if page_rows %}
+                    {{ button(_("Create another registration page"), type="submit", variant="primary") }}
+                {% else %}
+                    {{ button(_("Create registration page"), type="submit", variant="primary") }}
+                {% endif %}
             </form>
         </div>
 
@@ -21,6 +28,8 @@ ABOUTME: Rendered by the list page, and again behind the editor's takeover modal
                     <thead>
                         <tr style="background-color: var(--color-subtle-background-panels);">
                             <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Name") }}</th>
+                            <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Links") }}</th>
+                            <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("QR code") }}</th>
                             <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Status") }}</th>
                             <th scope="col" class="px-3 py-2 text-left text-label-md" style="color: var(--color-headings);">{{ _("Date of publish") }}</th>
                             <th scope="col" class="px-3 py-2 text-right">
@@ -45,6 +54,41 @@ ABOUTME: Rendered by the list page, and again behind the editor's takeover modal
                                               style="background-color: var(--color-subtle-background-panels); color: var(--color-secondary-text); border: 1px solid var(--color-borders-dividers);">{{ page.language }}</span>
                                     {% endif %}
                                 </td>
+                                {# The public URLs, so a page can be shared without opening its editor.
+                                   A page with no slug has no public URL at all (see _page_row). #}
+                                <td class="px-3 py-3">
+                                    {% if row.registration_url %}
+                                        <div class="flex flex-col gap-1.5">
+                                            {{ compact_url_display(_("Full URL"),
+                                            row.registration_url,
+                                            _('Copy the full URL for %(name)s', name=page.name)) }}
+                                            {% if row.short_url %}
+                                                {{ compact_url_display(_("Short URL"),
+                                                row.short_url,
+                                                _('Copy the short URL for %(name)s', name=page.name)) }}
+                                            {% endif %}
+                                        </div>
+                                    {% else %}
+                                        <span style="color: var(--color-secondary-text);">{{ _("No URL yet") }}</span>
+                                    {% endif %}
+                                </td>
+                                {# QR code encodes the short URL, as it does in the editor's sharing
+                                   panel. The thumbnail downloads the full-size PNG. #}
+                                <td class="px-3 py-3">
+                                    {% if row.qr_code_data_url %}
+                                        <a href="{{ row.qr_code_url }}"
+                                           download
+                                           class="inline-block p-1 rounded"
+                                           style="background-color: white; border: 1px solid var(--color-borders-dividers);"
+                                           aria-label="{{ _('Download the QR code for %(name)s', name=page.name) }}">
+                                            <img src="{{ row.qr_code_data_url }}"
+                                                 alt="{{ _('QR code for %(name)s', name=page.name) }}"
+                                                 class="w-16 h-16" />
+                                        </a>
+                                    {% else %}
+                                        <span style="color: var(--color-secondary-text);">—</span>
+                                    {% endif %}
+                                </td>
                                 <td class="px-3 py-3">
                                     {% if page.status.value == "PUBLISHED" %}
                                         <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-body-sm"
@@ -66,7 +110,9 @@ ABOUTME: Rendered by the list page, and again behind the editor's takeover modal
                                         </span>
                                     {% endif %}
                                 </td>
-                                <td class="px-3 py-3" style="color: var(--color-body-text);">
+                                <td class="px-3 py-3"
+                                    data-cell="published-at"
+                                    style="color: var(--color-body-text);">
                                     {% if row.published_at %}
                                         {{ row.published_at | dateformat }}
                                     {% else %}
@@ -75,15 +121,18 @@ ABOUTME: Rendered by the list page, and again behind the editor's takeover modal
                                 </td>
                                 <td class="px-3 py-3 text-right">
                                     {# Per-row actions menu (kebab), mirroring the dropdown_button component's
-                                       open/close and ARIA behaviour but mixing link and submit items #}
+                                       open/close and ARIA behaviour but mixing link and submit items. The row
+                                       component also owns the delete confirmation, which shares this menu's
+                                       state so the two surfaces never overlap. #}
                                     <div class="relative inline-flex"
-                                         x-data="{ open: false }"
-                                         @keydown.escape.window="open = false">
+                                         x-data="registrationPageRow"
+                                         @keydown.escape.window="closeMenu()">
                                         <button type="button"
                                                 id="page-actions-{{ loop.index }}-toggle"
+                                                x-ref="menuToggle"
                                                 class="p-2 rounded hover:bg-black/5"
-                                                @click="open = !open"
-                                                @click.outside="open = false"
+                                                @click="toggleMenu()"
+                                                @click.outside="closeMenu()"
                                                 aria-haspopup="menu"
                                                 x-bind:aria-expanded="open ? 'true' : 'false'"
                                                 aria-controls="page-actions-{{ loop.index }}-menu"
@@ -121,7 +170,52 @@ ABOUTME: Rendered by the list page, and again behind the editor's takeover modal
                                                     {{ _("Edit registration") }}
                                                 </a>
                                             {% endif %}
+                                            {# Delete is offered only where the service would allow it: a page
+                                               that has never been published and has no registrations. #}
+                                            {% if row.delete_url %}
+                                                <button type="button"
+                                                        role="menuitem"
+                                                        class="menu-item menu-item--danger w-full text-left"
+                                                        @click="openConfirmDelete()">
+                                                    {{ _("Delete registration page") }}
+                                                </button>
+                                            {% endif %}
                                         </div>
+                                        {# Delete confirmation — deleting is permanent, so a stray click on the
+                                           menu item must not be enough. Same single-surface dialog style as the
+                                           editor's close confirmation: the safe action is the primary on the
+                                           right and takes initial focus; the destructive one is a red button. #}
+                                        {% if row.delete_url %}
+                                            <div x-show="confirmDeleteOpen" x-cloak>
+                                                <div class="fixed inset-0 z-40"
+                                                     style="background-color: rgba(0, 0, 0, 0.5)"
+                                                     @click="cancelConfirmDelete()"
+                                                     @keydown.escape.window="cancelConfirmDelete()"></div>
+                                                <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+                                                     role="dialog"
+                                                     aria-modal="true"
+                                                     aria-labelledby="delete-page-{{ loop.index }}-title">
+                                                    <div class="pointer-events-auto w-full max-w-md mx-4 rounded-lg shadow-xl overflow-hidden px-6 py-5 text-left"
+                                                         style="background-color: var(--color-tables-cards);
+                                                                border: 1px solid var(--color-borders-dividers)"
+                                                         @click.stop>
+                                                        <h2 id="delete-page-{{ loop.index }}-title"
+                                                            class="text-heading-lg mb-2"
+                                                            style="color: var(--color-headings)">{{ _("Delete this registration page?") }}</h2>
+                                                        <p class="text-body-md mb-5" style="color: var(--color-body-text);">
+                                                            {{ _("'%(name)s' and the form you built on it will be deleted for good. There is no undo, and the URLs above will stop working.", name=page.name) }}
+                                                        </p>
+                                                        <div class="flex gap-2 justify-end items-center">
+                                                            <form method="post" action="{{ row.delete_url }}">
+                                                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                                                                {{ button(_("Delete page"), type="submit", variant="danger") }}
+                                                            </form>
+                                                            {{ button(_("Keep it"), variant="primary", attrs='type="button" x-ref="keepPageBtn" @click="cancelConfirmDelete()"') }}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        {% endif %}
                                     </div>
                                 </td>
                             </tr>

--- a/backend/templates/backoffice/components/url_display.html
+++ b/backend/templates/backoffice/components/url_display.html
@@ -1,7 +1,37 @@
 {#
-ABOUTME: Read-only URL display component with clickable link and copy button
-ABOUTME: Used across registration page details and registration tab modal
+ABOUTME: Read-only URL display components with clickable link and copy button
+ABOUTME: Used across registration page details, the registration tab modal and the pages list
 #}
+
+{#
+Component: Copy-to-clipboard button
+The clipboard wiring is a delegated document listener (see src/js/init/document-actions.js),
+so the button works anywhere in the page without per-instance JavaScript.
+
+Args:
+    text: The text placed on the clipboard
+    label: Accessible name, also the tooltip before copying
+    classes: Extra classes on the button (defaults to the roomy panel sizing)
+#}
+{% macro copy_button(text, label, classes="flex-shrink-0 p-2 rounded transition-colors duration-150 hover:opacity-70") %}
+    <button type="button"
+            class="{{ classes }}"
+            style="color: var(--color-secondary-text);"
+            data-copy-text="{{ text }}"
+            data-copy-feedback="inline"
+            data-copy-label="{{ label }}"
+            data-copied-label="{{ _('Copied to clipboard') }}"
+            aria-label="{{ label }}">
+        {# Copy icon (when not copied) #}
+        <svg class="copy-icon-default h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+        {# Checkmark icon (when copied) #}
+        <svg class="copy-icon-copied hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" style="color: var(--color-success-text);">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+    </button>
+{% endmacro %}
 
 {#
 Component: Read-only URL Display
@@ -28,23 +58,33 @@ Args:
                style="color: var(--color-link-text);">
                 {{ url }}
             </a>
-            <button type="button"
-                    class="flex-shrink-0 p-2 rounded transition-colors duration-150 hover:opacity-70"
-                    style="color: var(--color-secondary-text);"
-                    data-copy-text="{{ url }}"
-                    data-copy-feedback="inline"
-                    data-copy-label="{{ _('Copy URL to clipboard') }}"
-                    data-copied-label="{{ _('Copied to clipboard') }}"
-                    aria-label="{{ _('Copy URL to clipboard') }}">
-                {# Copy icon (when not copied) #}
-                <svg class="copy-icon-default h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-                {# Checkmark icon (when copied) #}
-                <svg class="copy-icon-copied hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" style="color: var(--color-success-text);">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-            </button>
+            {{ copy_button(url, _('Copy URL to clipboard')) }}
+        </div>
+    </div>
+{% endmacro %}
+
+{#
+Component: Compact URL Display
+One line of a table cell: a small caption, the link, and a copy button. Sized to
+sit several to a row, so the label is a caption rather than a heading.
+
+Args:
+    caption: Short label shown above the link (e.g. "Full URL")
+    url: The full URL to display
+    copy_label: Accessible name for the copy button — name the page it belongs to
+#}
+{% macro compact_url_display(caption, url, copy_label) %}
+    <div class="flex flex-col">
+        <span class="text-body-xs uppercase" style="color: var(--color-secondary-text);">{{ caption }}</span>
+        <div class="flex items-center gap-1">
+            <a href="{{ url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="text-body-sm underline break-all"
+               style="color: var(--color-link-text);">
+                {{ url }}
+            </a>
+            {{ copy_button(url, copy_label, classes="flex-shrink-0 p-1 rounded transition-colors duration-150 hover:opacity-70") }}
         </div>
     </div>
 {% endmacro %}

--- a/backend/tests/bdd/test_backoffice.py
+++ b/backend/tests/bdd/test_backoffice.py
@@ -424,13 +424,61 @@ def visit_registration_tab(page: Page, title: str, test_database):
 def see_registration_page_list(page: Page):
     """The list shows the table headers and the create CTA."""
     expect(page.get_by_role("columnheader", name="Date of publish")).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
-    expect(page.get_by_role("button", name="Create HTML page")).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+    # The assembly already has a page, so the CTA offers to add another
+    expect(page.get_by_role("button", name="Create another registration page")).to_be_visible(
+        timeout=PLAYWRIGHT_TIMEOUT
+    )
 
 
 @when("I open the first registration page from the list")
 def open_first_registration_page(page: Page):
     """Follow the first page-name link into that page's editor."""
     page.get_by_role("link", name="Registration page", exact=True).first.click()
+
+
+@when("I choose to delete the first registration page")
+def choose_delete_first_registration_page(page: Page):
+    """Open the first row's actions menu and pick the (permanent) delete item."""
+    page.get_by_role("button", name="Actions for Registration page").first.click()
+    page.get_by_role("menuitem", name="Delete registration page").first.click()
+
+
+@then("I should see the delete registration page confirmation")
+def see_delete_page_confirmation(page: Page):
+    expect(page.locator('[aria-labelledby="delete-page-1-title"]')).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+
+
+@when("I choose to keep the registration page")
+def choose_keep_registration_page(page: Page):
+    page.get_by_role("button", name="Keep it", exact=True).click()
+
+
+@then("the delete registration page confirmation should be closed")
+def delete_page_confirmation_closed(page: Page):
+    expect(page.locator('[aria-labelledby="delete-page-1-title"]')).to_be_hidden(timeout=PLAYWRIGHT_TIMEOUT)
+
+
+@when("I confirm deleting the registration page")
+def confirm_delete_registration_page(page: Page):
+    """The destructive submit inside the dialog."""
+    dialog = page.locator('[aria-labelledby="delete-page-1-title"]')
+    dialog.get_by_role("button", name="Delete page", exact=True).click()
+
+
+@then(parsers.parse('the assembly "{title}" should still have a registration page'))
+def assembly_still_has_registration_page(title: str, test_database):
+    assembly_id = _assembly_name_id_cache.find_title(title, test_database)
+    with SqlAlchemyUnitOfWork(test_database) as uow:
+        assert page_for_assembly(uow, assembly_id) is not None
+
+
+@then(parsers.parse('the assembly "{title}" should have no registration pages'))
+def assembly_has_no_registration_pages(page: Page, title: str, test_database):
+    """The delete lands back on the list, so wait for the row to go before checking the database."""
+    expect(page.get_by_role("button", name="Create registration page")).to_be_visible(timeout=PLAYWRIGHT_TIMEOUT)
+    assembly_id = _assembly_name_id_cache.find_title(title, test_database)
+    with SqlAlchemyUnitOfWork(test_database) as uow:
+        assert page_for_assembly(uow, assembly_id) is None
 
 
 @when(parsers.parse('I visit the registration form editor for "{title}"'))

--- a/backend/tests/component/test_backoffice_registration_view.py
+++ b/backend/tests/component/test_backoffice_registration_view.py
@@ -496,8 +496,9 @@ class TestRegistrationListView:
         assert response.status_code == 200
         body = response.get_data(as_text=True)
         # The publish date renders through the babel dateformat filter (not the em dash placeholder)
-        row = body.split("Live", 1)[1]
-        assert "\u2014" not in row.split("</tr>", 1)[0]
+        row = body.split("Live", 1)[1].split("</tr>", 1)[0]
+        date_cell = row.split('data-cell="published-at"', 1)[1].split("</td>", 1)[0]
+        assert "\u2014" not in date_cell
 
     def test_empty_assembly_offers_page_creation(self, logged_in_admin, fake_store, assembly_id):
         response = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration")
@@ -513,6 +514,110 @@ class TestRegistrationListView:
 
         assert f"/backoffice/assembly/{assembly_id}/registration/live-slug/save" in body
         assert f"/backoffice/assembly/{assembly_id}/registration/draft-slug/save" not in body
+
+    def test_create_button_label_reflects_whether_pages_exist(self, logged_in_admin, fake_store, assembly_id):
+        empty_body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, url_slug="draft-slug", name="Draft")
+        populated_body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+
+        assert "Create registration page" in empty_body
+        assert "Create another registration page" not in empty_body
+        assert "Create another registration page" in populated_body
+        assert "Create HTML page" not in populated_body
+
+    def test_each_row_shows_the_full_and_short_urls(self, logged_in_admin, fake_store, assembly_id):
+        page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, url_slug="climate-en", name="English")
+        with FakeUnitOfWork(store=fake_store) as uow:
+            uow.registration_pages.get(page.id).update_slugs(short_url_slug="123456")
+            uow.commit()
+
+        body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+
+        assert "/register/climate-en" in body
+        assert "/r/123456" in body
+
+    def test_a_page_without_a_short_url_shows_the_full_url_only(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, url_slug="climate-en", name="English")
+
+        body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+
+        assert "/register/climate-en" in body
+        assert "Short URL" not in body
+
+    def test_the_short_url_row_carries_a_qr_code(self, logged_in_admin, fake_store, assembly_id):
+        page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, url_slug="climate-en", name="English")
+        with FakeUnitOfWork(store=fake_store) as uow:
+            uow.registration_pages.get(page.id).update_slugs(short_url_slug="123456")
+            uow.commit()
+
+        body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+
+        assert "data:image/png;base64," in body
+        assert f"/backoffice/assembly/{assembly_id}/registration/climate-en/qr-code.png" in body
+
+
+class TestRegistrationListDeleteAction:
+    def test_delete_offered_for_a_never_published_page(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, url_slug="draft-slug", name="Draft")
+
+        body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+
+        assert f"/backoffice/assembly/{assembly_id}/registration/draft-slug/delete" in body
+        assert "Delete this registration page?" in body
+
+    def test_delete_not_offered_for_a_published_page(self, logged_in_admin, fake_store, assembly_id):
+        _seed_page(fake_store, assembly_id, RegistrationPageStatus.PUBLISHED, url_slug="live-slug", name="Live")
+
+        body = logged_in_admin.get(f"/backoffice/assembly/{assembly_id}/registration").get_data(as_text=True)
+
+        assert f"/backoffice/assembly/{assembly_id}/registration/live-slug/delete" not in body
+
+    def test_delete_removes_the_page_and_lands_on_the_list(self, logged_in_admin, fake_store, assembly_id):
+        page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, url_slug="draft-slug", name="Draft")
+
+        response = logged_in_admin.post(f"/backoffice/assembly/{assembly_id}/registration/draft-slug/delete")
+
+        assert response.status_code == 302
+        assert response.location.rstrip("/").endswith(f"/backoffice/assembly/{assembly_id}/registration")
+        with FakeUnitOfWork(store=fake_store) as uow:
+            assert uow.registration_pages.get(page.id) is None
+            assert uow.registration_page_html_sources.get_by_page_id(page.id) is None
+
+    def test_delete_refuses_a_published_page_and_keeps_it(self, logged_in_admin, fake_store, assembly_id):
+        """The list hides the action, but a page published in another tab can still be posted at."""
+        page = _seed_page(
+            fake_store,
+            assembly_id,
+            RegistrationPageStatus.TEST,
+            url_slug="live-slug",
+            name="Live",
+            form_html="<form>{{ csrf_form_element }} {{ form_action }}</form>",
+        )
+        with FakeUnitOfWork(store=fake_store) as uow:
+            stored = uow.registration_pages.get(page.id)
+            stored.publish(uow.registration_page_html_sources.get_by_page_id(page.id), author_id=uuid.uuid4())
+            uow.commit()
+
+        response = logged_in_admin.post(f"/backoffice/assembly/{assembly_id}/registration/live-slug/delete")
+
+        assert response.status_code == 302
+        with FakeUnitOfWork(store=fake_store) as uow:
+            assert uow.registration_pages.get(page.id) is not None
+
+    def test_delete_of_an_unknown_slug_lands_on_the_list(self, logged_in_admin, fake_store, assembly_id):
+        response = logged_in_admin.post(f"/backoffice/assembly/{assembly_id}/registration/nope/delete")
+
+        assert response.status_code == 302
+        assert response.location.rstrip("/").endswith(f"/backoffice/assembly/{assembly_id}/registration")
+
+    def test_non_member_cannot_delete(self, logged_in_user, fake_store, assembly_id):
+        page = _seed_page(fake_store, assembly_id, RegistrationPageStatus.TEST, url_slug="draft-slug", name="Draft")
+
+        response = logged_in_user.post(f"/backoffice/assembly/{assembly_id}/registration/draft-slug/delete")
+
+        assert response.status_code == 302
+        with FakeUnitOfWork(store=fake_store) as uow:
+            assert uow.registration_pages.get(page.id) is not None
 
 
 class TestEditorAtSlugUrl:

--- a/backend/tests/e2e/test_backoffice_registration.py
+++ b/backend/tests/e2e/test_backoffice_registration.py
@@ -31,6 +31,33 @@ def test_create_assembly_registration_page_success(
         assert page.url_slug
 
 
+def test_delete_assembly_registration_page_success(
+    logged_in_admin: FlaskClient, existing_assembly, postgres_session_factory
+):
+    """Deleting a never-published page removes it and its HTML source from the database."""
+    logged_in_admin.post(
+        _registration_url(existing_assembly.id, "/create"),
+        data={"csrf_token": get_csrf_token(logged_in_admin, _registration_url(existing_assembly.id))},
+    )
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        page = page_for_assembly(uow, existing_assembly.id)
+        assert page is not None
+        url_slug = page.url_slug
+        page_id = page.id
+
+    delete_url = _registration_url(existing_assembly.id, f"/{url_slug}/delete")
+    response = logged_in_admin.post(
+        delete_url,
+        data={"csrf_token": get_csrf_token(logged_in_admin, _registration_url(existing_assembly.id))},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    with SqlAlchemyUnitOfWork(postgres_session_factory) as uow:
+        assert uow.registration_pages.get(page_id) is None
+        assert uow.registration_page_html_sources.get_by_page_id(page_id) is None
+
+
 def test_get_registration_skeleton_success(logged_in_admin: FlaskClient, existing_assembly, admin_user: User):
     """The skeleton endpoint returns generated starter HTML as JSON."""
     response = logged_in_admin.get(_registration_url(existing_assembly.id, "/skeleton"))

--- a/backend/tests/unit/domain/test_registration_page.py
+++ b/backend/tests/unit/domain/test_registration_page.py
@@ -882,6 +882,15 @@ class TestCanBeDeleted:
         page.unpublish(author_id=uuid.uuid4())
         assert page.can_be_deleted() is False
 
+    def test_false_for_a_public_status_without_the_matching_activity(self):
+        """A page that arrived at PUBLISHED without going through publish() is still public."""
+        page = RegistrationPage(assembly_id=uuid.uuid4(), status=RegistrationPageStatus.PUBLISHED)
+        assert page.can_be_deleted() is False
+
+    def test_false_for_a_closed_page_without_the_matching_activity(self):
+        page = RegistrationPage(assembly_id=uuid.uuid4(), status=RegistrationPageStatus.CLOSED)
+        assert page.can_be_deleted() is False
+
 
 class TestSlugsFrozen:
     def test_unfrozen_initially(self):

--- a/backend/tests/unit/test_registration_page_multi.py
+++ b/backend/tests/unit/test_registration_page_multi.py
@@ -344,6 +344,64 @@ class TestDeleteRegistrationPage:
             service.delete_registration_page(uow, _stranger(uow).id, page.id)
 
 
+class TestDeletableRegistrationPageIds:
+    """The list view asks which pages it may offer a delete for."""
+
+    def test_a_never_published_page_is_deletable(self, uow):
+        admin, assembly = _admin(uow), _assembly(uow)
+        page = service.create_registration_page(uow, admin.id, assembly.id, name="Draft")
+
+        assert service.deletable_registration_page_ids(uow, admin.id, assembly.id) == {page.id}
+
+    def test_a_published_page_is_not_deletable(self, uow):
+        admin, assembly = _admin(uow), _assembly(uow)
+        page = _ready_page(uow, admin, assembly, "English", "climate-en")
+        service.publish_registration_page(uow, admin.id, page.id)
+
+        assert service.deletable_registration_page_ids(uow, admin.id, assembly.id) == set()
+
+    def test_a_page_with_registrations_is_not_deletable(self, uow):
+        admin, assembly = _admin(uow), _assembly(uow)
+        page = service.create_registration_page(uow, admin.id, assembly.id, name="Draft")
+        uow.respondents.add(
+            Respondent(
+                assembly_id=assembly.id,
+                external_id="reg-abc",
+                email="ada@example.com",
+                registration_page_id=page.id,
+            )
+        )
+
+        assert service.deletable_registration_page_ids(uow, admin.id, assembly.id) == set()
+
+    def test_only_the_deletable_siblings_come_back(self, uow):
+        admin, assembly = _admin(uow), _assembly(uow)
+        live = _ready_page(uow, admin, assembly, "English", "climate-en")
+        service.publish_registration_page(uow, admin.id, live.id)
+        draft = service.create_registration_page(uow, admin.id, assembly.id, name="Draft")
+
+        assert service.deletable_registration_page_ids(uow, admin.id, assembly.id) == {draft.id}
+
+    def test_a_viewer_is_offered_no_deletions(self, uow):
+        admin, assembly = _admin(uow), _assembly(uow)
+        service.create_registration_page(uow, admin.id, assembly.id, name="Draft")
+        viewer = _viewer(uow, assembly)
+
+        assert service.deletable_registration_page_ids(uow, viewer.id, assembly.id) == set()
+
+    def test_every_id_it_returns_can_actually_be_deleted(self, uow):
+        """The contract the list view relies on: offered means it will succeed."""
+        admin, assembly = _admin(uow), _assembly(uow)
+        live = _ready_page(uow, admin, assembly, "English", "climate-en")
+        service.publish_registration_page(uow, admin.id, live.id)
+        service.create_registration_page(uow, admin.id, assembly.id, name="Draft")
+
+        for page_id in service.deletable_registration_page_ids(uow, admin.id, assembly.id):
+            service.delete_registration_page(uow, admin.id, page_id)
+
+        assert [p.id for p in service.list_registration_pages(uow, admin.id, assembly.id)] == [live.id]
+
+
 class TestBulkStatusChanges:
     def test_publish_all_moves_every_ready_page(self, uow):
         admin, assembly = _admin(uow), _assembly(uow)

--- a/backend/translations/hu/LC_MESSAGES/messages.po
+++ b/backend/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 16:56+0200\n"
+"POT-Creation-Date: 2026-08-24 14:04+0000\n"
 "PO-Revision-Date: 2025-10-06 11:07+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -1068,9 +1068,9 @@ msgstr "Hiba történt a gyűlés létrehozásakor"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:161
 #: src/opendlp/entrypoints/blueprints/backoffice.py:392
 #: src/opendlp/entrypoints/blueprints/backoffice.py:449
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:247
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:361
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:82
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:276
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:391
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:83
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:94
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:129
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:164
@@ -1108,22 +1108,23 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 #: src/opendlp/entrypoints/blueprints/backoffice.py:284
 #: src/opendlp/entrypoints/blueprints/backoffice.py:383
 #: src/opendlp/entrypoints/blueprints/backoffice.py:440
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:253
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:367
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:538
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:750
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:816
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:840
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:938
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1001
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1029
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1054
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1102
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1132
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1159
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:79
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:381
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:408
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:282
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:397
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:568
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:780
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:846
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:890
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:919
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1017
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1080
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1108
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1133
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1181
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1211
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1238
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:80
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:393
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:420
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:91
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:126
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:161
@@ -1274,104 +1275,106 @@ msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 msgid "An error occurred while removing the user from the assembly"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:150
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:185
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:152
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:187
 #, fuzzy, python-format
 msgid "Details for %(name)s"
 msgstr "Hiba részletei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:151
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:153
 #, python-format
 msgid "Copy <img> snippet for %(name)s"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:152
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:187
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:154
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:189
 #, fuzzy, python-format
 msgid "Delete %(name)s"
 msgstr "Válaszadókat tartalmazó lapful neve"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:186
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:188
 #, python-format
 msgid "Copy download link snippet for %(name)s"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:259
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:377
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:288
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:407
 #, fuzzy
 msgid "An error occurred while loading registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:352
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:523
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:744
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:382
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:553
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:774
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:876
 #, fuzzy
 msgid "That registration page could not be found."
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:391
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:421
 #, fuzzy
 msgid "Registration form published successfully"
 msgstr "Google táblázat beállításai sikeresen eltávolítva"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:392
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:422
 #, fuzzy
 msgid "Registration form HTML updated successfully"
 msgstr "A '%(title)s' gyűlés sikeresen frissült"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:395
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:425
 #, fuzzy
 msgid "Registration form unpublished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:398
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:428
 #, fuzzy
 msgid "Registration form closed"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:401
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:431
 #, fuzzy
 msgid "Registration form reopened"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:403
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:433
 #, fuzzy
 msgid "Registration form saved and republished"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:404
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:434
 #, fuzzy
 msgid "Registration form saved"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:532
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:747
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:813
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:999
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1027
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1052
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1100
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1130
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1157
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:562
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:777
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:843
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:884
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1078
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1106
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1131
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1179
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1209
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1236
 #, fuzzy
 msgid "You don't have permission to modify this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:548
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:578
 #, fuzzy
 msgid "An error occurred while saving registration settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:619
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:649
 #, fuzzy
 msgid "Registration auto-reply"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:620
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:650
 msgid "Thanks for registering for {{ assembly.title }}"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:622
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:652
 msgid ""
 "<p>Hi {{ respondent.first_name_or_friend }},</p>\n"
 "<p>Thanks for registering for <strong>{{ assembly.title }}</strong>.</p>\n"
@@ -1380,32 +1383,32 @@ msgid ""
 "<p>Best wishes,<br>The team</p>"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:660
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:690
 msgid "Auto-reply email created. Edit it below and click Save."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:672
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:702
 msgid "There is no auto-reply email to save yet — set one up first."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:686
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:716
 msgid "Auto-reply email saved."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:705
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:735
 msgid "Unknown action — nothing was changed."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:741
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:771
 msgid "The auto-reply email could not be found."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:759
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:789
 #, fuzzy
 msgid "An error occurred while saving the auto-reply email"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:784
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:814
 #: templates/backoffice/assembly_registration.html:100
 #: templates/backoffice/patterns/_stepper.html:28
 #: templates/backoffice/patterns/_stepper.html:102
@@ -1413,149 +1416,159 @@ msgstr "Hiba történt a gyűlés frissítése közben"
 msgid "Registration page"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:808
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:838
 msgid ""
 "Registration page created. URLs have been generated automatically and can"
 " be edited below."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:824
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:854
 #, fuzzy
 msgid "An error occurred while creating the registration page"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:838
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:932
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:874
+#, fuzzy, python-format
+msgid "Registration page '%(name)s' deleted"
+msgstr "Vissza a regisztrációhoz"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:903
+#, fuzzy
+msgid "An error occurred while deleting the registration page"
+msgstr "Hiba történt a gyűlés frissítése közben"
+
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:917
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1011
 #, fuzzy
 msgid "You don't have permission to access this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:843
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:922
 #, fuzzy
 msgid "An error occurred while generating the form skeleton"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:942
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1021
 #, fuzzy
 msgid "An error occurred while generating QR code"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:969
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1072
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1048
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1151
 #, fuzzy
 msgid "No file was selected"
 msgstr "Táblázat lapfülei"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:975
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1078
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1054
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1157
 msgid "Failed to read the uploaded file"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:979
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1016
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1058
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1095
 #: templates/backoffice/assembly_registration.html:1678
 msgid "Alt text is required for accessibility"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:997
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1098
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1076
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1177
 msgid "Please create a registration page first from the Details tab."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1004
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1083
 #, fuzzy
 msgid "An error occurred while uploading the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1023
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1048
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1102
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1127
 #, fuzzy
 msgid "Image not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1025
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1050
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1128
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1155
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1104
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1129
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1207
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1234
 #, fuzzy
 msgid "Registration page not found"
 msgstr "Vissza a regisztrációhoz"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1032
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1111
 #, fuzzy
 msgid "An error occurred while updating the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1057
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1136
 #, fuzzy
 msgid "An error occurred while deleting the image"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1105
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1184
 #, fuzzy
 msgid "An error occurred while uploading the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1119
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1198
 #: templates/backoffice/assembly_registration.html:1688
 msgid "Label is required"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1126
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1153
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1205
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1232
 #, fuzzy
 msgid "Document not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1137
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1216
 #, fuzzy
 msgid "An error occurred while updating the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1162
+#: src/opendlp/entrypoints/blueprints/backoffice_registration.py:1241
 #, fuzzy
 msgid "An error occurred while deleting the document"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:57
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:58
 msgid "Please review and save the selection settings before checking data."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:66
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:67
 #, python-format
 msgid ""
 "Data validation passed: %(features)s targets, %(people)s respondents "
 "ready for selection."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:86
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:87
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:168
 #, fuzzy
 msgid "An unexpected error occurred while checking data"
 msgstr "Hiba történt a betöltés indítása közben"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:103
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:104
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:182
 #: templates/backoffice/assembly_selection.html:55
 msgid "Please review and save the selection settings before running selection."
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:117
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:118
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:191
 #: src/opendlp/entrypoints/blueprints/gsheets_legacy.py:447
 #, fuzzy, python-format
 msgid "Could not start selection task: %(error)s"
 msgstr "A kiválasztás futtatásának indítása sikertelen: %(error)s"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:120
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:121
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:194
 #: src/opendlp/entrypoints/blueprints/gsheets_legacy.py:455
 #, python-format
 msgid "Failed to start selection task: %(error)s"
 msgstr "A kiválasztás futtatásának indítása sikertelen: %(error)s"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:123
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:384
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:124
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:396
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:197
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:413
 #: src/opendlp/entrypoints/blueprints/gsheets.py:786
@@ -1569,27 +1582,27 @@ msgstr "A kiválasztás futtatásának indítása sikertelen: %(error)s"
 msgid "You don't have permission to manage this assembly"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:127
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:128
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:201
 #: src/opendlp/entrypoints/blueprints/gsheets_legacy.py:474
 msgid "An unexpected error occurred while starting the selection task"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:188
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:189
 #: src/opendlp/entrypoints/blueprints/gsheets.py:510
 #: src/opendlp/entrypoints/blueprints/gsheets.py:655
 #, fuzzy
 msgid "Task cancelled"
 msgstr "Kész"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:198
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:199
 #: src/opendlp/entrypoints/blueprints/gsheets.py:520
 #: src/opendlp/entrypoints/blueprints/gsheets.py:665
 #, fuzzy, python-format
 msgid "Cannot cancel task: %(error)s"
 msgstr "A kiválasztás futtatásának indítása sikertelen: %(error)s"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:202
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:203
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:257
 #: src/opendlp/entrypoints/blueprints/gsheets.py:524
 #: src/opendlp/entrypoints/blueprints/gsheets.py:669
@@ -1602,7 +1615,7 @@ msgstr "A kiválasztás futtatásának indítása sikertelen: %(error)s"
 msgid "Task not found"
 msgstr "Az oldal nem elérhető"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:206
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:207
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:265
 #: src/opendlp/entrypoints/blueprints/gsheets.py:528
 #: src/opendlp/entrypoints/blueprints/gsheets.py:673
@@ -1614,7 +1627,7 @@ msgstr "Az oldal nem elérhető"
 msgid "You don't have permission to cancel this task"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:210
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:211
 #: src/opendlp/entrypoints/blueprints/gsheets.py:532
 #: src/opendlp/entrypoints/blueprints/gsheets.py:677
 #: src/opendlp/entrypoints/blueprints/gsheets.py:890
@@ -1625,47 +1638,47 @@ msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 msgid "An error occurred while cancelling the task"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:239
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:272
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:308
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:240
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:273
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:309
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:295
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:325
 #, fuzzy
 msgid "You don't have permission to download this data"
 msgstr "Nincs jogosultsága a közösségi gyűlés szerkesztéséhez"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:243
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:276
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:312
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:244
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:277
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:313
 #, fuzzy
 msgid "An error occurred while generating the download"
 msgstr "Hiba történt a gyűlés létrehozásakor"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:375
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:387
 #, fuzzy
 msgid "Selection settings saved successfully."
 msgstr "További beállítások"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:388
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:400
 #, fuzzy
 msgid "An error occurred while saving settings"
 msgstr "Hiba történt a gyűlés frissítése közben"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:404
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:416
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:446
 #: src/opendlp/entrypoints/blueprints/respondents_legacy.py:191
 #, python-format
 msgid "Reset %(count)s respondents to Pool status"
 msgstr ""
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:411
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:423
 #: src/opendlp/entrypoints/blueprints/db_selection_legacy.py:452
 #: src/opendlp/entrypoints/blueprints/respondents_legacy.py:197
 #, fuzzy
 msgid "You don't have permission to reset selection status"
 msgstr "Nincs jogosultsága a közösségi gyűlés megtekintéséhez"
 
-#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:415
+#: src/opendlp/entrypoints/blueprints/db_selection_backoffice.py:427
 #, fuzzy
 msgid "An error occurred while resetting respondent status"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
@@ -3034,38 +3047,38 @@ msgid "Failed to generate unique short URL slug after multiple attempts"
 msgstr ""
 
 #: src/opendlp/service_layer/registration_page_service.py:226
-#: src/opendlp/service_layer/registration_page_service.py:553
+#: src/opendlp/service_layer/registration_page_service.py:588
 #, fuzzy
 msgid "The registration page name is required"
 msgstr "Vissza a regisztrációhoz"
 
 #: src/opendlp/service_layer/registration_page_service.py:229
-#: src/opendlp/service_layer/registration_page_service.py:556
+#: src/opendlp/service_layer/registration_page_service.py:591
 #, python-format
 msgid "This assembly already has a registration page named '%(name)s'"
 msgstr ""
 
-#: src/opendlp/service_layer/registration_page_service.py:400
+#: src/opendlp/service_layer/registration_page_service.py:397
 msgid ""
 "A registration page that has been published cannot be deleted; close it "
 "instead"
 msgstr ""
 
-#: src/opendlp/service_layer/registration_page_service.py:402
+#: src/opendlp/service_layer/registration_page_service.py:399
 msgid "This registration page has registrations, so it cannot be deleted"
 msgstr ""
 
-#: src/opendlp/service_layer/registration_page_service.py:482
-#: src/opendlp/service_layer/registration_page_service.py:490
+#: src/opendlp/service_layer/registration_page_service.py:517
+#: src/opendlp/service_layer/registration_page_service.py:525
 #, python-format
 msgid "The slug '%(slug)s' is already in use by another registration page"
 msgstr ""
 
-#: src/opendlp/service_layer/registration_page_service.py:588
+#: src/opendlp/service_layer/registration_page_service.py:623
 msgid "thank-you HTML"
 msgstr ""
 
-#: src/opendlp/service_layer/registration_page_service.py:604
+#: src/opendlp/service_layer/registration_page_service.py:639
 #, fuzzy
 msgid "form HTML"
 msgstr "Keresztnév"
@@ -3561,7 +3574,7 @@ msgstr ""
 #: templates/backoffice/assembly_respondents.html:126
 #: templates/backoffice/assembly_selection.html:171
 #: templates/backoffice/assembly_selection.html:351
-#: templates/backoffice/components/registration_page_list.html:24
+#: templates/backoffice/components/registration_page_list.html:33
 #: templates/backoffice/respondents/export_modal.html:38
 #: templates/main/view_assembly_data.html:54
 #: templates/main/view_assembly_details.html:13
@@ -3725,7 +3738,7 @@ msgstr ""
 #: templates/backoffice/assembly_respondents.html:130
 #: templates/backoffice/assembly_selection.html:183
 #: templates/backoffice/assembly_selection.html:363
-#: templates/backoffice/components/registration_page_list.html:27
+#: templates/backoffice/components/registration_page_list.html:36
 #: templates/backoffice/respondent_field_schema/view.html:138
 #: templates/backoffice/targets/category_block.html:111
 #: templates/main/view_assembly_data.html:60
@@ -4050,7 +4063,7 @@ msgstr ""
 
 #: templates/admin/users.html:112
 #: templates/backoffice/assembly_respondents.html:127
-#: templates/backoffice/components/registration_page_list.html:23
+#: templates/backoffice/components/registration_page_list.html:30
 #: templates/backoffice/service_docs/_emails.html:70
 #, fuzzy
 msgid "Name"
@@ -4741,6 +4754,7 @@ msgstr "Vissza a regisztrációhoz"
 
 #: templates/backoffice/assembly_details.html:125
 #: templates/backoffice/assembly_registration.html:773
+#: templates/backoffice/components/registration_page_list.html:66
 msgid "Short URL"
 msgstr ""
 
@@ -4852,7 +4866,7 @@ msgstr ""
 
 #: templates/backoffice/assembly_registration.html:16
 #: templates/backoffice/components/assembly_tabs.html:55
-#: templates/backoffice/components/registration_page_list.html:10
+#: templates/backoffice/components/registration_page_list.html:13
 #: templates/backoffice/service_docs.html:32
 #, fuzzy
 msgid "Registration"
@@ -4920,7 +4934,7 @@ msgid "Visitors who follow the form URL are redirected to the closed page."
 msgstr ""
 
 #: templates/backoffice/assembly_registration.html:137
-#: templates/backoffice/components/registration_page_list.html:53
+#: templates/backoffice/components/registration_page_list.html:97
 msgid "Published"
 msgstr ""
 
@@ -5192,7 +5206,7 @@ msgstr ""
 
 #: templates/backoffice/assembly_registration.html:848
 #: templates/backoffice/assembly_registration.html:1587
-#: templates/backoffice/components/registration_page_list.html:115
+#: templates/backoffice/components/registration_page_list.html:164
 #, fuzzy
 msgid "Close registration"
 msgstr "Vissza a regisztrációhoz"
@@ -5448,7 +5462,7 @@ msgid "An error occurred while fetching the form skeleton"
 msgstr "Hiba történt a kiválasztás futtatásának indítása közben"
 
 #: templates/backoffice/assembly_registration.html:1673
-#: templates/backoffice/components/url_display.html:37
+#: templates/backoffice/components/url_display.html:23
 msgid "Copied to clipboard"
 msgstr ""
 
@@ -6631,42 +6645,112 @@ msgstr "Jelentések a folyamatról"
 msgid "Showing %(start)s-%(end)s of %(total)s %(items)s"
 msgstr ""
 
-#: templates/backoffice/components/registration_page_list.html:14
+#: templates/backoffice/components/registration_page_list.html:18
 #, fuzzy
-msgid "Create HTML page"
+msgid "Create another registration page"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/components/registration_page_list.html:25
+#: templates/backoffice/components/registration_page_list.html:20
+#, fuzzy
+msgid "Create registration page"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/components/registration_page_list.html:31
+#, fuzzy
+msgid "Links"
+msgstr "Folyamatban"
+
+#: templates/backoffice/components/registration_page_list.html:32
+#, fuzzy
+msgid "QR code"
+msgstr "Meghívó kód"
+
+#: templates/backoffice/components/registration_page_list.html:34
 #, fuzzy
 msgid "Date of publish"
 msgstr "Módosítások mentése"
 
-#: templates/backoffice/components/registration_page_list.html:59
+#: templates/backoffice/components/registration_page_list.html:62
+msgid "Full URL"
+msgstr ""
+
+#: templates/backoffice/components/registration_page_list.html:64
+#, fuzzy, python-format
+msgid "Copy the full URL for %(name)s"
+msgstr "Hiba részletei"
+
+#: templates/backoffice/components/registration_page_list.html:68
+#, fuzzy, python-format
+msgid "Copy the short URL for %(name)s"
+msgstr "Hiba részletei"
+
+#: templates/backoffice/components/registration_page_list.html:72
+msgid "No URL yet"
+msgstr ""
+
+#: templates/backoffice/components/registration_page_list.html:83
+#, fuzzy, python-format
+msgid "Download the QR code for %(name)s"
+msgstr "Táblázat lapfülei"
+
+#: templates/backoffice/components/registration_page_list.html:85
+#, fuzzy, python-format
+msgid "QR code for %(name)s"
+msgstr "Hiba részletei"
+
+#: templates/backoffice/components/registration_page_list.html:103
 #, fuzzy
 msgid "Closed"
 msgstr "Menü bezárása"
 
-#: templates/backoffice/components/registration_page_list.html:65
+#: templates/backoffice/components/registration_page_list.html:109
 #, fuzzy
 msgid "Test"
 msgstr "Kezdés dátuma"
 
-#: templates/backoffice/components/registration_page_list.html:90
+#: templates/backoffice/components/registration_page_list.html:139
 #, fuzzy, python-format
 msgid "Actions for %(name)s"
 msgstr "Hiba részletei"
 
-#: templates/backoffice/components/registration_page_list.html:105
+#: templates/backoffice/components/registration_page_list.html:154
 #, fuzzy
 msgid "See assembly details"
 msgstr "Közösségi gyűlés"
 
-#: templates/backoffice/components/registration_page_list.html:121
+#: templates/backoffice/components/registration_page_list.html:170
 #, fuzzy
 msgid "Edit registration"
 msgstr "Vissza a regisztrációhoz"
 
-#: templates/backoffice/components/registration_page_list.html:136
+#: templates/backoffice/components/registration_page_list.html:180
+#, fuzzy
+msgid "Delete registration page"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/components/registration_page_list.html:204
+#, fuzzy
+msgid "Delete this registration page?"
+msgstr "Vissza a regisztrációhoz"
+
+#: templates/backoffice/components/registration_page_list.html:206
+#, python-format
+msgid ""
+"'%(name)s' and the form you built on it will be deleted for good. There "
+"is no undo, and the URLs above will stop working."
+msgstr ""
+
+#: templates/backoffice/components/registration_page_list.html:211
+#, fuzzy
+msgid "Delete page"
+msgstr "Kezdés dátuma"
+
+#: templates/backoffice/components/registration_page_list.html:213
+#, fuzzy
+msgid "Keep it"
+msgstr "Kieső emberek pótlása új kiválasztással"
+
+#: templates/backoffice/components/registration_page_list.html:230
 msgid ""
 "This assembly has no registration pages yet. Create one to start "
 "collecting registrations — you can add more pages later, for example for "
@@ -6775,8 +6859,7 @@ msgstr "Befejezve"
 msgid "has errors"
 msgstr "Hiba történt"
 
-#: templates/backoffice/components/url_display.html:36
-#: templates/backoffice/components/url_display.html:38
+#: templates/backoffice/components/url_display.html:61
 msgid "Copy URL to clipboard"
 msgstr ""
 
@@ -14470,4 +14553,7 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Registration tab"
+#~ msgstr "Vissza a regisztrációhoz"
+
+#~ msgid "Create HTML page"
 #~ msgstr "Vissza a regisztrációhoz"


### PR DESCRIPTION
Three pieces of review feedback on story 830:

- Each row now shows the full and short registration URLs with copy buttons, plus a QR code thumbnail of the short URL that downloads the full-size PNG. url_display.html grows a copy_button atom and a compact_url_display macro, which readonly_url_display now composes.
- The create CTA says what it makes: "Create registration page", or "Create another registration page" once the assembly has one.
- The row menu offers "Delete registration page" behind a confirmation dialog. It is a hard delete - no archive, no soft delete, no undelete. The item appears only where delete_registration_page would accept it (never published, no registrations); deletable_registration_page_ids answers that for the whole list in one query, sharing _delete_blocker with the delete itself so the offer and the refusal cannot drift.

can_be_deleted() now requires status TEST as well as an activity log with no PUBLISH: a page that reached PUBLISHED without the matching activity entry is just as public as one that got there through publish(), and delete is reachable from the UI now.